### PR TITLE
Add back use of sed for template rewrite

### DIFF
--- a/ska_conda/pkg_defs/ska3-template/bin/flt_envs
+++ b/ska_conda/pkg_defs/ska3-template/bin/flt_envs
@@ -1,5 +1,10 @@
 #!%{PREFIX}%%{MYPY}%
 
+# If updating the ska3-template conda package that provides this
+# script, see the build.sh and the post-link.sh for the substitutions
+# that were used to construct the shebang
+
+
 """
 Print to stdout the appropriate shell commands to initialize the standalone
 Ska environment.

--- a/ska_conda/pkg_defs/ska3-template/bin/flt_envs
+++ b/ska_conda/pkg_defs/ska3-template/bin/flt_envs
@@ -1,4 +1,4 @@
-#!/opt/anaconda1anaconda2anaconda3/bin/python -E
+#!%{PREFIX}%/bin/python -E
 
 """
 Print to stdout the appropriate shell commands to initialize the standalone

--- a/ska_conda/pkg_defs/ska3-template/bin/flt_envs
+++ b/ska_conda/pkg_defs/ska3-template/bin/flt_envs
@@ -1,4 +1,4 @@
-#!%{PREFIX}%/bin/python -E
+#!%{PREFIX}%%{MYPY}%
 
 """
 Print to stdout the appropriate shell commands to initialize the standalone

--- a/ska_conda/pkg_defs/ska3-template/bin/ska_envs.csh
+++ b/ska_conda/pkg_defs/ska3-template/bin/ska_envs.csh
@@ -1,1 +1,1 @@
-eval `/opt/anaconda1anaconda2anaconda3/bin/flt_envs -shell csh -ska`
+eval `%{PREFIX}%/bin/flt_envs -shell csh -ska`

--- a/ska_conda/pkg_defs/ska3-template/bin/ska_envs.sh
+++ b/ska_conda/pkg_defs/ska3-template/bin/ska_envs.sh
@@ -1,1 +1,1 @@
-eval `/opt/anaconda1anaconda2anaconda3/bin/flt_envs -shell sh -ska`
+eval `%{PREFIX}%/bin/flt_envs -shell sh -ska`

--- a/ska_conda/pkg_defs/ska3-template/bin/ska_version
+++ b/ska_conda/pkg_defs/ska3-template/bin/ska_version
@@ -1,4 +1,4 @@
-#!${PREFIX}/bin/python
+#!%{PREFIX}%/bin/python
 """
 Create and return an environment version string based on the ska3-* conda
 packages in an environment.

--- a/ska_conda/pkg_defs/ska3-template/build.sh
+++ b/ska_conda/pkg_defs/ska3-template/build.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
-chmod +x ${RECIPE_DIR}/bin/*
-cp -a ${RECIPE_DIR}/bin/* ${PREFIX}/bin
+for file in flt_envs ska_envs.sh ska_envs.csh ska_version
+   do
+    chmod +x ${RECIPE_DIR}/bin/${file}
+    cp -a ${RECIPE_DIR}/bin/${file} ${PREFIX}/bin
+    # Replace %{PREFIX}% with the conda build prefix.
+    sed -i.bak -e "s|%{PREFIX}%|${PREFIX}|" ${PREFIX}/bin/${file}
+    rm ${PREFIX}/bin/${file}.bak
+   done

--- a/ska_conda/pkg_defs/ska3-template/meta.yaml
+++ b/ska_conda/pkg_defs/ska3-template/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-template
-  version:  0.1
+  version:  0.2
 
 build:
   noarch: generic

--- a/ska_conda/pkg_defs/ska3-template/meta.yaml
+++ b/ska_conda/pkg_defs/ska3-template/meta.yaml
@@ -4,3 +4,7 @@ package:
 
 build:
   noarch: generic
+
+requirements:
+  run:
+   - python

--- a/ska_conda/pkg_defs/ska3-template/meta.yaml
+++ b/ska_conda/pkg_defs/ska3-template/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-template
-  version:  0.2
+  version:  2018.07.27
 
 build:
   noarch: generic

--- a/ska_conda/pkg_defs/ska3-template/post-link.sh
+++ b/ska_conda/pkg_defs/ska3-template/post-link.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Updating flt_envs to use python -E with sed via post-link.sh" > $PREFIX/.messages.txt
+sed -i.bak -e "s|%{MYPY}%|/bin/python -E|" ${PREFIX}/bin/flt_envs
+rm ${PREFIX}/bin/flt_envs.bak

--- a/ska_conda/pkg_defs/ska3-template/post-link.sh
+++ b/ska_conda/pkg_defs/ska3-template/post-link.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-echo "Updating flt_envs to use python -E with sed via post-link.sh" > $PREFIX/.messages.txt
 sed -i.bak -e "s|%{MYPY}%|/bin/python -E|" ${PREFIX}/bin/flt_envs
 rm ${PREFIX}/bin/flt_envs.bak


### PR DESCRIPTION
Use sed to rewrite templates with the prefix of our installation.

This replaces the technique in #28