### PR TITLE
Add empty string as option value for sed -i

### DIFF
--- a/ska_conda/pkg_defs/ska3-template/build.sh
+++ b/ska_conda/pkg_defs/ska3-template/build.sh
@@ -4,5 +4,5 @@ for file in flt_envs ska_envs.sh ska_envs.csh
    do
     chmod +x ${RECIPE_DIR}/bin/${file}
     cp -a ${RECIPE_DIR}/bin/${file} ${PREFIX}/bin
-    sed -i "s|%{PREFIX}%|${PREFIX}|" ${PREFIX}/bin/${file}
+    sed -i ""  "s|%{PREFIX}%|${PREFIX}|" ${PREFIX}/bin/${file}
    done


### PR DESCRIPTION
Add empty string as option value for sed -i .  This fixes ska3-template creation on osx .