### PR TITLE
Make ska_version output shorter by default

### DIFF
--- a/ska_conda/pkg_defs/ska3-flight/meta.yaml
+++ b/ska_conda/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2018.08.01
+  version: 2018.08.02
 
 build:
   noarch: generic
@@ -10,7 +10,7 @@ requirements:
   # will be installed automatically whenever the package is installed.
   run:
     - ska3-core ==2018.07.27.1
-    - ska3-template ==2018.07.30
+    - ska3-template ==2018.08.02
     - agasc ==3.5.2
     - annie ==0.5
     - acisfp_check ==v2.4.0

--- a/ska_conda/pkg_defs/ska3-template/bin/ska_version
+++ b/ska_conda/pkg_defs/ska3-template/bin/ska_version
@@ -6,24 +6,44 @@ followed by a sha based on the versions of the other packages.
 
 Example:
 
+$ ska_version
+2018.07.16-f272ef6
+
+$ ska_version --full
 core-2018.07.16:flight-2018.07.16:pinned-2018.07.16:template-0.1:sha-f272ef6
 
 """
-
 import subprocess
 import json
 import hashlib
+import argparse
+
+parser = argparse.ArgumentParser(description='Get Ska3 version tag')
+parser.add_argument('--full',
+                    action='store_true',
+                    help='Output full version string')
+args = parser.parse_args()
+
 # Conda list output appears already sorted by package name
+# NOTE: conda JSON list does not include pip packages for some reason.
 pkgs_json = subprocess.check_output(["conda", "list", "--json"])
 pkgs = json.loads(pkgs_json)
-ska3_pkgs = [f"{pkg['name'].lstrip('ska3-')}-{pkg['version']}"
-             for pkg in pkgs if pkg['name'].startswith('ska3-')]
-# Get a list of all the other conda pkgs and their versions (not builds or channels)
-all_pkgs = [f"{pkg['name']}-{pkg['version']}"
-            for pkg in pkgs if not pkg['name'].startswith('ska3-')]
-pkgs = subprocess.check_output(["conda", "list"], encoding='utf-8').splitlines()
+if args.full:
+    ska3_pkgs = [f"{pkg['name'].lstrip('ska3-')}-{pkg['version']}"
+                 for pkg in pkgs if pkg['name'].startswith('ska3-')]
+else:
+    ska3_pkgs = [pkg['version']
+                 for pkg in pkgs if pkg['name'] == 'ska3-flight']
+
+# Get a list of all conda pkgs and their versions (not builds or channels)
+all_pkgs = [f"{pkg['name']}-{pkg['version']}" for pkg in pkgs]
+
 # Add the 'pip' installed packages to that list
+pkgs = subprocess.check_output(["conda", "list"], encoding='utf-8').splitlines()
 all_pkgs.extend(pkg for pkg in pkgs if '<pip>' in pkg)
+
+# SHA1 tag for all packages
 sha_tag = hashlib.sha1(''.join(all_pkgs).encode('utf-8')).hexdigest()[0:7]
-ska3_pkgs.append(f'sha-{sha_tag}')
-print(":".join(ska3_pkgs))
+ska3_pkgs.append(f'sha-{sha_tag}' if args.full else sha_tag)
+
+print("-".join(ska3_pkgs))

--- a/ska_conda/pkg_defs/ska3-template/bin/ska_version
+++ b/ska_conda/pkg_defs/ska3-template/bin/ska_version
@@ -35,8 +35,10 @@ else:
     ska3_pkgs = [pkg['version']
                  for pkg in pkgs if pkg['name'] == 'ska3-flight']
 
-# Get a list of all conda pkgs and their versions (not builds or channels)
-all_pkgs = [f"{pkg['name']}-{pkg['version']}" for pkg in pkgs]
+# Get a list of all non-ska3-* metapackages conda pkgs and their versions
+# (not builds or channels)
+all_pkgs = [f"{pkg['name']}-{pkg['version']}" for pkg in pkgs
+            if not pkg['name'].startswith('ska3-')]
 
 # Add the 'pip' installed packages to that list
 pkgs = subprocess.check_output(["conda", "list"], encoding='utf-8').splitlines()

--- a/ska_conda/pkg_defs/ska3-template/meta.yaml
+++ b/ska_conda/pkg_defs/ska3-template/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-template
-  version:  2018.07.30
+  version:  2018.08.02
 
 build:
   noarch: generic


### PR DESCRIPTION
The dog-fooding begins...

The `:`-separated version actually breaks the Ska.engarchive long test because `:` in the path is interpreted as a path separator.  So using colon was just not a good choice.  But more to the point, I realized that in practice `ska3-flight` has embedded in it the other package versions.  Unless you purposely do crazy things with forcing different metapackages, the version of `ska3-flight` plus the SHA1 of everything is fine.

This PR makes that short form the default, but does add a `--full` option to get the full list consistent (mostly, see next paragraph) with the current output.

The other thing this changes is having *all* packages factor into the SHA hash.  This was mostly driven by having a simple code base that produces the same SHA for both the short and full forms, but also makes sense to me.  The SHA should be different if *any* package version is different.