### PR TITLE
Mods for 32 bit Linux

### DIFF
--- a/ska_conda/pkg_defs/astropy/meta.yaml
+++ b/ska_conda/pkg_defs/astropy/meta.yaml
@@ -8,7 +8,8 @@ source:
   fn: astropy-{{version}}.tar.gz
   url: https://pypi.io/packages/source/a/astropy/astropy-{{version}}.tar.gz
   sha256: 6af07abe5e263820a3dec93832a6ad74005013071490e125afbc6514411721da
-
+  patches:
+    - old_gcc_cfitsio_patch.txt [linux32]
 
 build:
   detect_binary_files_with_prefix: False
@@ -21,7 +22,7 @@ build:
     - samp_hub = astropy.samp.hub_script:hub_script
     - volint = astropy.io.votable.volint:main
     - wcslint = astropy.wcs.wcslint:main
-  number: 1
+  number: 2
 
 requirements:
 
@@ -30,14 +31,14 @@ requirements:
     - setuptools
     - numpy ==1.12.1
     - llvmlite ==0.18.0
-    - gcc ==4.8.5 [linux]
-    - libgcc ==4.8.5 [linux]
+    - gcc ==4.8.5 [linux64]
+    - libgcc ==4.8.5 [linux64]
   run:
     - python
     - llvmlite ==0.18.0
     - numpy ==1.12.1
     - pytest-astropy
-    - libgcc ==4.8.5 [linux]
+    - libgcc ==4.8.5 [linux64]
 test:
   commands:
     - fits2bitmap --help

--- a/ska_conda/pkg_defs/astropy/meta.yaml
+++ b/ska_conda/pkg_defs/astropy/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://pypi.io/packages/source/a/astropy/astropy-{{version}}.tar.gz
   sha256: 6af07abe5e263820a3dec93832a6ad74005013071490e125afbc6514411721da
   patches:
-    - old_gcc_cfitsio_patch.txt [linux32]
+    - old_gcc_cfitsio_patch.txt # [linux32]
 
 build:
   detect_binary_files_with_prefix: False
@@ -31,14 +31,14 @@ requirements:
     - setuptools
     - numpy ==1.12.1
     - llvmlite ==0.18.0
-    - gcc ==4.8.5 [linux64]
-    - libgcc ==4.8.5 [linux64]
+    - gcc ==4.8.5 # [linux64]
+    - libgcc ==4.8.5 # [linux64]
   run:
     - python
     - llvmlite ==0.18.0
     - numpy ==1.12.1
     - pytest-astropy
-    - libgcc ==4.8.5 [linux64]
+    - libgcc ==4.8.5 # [linux64]
 test:
   commands:
     - fits2bitmap --help

--- a/ska_conda/pkg_defs/astropy/old_gcc_cfitsio_patch.txt
+++ b/ska_conda/pkg_defs/astropy/old_gcc_cfitsio_patch.txt
@@ -1,0 +1,14 @@
+diff --git a/astropy/io/fits/setup_package.py b/astropy/io/fits/setup_package.py
+index c73b6dd..0e52520 100644
+--- a/astropy/io/fits/setup_package.py
++++ b/astropy/io/fits/setup_package.py
+@@ -41,9 +41,6 @@ def _get_compression_extension():
+                     '-Wno-strict-prototypes',
+                     '-Wno-unused',
+                     '-Wno-uninitialized',
+-                    '-Wno-unused-result',  # gcc >~4.8
+-                    '-Wno-misleading-indentation',  # gcc >~7.2
+-                    '-Wno-format-overflow',  # gcc >~7.2
+                 ])
+ 
+         cfitsio_lib_path = os.path.join('cextern', 'cfitsio', 'lib')

--- a/ska_conda/pkg_defs/ska3-core/README
+++ b/ska_conda/pkg_defs/ska3-core/README
@@ -1,0 +1,22 @@
+The combine_arch.py script was intended to help to make a combined
+package list.  
+
+The intent is that one builds a ska3-dev environment on the two
+platforms (linux and osx), exports the package list, and then creates
+a combined list using the script.
+
+It is set with the logic that for shared packages the lowest-common
+package version is "hopefully" appropriate for the full environment.
+However, this may not be true (wasn't for the zeromq package) and also
+doesn't neatly scale to adding new operating systems (linux32 and
+windows).  The script should probably be updated so that it will have
+a single entry/version if all OS naturally share the version and an
+explicit version per OS otherwise.
+
+In the interim, manual updates to the ska3-core list are OK.
+
+Note that sherpa has been added to ska3-core but is not in the
+"defaults" channel.  Care should be taken so it is not accidentally
+removed.
+
+ 

--- a/ska_conda/pkg_defs/ska3-core/meta.yaml
+++ b/ska_conda/pkg_defs/ska3-core/meta.yaml
@@ -6,13 +6,31 @@ requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
+
+  # Note that sherpa is not in the defaults channel and may be missed
+  # if trying to automatically update ska3-core
+   - sherpa ==4.9.1 [linux64 and osx]
+
+  # And note that these packages are presently built out of skare3.
+  # If the versions we request become available in conda default channels,
+  # it will be fine to move to those default packages and deprecate the
+  # skare3 builds
+   - astropy ==3.0.3
+   - ipywidgets ==7.3.0
+   - widgetsnbextension ==3.3.0
+   - pytest-arraydiff ==0.2
+   - pytest-astropy ==0.4.0
+   - pytest-doctestplus ==0.1.3
+   - pytest-openfiles ==0.3.0
+   - pytest-remotedata ==0.3.0
+
+  # Packages from conda defaults channels, limited to older channels for CentOS5
    - _nb_ext_conf ==0.4.0
    - alabaster ==0.7.10
    - anaconda-client ==1.6.3
    - appnope ==0.1.0 # [osx]
    - asn1crypto ==0.22.0
    - astroid ==1.5.3
-   - astropy ==3.0.3
    - babel ==2.5.0
    - beautifulsoup4 ==4.6.0
    - bkcharts ==0.2
@@ -53,7 +71,6 @@ requirements:
    - ipyparallel ==6.0.2
    - ipython ==6.1.0
    - ipython_genutils ==0.2.0
-   - ipywidgets ==7.3.0
    - isort ==4.2.15
    - jbig ==2.1
    - jedi ==0.10.2
@@ -127,11 +144,6 @@ requirements:
    - pyqt ==5.6.0
    - pytables ==3.4.2
    - pytest ==3.2.1
-   - pytest-arraydiff ==0.2
-   - pytest-astropy ==0.4.0
-   - pytest-doctestplus ==0.1.3
-   - pytest-openfiles ==0.3.0
-   - pytest-remotedata ==0.3.0
    - python ==3.6.2
    - python-dateutil ==2.6.1
    - python.app ==1.2 # [osx]
@@ -150,7 +162,6 @@ requirements:
    - scipy ==0.19.1
    - setuptools ==27.2.0 # [linux32]
    - setuptools ==36.4.0 # [linux64 and osx]
-   - sherpa ==4.9.1 [linux64 and osx]
    - simplegeneric ==0.8.1
    - singledispatch ==3.4.0.3
    - sip ==4.18
@@ -170,7 +181,6 @@ requirements:
    - traitlets ==4.3.2
    - wcwidth ==0.1.7
    - wheel ==0.29.0
-   - widgetsnbextension ==3.3.0
    - wrapt ==1.10.11
    - xz ==5.2.2 # [linux32]
    - xz ==5.2.3 # [linux64 and osx]

--- a/ska_conda/pkg_defs/ska3-core/meta.yaml
+++ b/ska_conda/pkg_defs/ska3-core/meta.yaml
@@ -150,6 +150,7 @@ requirements:
    - scipy ==0.19.1
    - setuptools ==27.2.0 # [linux32]
    - setuptools ==36.4.0 # [linux64 and osx]
+   - sherpa ==4.9.1 [linux64 and osx]
    - simplegeneric ==0.8.1
    - singledispatch ==3.4.0.3
    - sip ==4.18

--- a/ska_conda/pkg_defs/ska3-core/meta.yaml
+++ b/ska_conda/pkg_defs/ska3-core/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core
-  version: 2018.07.27.1
+  version: 2018.08.10
 
 requirements:
   # Packages required to run the package. These are the dependencies that
@@ -9,7 +9,7 @@ requirements:
    - _nb_ext_conf ==0.4.0
    - alabaster ==0.7.10
    - anaconda-client ==1.6.3
-   - appnope ==0.1.0 [osx]
+   - appnope ==0.1.0 # [osx]
    - asn1crypto ==0.22.0
    - astroid ==1.5.3
    - astropy ==3.0.3
@@ -18,7 +18,7 @@ requirements:
    - bkcharts ==0.2
    - bleach ==1.5.0
    - bokeh ==0.12.7
-   - certifi ==2016.2.28
+   - certifi ==2016.2.28 # [not linux32]
    - cffi ==1.10.0
    - chardet ==3.0.4
    - clyent ==1.2.2
@@ -27,25 +27,27 @@ requirements:
    - curl ==7.54.1
    - cycler ==0.10.0
    - cython ==0.26
-   - dbus ==1.10.20 [linux]
+   - dbus ==1.10.20 # [linux]
    - decorator ==4.1.2
    - django ==1.11.3
    - docutils ==0.14
    - entrypoints ==0.2.3
    - expat ==2.1.0
-   - fontconfig ==2.12.1 [linux]
+   - fontconfig ==2.12.1 # [linux64]
    - freetype ==2.5.5
-   - git ==2.11.1
+   - git ==2.9.3 # [linux32]
+   - git ==2.11.1 # [linux64 and osx]
    - gitdb2 ==2.0.0
    - gitpython ==2.1.3
-   - glib ==2.50.2 [linux]
-   - gst-plugins-base ==1.8.0 [linux]
-   - gstreamer ==1.8.0 [linux]
+   - glib ==2.50.2 # [linux]
+   - gst-plugins-base ==1.8.0 # [linux]
+   - gstreamer ==1.8.0 # [linux]
    - h5py ==2.7.0
    - hdf5 ==1.8.17
    - html5lib ==0.999
    - icu ==54.1
-   - idna ==2.6
+   - idna ==2.5 # [linux32]
+   - idna ==2.6 # [linux64 and osx]
    - imagesize ==0.7.1
    - ipykernel ==4.6.1
    - ipyparallel ==6.0.2
@@ -64,16 +66,16 @@ requirements:
    - jupyter_core ==4.3.0
    - krb5 ==1.13.2
    - lazy-object-proxy ==1.3.1
-   - libffi ==3.2.1 [linux]
+   - libffi ==3.2.1 # [linux]
    - libgcc ==4.8.5
    - libgfortran ==3.0.0
-   - libiconv ==1.14 [linux]
+   - libiconv ==1.14 # [linux]
    - libpng ==1.6.30
-   - libsodium ==1.0.10 [linux]
+   - libsodium ==1.0.10 # [linux]
    - libssh2 ==1.8.0
    - libtiff ==4.0.6
-   - libxcb ==1.12 [linux]
-   - libxml2 ==2.9.4 [linux]
+   - libxcb ==1.12 # [linux]
+   - libxml2 ==2.9.4 # [linux]
    - line_profiler ==2.0
    - llvmlite ==0.18.0
    - markupsafe ==1.0
@@ -100,23 +102,27 @@ requirements:
    - pandocfilters ==1.4.2
    - paramiko ==2.1.2
    - path.py ==10.3.1
-   - pcre ==8.39 [linux]
+   - pcre ==8.39 # [linux]
    - pep8 ==1.7.0
    - pexpect ==4.2.1
    - pickleshare ==0.7.4
    - pillow ==4.2.1
    - pip ==9.0.1
+   - pkginfo ==1.4.1 # [linux32]
    - prompt_toolkit ==1.0.15
    - psutil ==5.2.2
    - ptyprocess ==0.5.2
    - py ==1.4.34
    - pyasn1 ==0.2.3
    - pycodestyle ==2.3.1
-   - pycparser ==2.18
+   - pycosat ==0.6.2 # [linux32]
+   - pycparser ==2.17 # [linux32]
+   - pycparser ==2.18 # [linux64 and osx]
    - pycrypto ==2.6.1
    - pyflakes ==1.6.0
    - pygments ==2.2.0
    - pylint ==1.7.2
+   - pyopenssl ==17.0.0 # [linux32]
    - pyparsing ==2.2.0
    - pyqt ==5.6.0
    - pytables ==3.4.2
@@ -128,7 +134,7 @@ requirements:
    - pytest-remotedata ==0.3.0
    - python ==3.6.2
    - python-dateutil ==2.6.1
-   - python.app ==1.2 [osx]
+   - python.app ==1.2 # [osx]
    - pytz ==2017.2
    - pyyaml ==3.12
    - pyzmq ==16.0.2
@@ -142,7 +148,8 @@ requirements:
    - runipy ==0.1.5
    - scikit-learn ==0.19.0
    - scipy ==0.19.1
-   - setuptools ==36.4.0
+   - setuptools ==27.2.0 # [linux32]
+   - setuptools ==36.4.0 # [linux64 and osx]
    - simplegeneric ==0.8.1
    - singledispatch ==3.4.0.3
    - sip ==4.18
@@ -152,7 +159,8 @@ requirements:
    - sphinx ==1.6.3
    - sphinxcontrib ==1.0
    - sphinxcontrib-websupport ==1.0.1
-   - spyder ==3.2.3
+   - spyder ==3.2.2 # [linux32]
+   - spyder ==3.2.3 # [linux64 and osx]
    - sqlite ==3.13.0
    - terminado ==0.6
    - testpath ==0.3.1
@@ -163,8 +171,10 @@ requirements:
    - wheel ==0.29.0
    - widgetsnbextension ==3.3.0
    - wrapt ==1.10.11
-   - xz ==5.2.3
+   - xz ==5.2.2 # [linux32]
+   - xz ==5.2.3 # [linux64 and osx]
    - yaml ==0.1.6
-   - zeromq ==4.1.3 [osx]
-   - zeromq ==4.1.5 [linux]
-   - zlib ==1.2.11
+   - zeromq ==4.1.3 # [osx]
+   - zeromq ==4.1.5 # [linux]
+   - zlib ==1.2.8 # [linux32]
+   - zlib ==1.2.11 # [linux64 and osx]

--- a/ska_conda/pkg_defs/ska3-flight/meta.yaml
+++ b/ska_conda/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2018.08.08
+  version: 2018.08.10
 
 build:
   noarch: generic
@@ -9,7 +9,7 @@ requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
-    - ska3-core ==2018.07.27.1
+    - ska3-core ==2018.08.10
     - ska3-template ==2018.08.02
     - agasc ==3.5.2
     - annie ==0.5
@@ -32,7 +32,6 @@ requirements:
     - psmc_check ==v1.2.0
     - pyyaks ==3.3.4
     - quaternion ==3.4.1
-    - sherpa ==4.9.1
     - ska.arc5gl ==3.1.1
     - ska.astro ==3.2.1
     - ska.dbi ==3.8.2


### PR DESCRIPTION
Update ska3-core to include modifications needed for 32bit linux. 

Also add a small patch for astropy when compiled on ancient 32 bit build system (the conda gcc didn't work either).