### PR TITLE
Update ska3-template to actually install 'skare'

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2018.08.10
+  version: 2018.08.12
 
 build:
   noarch: generic
@@ -10,7 +10,7 @@ requirements:
   # will be installed automatically whenever the package is installed.
   run:
     - ska3-core ==2018.08.10
-    - ska3-template ==2018.08.02
+    - ska3-template ==2018.08.12
     - agasc ==3.5.2
     - annie ==0.5
     - acisfp_check ==v2.4.0

--- a/pkg_defs/ska3-template/build.sh
+++ b/pkg_defs/ska3-template/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-for file in flt_envs ska_envs.sh ska_envs.csh ska_version
+for file in flt_envs ska_envs.sh ska_envs.csh ska_version skare
    do
-    chmod +x ${RECIPE_DIR}/bin/${file}
     cp -a ${RECIPE_DIR}/bin/${file} ${PREFIX}/bin
+    chmod +x ${PREFIX}/bin/${file}
     # Replace %{PREFIX}% with the conda build prefix.
     sed -i.bak -e "s|%{PREFIX}%|${PREFIX}|" ${PREFIX}/bin/${file}
     rm ${PREFIX}/bin/${file}.bak

--- a/pkg_defs/ska3-template/meta.yaml
+++ b/pkg_defs/ska3-template/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-template
-  version:  2018.08.02
+  version:  2018.08.12
 
 build:
   noarch: generic


### PR DESCRIPTION
Update ska3-template to actually install 'skare'

This is a trivial update to actually install the 'skare' script that was already in the ska3-template bin directory.  The 'sed' part of the build process will be a no-op on the 'skare' script itself, but that is not a an issue.