### PR TITLE
ACIS updates approved 31-Aug-2018

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2018.08.31
+  version: 2018.09.07
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - dea_check ==v2.2.0
     - dpa_check ==v2.3.0
     - hopper ==0.3
-    - kadi ==3.16.1
+    - kadi ==3.16.2
     - maude ==3.2
     - mica ==3.14.0
     - parse_cm ==3.4

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - acis_thermal_check ==v2.7.0
     - backstop_history ==v1.1.0
     - chandra_aca ==4.23
-    - chandra.cmd_states ==3.14.1
+    - chandra.cmd_states ==3.14.2
     - chandra.maneuver ==3.7
     - chandra.time ==3.20.1
     - cxotime ==3.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - annie ==0.5
     - acisfp_check ==v2.4.0
     - acis_taco ==4.0
-    - acis_thermal_check ==v2.7.0
+    - acis_thermal_check ==v2.8.0
     - backstop_history ==v1.1.0
     - chandra_aca ==4.23
     - chandra.cmd_states ==3.14.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - dea_check ==v2.2.0
     - dpa_check ==v2.3.0
     - hopper ==0.3
-    - kadi ==3.16
+    - kadi ==3.16.1
     - maude ==3.2
     - mica ==3.14.0
     - parse_cm ==3.4

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2018.08.28
+  version: 2018.08.31
 
 build:
   noarch: generic


### PR DESCRIPTION
This includes changes to cmd_states and kadi to support that WSVIDALLDN sets ccd_count to 0.
There's also a new version of acis_thermal_check that uses the sqlite database by default instead of Sybase.