### PR TITLE
Add local astropy

### DIFF
--- a/ska_conda/build_order.txt
+++ b/ska_conda/build_order.txt
@@ -1,3 +1,9 @@
+pytest-arraydiff
+pytest-doctestplus
+pytest-openfiles
+pytest-remotedata
+pytest-astropy
+astropy
 Ska.Shell
 Ska.File
 pyyaks

--- a/ska_conda/pkg_defs/astropy/RECIPE_LICENSE
+++ b/ska_conda/pkg_defs/astropy/RECIPE_LICENSE
@@ -1,0 +1,26 @@
+This recipe is adapted from the anaconda-recipes repository. The original license was:
+
+(c) 2016 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ska_conda/pkg_defs/astropy/bld.bat
+++ b/ska_conda/pkg_defs/astropy/bld.bat
@@ -1,0 +1,10 @@
+if "%ARCH%"=="64" (
+    call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+)
+
+%PYTHON% setup.py install --offline --old-and-unmanageable
+if errorlevel 1 exit 1
+
+if "%PY3K%"=="1" (
+    rd /s /q %SP_DIR%\numpy
+)

--- a/ska_conda/pkg_defs/astropy/build.sh
+++ b/ska_conda/pkg_defs/astropy/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ `uname` == Linux ]]; then
+    export CFLAGS="$CFLAGS -std=c99"
+    export CC=gcc
+fi
+
+$PYTHON setup.py install --offline --old-and-unmanageable

--- a/ska_conda/pkg_defs/astropy/meta.yaml
+++ b/ska_conda/pkg_defs/astropy/meta.yaml
@@ -28,13 +28,16 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy 1.12.*  # [py36]
-
+    - numpy ==1.12.1
+    - llvmlite ==0.18.0
+    - gcc ==4.8.5 [linux]
+    - libgcc ==4.8.5 [linux]
   run:
     - python
-    - numpy >=1.11  # [py36]
+    - llvmlite ==0.18.0
+    - numpy ==1.12.1
     - pytest-astropy
-
+    - libgcc ==4.8.5 [linux]
 test:
   commands:
     - fits2bitmap --help

--- a/ska_conda/pkg_defs/astropy/meta.yaml
+++ b/ska_conda/pkg_defs/astropy/meta.yaml
@@ -28,12 +28,10 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy 1.10.*  # [py35]
-    - numpy 1.11.*  # [py36]
+    - numpy 1.12.*  # [py36]
 
   run:
     - python
-    - numpy >=1.10  # [py35]
     - numpy >=1.11  # [py36]
     - pytest-astropy
 

--- a/ska_conda/pkg_defs/astropy/meta.yaml
+++ b/ska_conda/pkg_defs/astropy/meta.yaml
@@ -1,0 +1,68 @@
+{% set version = "3.0.3" %}
+
+package:
+  name: astropy
+  version: {{version}}
+
+source:
+  fn: astropy-{{version}}.tar.gz
+  url: https://pypi.io/packages/source/a/astropy/astropy-{{version}}.tar.gz
+  sha256: 6af07abe5e263820a3dec93832a6ad74005013071490e125afbc6514411721da
+
+
+build:
+  detect_binary_files_with_prefix: False
+  entry_points:
+    - fits2bitmap = astropy.visualization.scripts.fits2bitmap:main
+    - fitscheck = astropy.io.fits.scripts.fitscheck:main
+    - fitsdiff = astropy.io.fits.scripts.fitsdiff:main
+    - fitsheader = astropy.io.fits.scripts.fitsheader:main
+    - fitsinfo = astropy.io.fits.scripts.fitsinfo:main
+    - samp_hub = astropy.samp.hub_script:hub_script
+    - volint = astropy.io.votable.volint:main
+    - wcslint = astropy.wcs.wcslint:main
+  number: 1
+
+requirements:
+
+  build:
+    - python
+    - setuptools
+    - numpy 1.10.*  # [py35]
+    - numpy 1.11.*  # [py36]
+
+  run:
+    - python
+    - numpy >=1.10  # [py35]
+    - numpy >=1.11  # [py36]
+    - pytest-astropy
+
+test:
+  commands:
+    - fits2bitmap --help
+    - fitscheck --help
+    - fitsdiff --help
+    - fitsheader --help
+    - fitsinfo --help
+    - samp_hub --help
+    - volint --help
+    - wcslint --help
+  imports:
+    - astropy
+
+about:
+  home: http://www.astropy.org/
+  license: BSD
+  summary: Community-developed Python Library for Astronomy
+  description: |
+    The Astropy Project is a community effort to develop a single package for
+    Astronomy in Python. It contains core functionality and common tools
+    needed for performing astronomy and astrophysics research with Python.
+  doc_url: http://docs.astropy.org/en/stable/
+  dev_url: https://github.com/astropy/astropy
+
+extra:
+  recipe-maintainers:
+    - astrofrog-conda-forge
+    - mwcraig
+    - bsipocz

--- a/ska_conda/pkg_defs/astropy/run_test.py
+++ b/ska_conda/pkg_defs/astropy/run_test.py
@@ -1,0 +1,25 @@
+import astropy._compiler
+import astropy._erfa._core
+import astropy.convolution.boundary_extend
+import astropy.convolution.boundary_fill
+import astropy.convolution.boundary_none
+import astropy.convolution.boundary_wrap
+import astropy.cosmology.scalar_inv_efuncs
+import astropy.io.ascii.cparser
+import astropy.io.fits.compression
+import astropy.io.votable.tablewriter
+import astropy.modeling._projections
+import astropy.stats.lombscargle.implementations.cython_impl
+import astropy.table._column_mixins
+import astropy.table._np_utils
+import astropy.utils._compiler
+import astropy.utils.xml._iterparser
+import astropy.wcs._wcs
+
+# We run a subset of the tests which are the most likely to have
+# issues because they rely on C extensions and bundled libraries
+
+from astropy import test
+test(package='io.ascii')
+test(package='time')
+test(package='wcs')

--- a/ska_conda/pkg_defs/pytest-arraydiff/meta.yaml
+++ b/ska_conda/pkg_defs/pytest-arraydiff/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "pytest-arraydiff" %}
+{% set version = "0.2" %}
+{% set git_url = "https://github.com/astrofrog/pytest-arraydiff" %}
+{% set sha256 = "0145edfa8830aba07150fc09443da74d0ec4074e3de702445453415a744d3ad9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+    - pytest
+    - numpy
+    - six
+  run:
+    - python
+    - pytest
+    - numpy
+    - six
+
+test:
+  imports:
+    - pytest_arraydiff
+
+about:
+  home: {{ git_url }}
+  license: BSD
+  summary: 'pytest plugin to help with comparing array output from tests'
+  description: |
+    This is a py.test plugin to facilitate the generation and comparison of
+    data arrays produced during tests.
+  doc_url: {{ git_url }}
+  dev_url: {{ git_url }}
+
+extra:
+  recipe-maintainers:
+    - astrofrog-conda-forge
+    - drdavella
+    - mwcraig

--- a/ska_conda/pkg_defs/pytest-astropy/meta.yaml
+++ b/ska_conda/pkg_defs/pytest-astropy/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "pytest-astropy" %}
+{% set version = "0.4.0" %}
+{% set git_url = "https://github.com/astropy/pytest-astropy" %}
+{% set sha256 = "8eacabc025b22459bd1db7313ba8e4236918b46cba241e49b2245c8ec69a267b" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+    - pytest >=3.1
+    - pytest-openfiles >=0.3
+    - pytest-remotedata >=0.3.0
+    - pytest-doctestplus >=0.1.3
+    - pytest-arraydiff >=0.1
+  run:
+    - python
+    - pytest >=3.1
+    - pytest-openfiles >=0.3
+    - pytest-remotedata >=0.3.0
+    - pytest-doctestplus >=0.1.3
+    - pytest-arraydiff >=0.1
+
+test:
+  imports:
+    - pytest_remotedata
+    - pytest_doctestplus
+    - pytest_openfiles
+    - pytest_arraydiff
+
+about:
+  home: {{ git_url }}
+  license: BSD
+  summary: 'Meta-package containing dependencies for testing Astropy'
+  description: |
+    This is a meta-package that pulls in the dependencies that are used by
+    astropy and some affiliated packages for testing. It can also be used for
+    testing packages that are not affiliated with the Astropy project.
+  doc_url: {{ git_url }}
+  dev_url: {{ git_url }}
+
+extra:
+  recipe-maintainers:
+    - astrofrog-conda-forge
+    - drdavella
+    - mwcraig

--- a/ska_conda/pkg_defs/pytest-doctestplus/meta.yaml
+++ b/ska_conda/pkg_defs/pytest-doctestplus/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "pytest-doctestplus" %}
+{% set version = "0.1.3" %}
+{% set git_url = "https://github.com/astropy/pytest-doctestplus" %}
+{% set sha256 = "91a5f81ff9e2038d363f6d49f4ec3c1b9726cc989ae8e3f227689a3793aa51fc" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+    - pytest >=2.8
+    - six
+  run:
+    - python
+    - pytest >=2.8
+    - six
+
+test:
+  imports:
+    - pytest_doctestplus
+
+about:
+  home: {{ git_url }}
+  license: BSD
+  summary: 'Pytest plugin with advanced doctest features'
+  description: |
+    This package contains a plugin for the pytest framework that provides
+    advanced doctest support and enables the testing of reStructuredText files.
+  doc_url: {{ git_url }}
+  dev_url: {{ git_url }}
+
+extra:
+  recipe-maintainers:
+    - astrofrog-conda-forge
+    - drdavella
+    - mwcraig

--- a/ska_conda/pkg_defs/pytest-openfiles/meta.yaml
+++ b/ska_conda/pkg_defs/pytest-openfiles/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "pytest-openfiles" %}
+{% set version = "0.3.0" %}
+{% set git_url = "https://github.com/astropy/pytest-openfiles" %}
+{% set sha256 = "be5e6a0e7c6a64e58a27bdcdd9ab2aa09a9a9c9a525499ee08d2e77e2c19f535" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+    - pytest >=3.1
+    - psutil
+  run:
+    - python
+    - pytest >=3.1
+    - psutil
+
+test:
+  imports:
+    - pytest_openfiles
+
+about:
+  home: {{ git_url }}
+  license: BSD
+  summary: 'Pytest plugin for detecting inadvertent open file handles'
+  description: |
+    This package provides a plugin for the pytest framework that allows
+    developers to detect whether any file handles or other file-like objects
+    were inadvertently left open at the end of a unit test.
+  doc_url: {{ git_url }}
+  dev_url: {{ git_url }}
+
+extra:
+  recipe-maintainers:
+    - astrofrog-conda-forge
+    - drdavella
+    - mwcraig

--- a/ska_conda/pkg_defs/pytest-remotedata/meta.yaml
+++ b/ska_conda/pkg_defs/pytest-remotedata/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "pytest-remotedata" %}
+{% set version = "0.3.0" %}
+{% set git_url = "https://github.com/astropy/pytest-remotedata" %}
+{% set sha256 = "cb0a6e22ba07ff870edeb17d5d38c495e8f37e2db741cd15e723fb8e609909eb" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+    - pytest >=3.1
+    - six
+  run:
+    - python
+    - pytest >=3.1
+    - six
+
+test:
+  imports:
+    - pytest_remotedata
+
+about:
+  home: {{ git_url }}
+  license: BSD
+  summary: 'Pytest plugin for controlling remote data access'
+  description: |
+    This package provides a plugin for the pytest framework that allows
+    developers to control unit tests that require access to data from the
+    internet.
+  doc_url: {{ git_url }}
+  dev_url: {{ git_url }}
+
+extra:
+  recipe-maintainers:
+    - astrofrog-conda-forge
+    - drdavella
+    - mwcraig

--- a/ska_conda/ska_builder.py
+++ b/ska_conda/ska_builder.py
@@ -6,7 +6,9 @@ import re
 ska_conda_path = os.path.abspath(os.path.dirname(__file__))
 pkg_defs_path = os.path.join(ska_conda_path, "pkg_defs")
 build_list = os.path.join(ska_conda_path, "build_order.txt")
-no_source_pkgs = ['ska3-flight', 'ska3-core', 'ska3-dev', 'ska3-pinned', 'ska3-template']
+no_source_pkgs = ['ska3-flight', 'ska3-core', 'ska3-dev', 'ska3-pinned', 'ska3-template',
+                  'pytest-arraydiff', 'pytest-doctestplus', 'pytest-openfiles', 'pytest-remotedata',
+                  'pytest-astropy', 'astropy']
 
 class SkaBuilder(object):
 


### PR DESCRIPTION
Bundle a recipe for astropy (and some test dependencies) in skare3 to give us an astropy 3.0.3 that will still run on our CentOS5-compatible Linux env.