### PR TITLE
Build openssh 6.5p1 for presto

### DIFF
--- a/ska_conda/pkg_defs/openssh/build.sh
+++ b/ska_conda/pkg_defs/openssh/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+./configure --prefix=${PREFIX} --with-ssl-dir=${PREFIX}/lib
+make
+make install
+

--- a/ska_conda/pkg_defs/openssh/meta.yaml
+++ b/ska_conda/pkg_defs/openssh/meta.yaml
@@ -1,0 +1,7 @@
+package:
+  name: openssh
+  version: 6.5p1
+
+source:
+  url: https://ftp4.usa.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-6.5p1.tar.gz
+  md5: a084e7272b8cbd25afe0f5dce4802fef

--- a/ska_conda/ska_builder.py
+++ b/ska_conda/ska_builder.py
@@ -6,7 +6,7 @@ import yaml
 ska_conda_path = os.path.abspath(os.path.dirname(__file__))
 pkg_defs_path = os.path.join(ska_conda_path, "pkg_defs")
 build_list = os.path.join(ska_conda_path, "build_order.txt")
-no_source_pkgs = ['ska3-flight', 'ska3-core', 'ska3-dev', 'ska3-pinned', 'ska3-template']
+no_source_pkgs = ['ska3-flight', 'ska3-core', 'ska3-dev', 'ska3-pinned', 'ska3-template', 'openssh']
 
 class SkaBuilder(object):
 


### PR DESCRIPTION
Build openssh 6.5p1 for presto

We probably won't need this, but can keep it in our back pocket.  I just pushed this branch with it.  Newer versions would probably build too, I just picked this one because I saw an example of somebody building it for CentOS5.

```
bash-3.2$ git push origin openssh
no kex alg
fatal: Could not read from remote repository.
bash-3.2$ conda install builds/linux-64/openssh-6.5p1-ha39d96a_0.tar.bz2 
bash-3.2$ git push origin openssh
Enter passphrase for key '/home/jeanconn/.ssh/id_rsa': 
Counting objects: 8, done.
Delta compression using up to 2 threads.
Compressing objects: 100% (8/8), done.
Writing objects: 100% (8/8), 871 bytes | 0 bytes/s, done.
Total 8 (delta 3), reused 0 (delta 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To github.com:/sot/skare3.git
 * [new branch]      openssh -> openssh
```