### PR TITLE
Make acis_taco an arch package

### DIFF
--- a/ska_conda/pkg_defs/acis_taco/meta.yaml
+++ b/ska_conda/pkg_defs/acis_taco/meta.yaml
@@ -3,7 +3,6 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
-  noarch: python
   script_env:
     - SKA_TOP_SRC_DIR
 


### PR DESCRIPTION
Remove "noarch: python" from acis_taco recipe so it becomes a regular arch package.

It looks like this is the easiest way to let the current acis_taco install make_esaview_data.py (which it is set to do from setup.py). It also puts the task_sched* files in prefix/share/acis_taco.

Closes #57 
