### PR TITLE
Collection of updates for starcheck + chandra_aca + agasc 

### DIFF
--- a/pkg_defs/hopper/meta.yaml
+++ b/pkg_defs/hopper/meta.yaml
@@ -18,9 +18,19 @@ requirements:
   # listed explicitly if they are required.
   build:
     - pip
-    - python
     - setuptools
+    - python
+    - six
+    - quaternion
+    - chandra_aca
+    - pyyaks
+    - chandra.maneuver
+    - chandra.time
+    - cxotime
+    - parse_cm
+    - astropy
     - testr
+
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/hopper/meta.yaml
+++ b/pkg_defs/hopper/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - pyyaks
     - chandra.maneuver
     - chandra.time
+    - cxotime
     - parse_cm
     - astropy
     - testr

--- a/pkg_defs/jplephem/meta.yaml
+++ b/pkg_defs/jplephem/meta.yaml
@@ -23,10 +23,10 @@ requirements:
     - pip
     - python
     - setuptools
-    - numpy ==1.12
+    - numpy ==1.12.1
   run:
     - python
-    - numpy ==1.12
+    - numpy ==1.12.1
 
 test:
   requires:

--- a/pkg_defs/proseco/build.sh
+++ b/pkg_defs/proseco/build.sh
@@ -1,0 +1,1 @@
+pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/proseco/meta.yaml
+++ b/pkg_defs/proseco/meta.yaml
@@ -1,0 +1,43 @@
+package:
+  name: proseco
+  version:  {{ GIT_DESCRIBE_TAG }}
+
+build:
+  noarch: python
+  script_env:
+    - SKA_TOP_SRC_DIR
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/proseco
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - python
+    - pip
+    - setuptools
+    - testr
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - numpy
+    - scipy
+    - astropy
+    - chandra_aca
+    - agasc
+    - mica
+    - testr
+
+test:
+  imports:
+    - proseco
+
+
+about:
+  home: git@github.com:sot/proseco
+

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cxotime ==3.1
     - dea_check ==v2.2.0
     - dpa_check ==v2.3.0
-    - hopper ==0.3
+    - hopper ==4.4
     - jplephem ==2.8
     - kadi ==3.16.2
     - maude ==3.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - acis_taco ==4.0
     - acis_thermal_check ==v2.8.0
     - backstop_history ==v1.1.0
-    - chandra_aca ==4.23.1
+    - chandra_aca ==4.24
     - chandra.cmd_states ==3.14.2
     - chandra.maneuver ==3.7.1
     - chandra.time ==3.20.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - ska.arc5gl ==3.1.1
     - ska.astro ==3.2.1
     - ska.dbi ==3.8.2
-    - ska.engarchive ==3.43.2
+    - ska.engarchive ==4.44
     - ska.file ==3.4.1
     - ska.ftp ==3.5
     - ska.numpy ==3.8.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2018.11.27
+  version: 2018.12.06
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - maude ==3.2
     - mica ==3.15
     - parse_cm ==3.4
+    - proseco ==4.2
     - psmc_check ==v1.2.0
     - pyyaks ==3.3.4
     - quaternion ==3.4.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2018.10.05
+  version: 2018.11.27
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -51,4 +51,4 @@ requirements:
     - ska.tdb ==3.5.1
     - tables3_api ==0.1
     - testr ==3.2
-    - xija ==3.12
+    - xija ==4.13

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -50,4 +50,4 @@ requirements:
     - ska.tdb ==3.5.1
     - tables3_api ==0.1
     - testr ==3.2
-    - xija ==3.11.1
+    - xija ==3.12

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - dpa_check ==v2.3.0
     - hopper ==4.4
     - jplephem ==2.8
-    - kadi ==3.16.2
+    - kadi ==3.16.3
     - maude ==3.2
     - mica ==3.15
     - parse_cm ==3.4

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -11,7 +11,7 @@ requirements:
   run:
     - ska3-core ==2018.08.27
     - ska3-template ==2018.08.12
-    - agasc ==4.6
+    - agasc ==4.7
     - annie ==0.5
     - acisfp_check ==v2.4.0
     - acis_taco ==4.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-perl
-  version: 2018.12.03
+  version: 2018.12.04
 
 requirements:
   run:
@@ -18,6 +18,6 @@ requirements:
     - perl-cxc-sysarch ==1.0
     - perl-ska-agasc ==3.5.0
     - perl-ska-classic ==0.5
-    - watch_cron_logs ==4.1
-    - task_schedule ==4.1
-    - starcheck ==12.1
+    - watch_cron_logs ==4.1 # [linux]
+    - task_schedule ==4.1 # [linux]
+    - starcheck ==12.1 # [linux]

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,23 +1,23 @@
 package:
   name: ska3-perl
-  version: 2018.11.19
+  version: 2018.11.27
 
 requirements:
   run:
-    - cfitsio
-    - xtime
-    - pgplot [linux]
+    - cfitsio ==3.450
+    - xtime ==1.2.2
+    - pgplot ==5.2.2 [linux]
     - perl ==5.26.2
-    - perl-extutils-f77
-    - perl-app-cpanminus
-    - perl-core-deps
-    - perl-pgplot [linux]
-    - perl-ska-convert
-    - perl-chandra-time
-    - perl-app-env-ascds
-    - perl-cxc-sysarch
-    - perl-ska-agasc
-    - perl-ska-classic
+    - perl-extutils-f77 ==1.20
+    - perl-app-cpanminus ==1.7044
+    - perl-core-deps ==0.1
+    - perl-pgplot ==2.19 [linux]
+    - perl-dbd-sybase ==1.15 [linux]
+    - perl-chandra-time ==0.9.2
+    - perl-app-env-ascds ==0.4
+    - perl-cxc-sysarch ==1.0
+    - perl-ska-agasc ==3.5.0
+    - perl-ska-classic ==0.5
     - watch_cron_logs ==4.1
     - task_schedule ==4.1
     - starcheck ==12.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,0 +1,23 @@
+package:
+  name: ska3-perl
+  version: 2018.11.19
+
+requirements:
+  run:
+    - cfitsio
+    - xtime
+    - pgplot [linux]
+    - perl ==5.26.2
+    - perl-extutils-f77
+    - perl-app-cpanminus
+    - perl-core-deps
+    - perl-pgplot [linux]
+    - perl-ska-convert
+    - perl-chandra-time
+    - perl-app-env-ascds
+    - perl-cxc-sysarch
+    - perl-ska-agasc
+    - perl-ska-classic
+    - watch_cron_logs ==4.1
+    - task_schedule ==4.1
+    - starcheck ==12.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -20,4 +20,4 @@ requirements:
     - perl-ska-classic ==0.5
     - watch_cron_logs ==4.1
     - task_schedule ==4.1
-    - starcheck ==12.0
+    - starcheck ==12.1

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -6,13 +6,13 @@ requirements:
   run:
     - cfitsio ==3.450
     - xtime ==1.2.2
-    - pgplot ==5.2.2 [linux]
+    - pgplot ==5.2.2 # [linux]
     - perl ==5.26.2
     - perl-extutils-f77 ==1.20
     - perl-app-cpanminus ==1.7044
     - perl-core-deps ==0.1
-    - perl-pgplot ==2.19 [linux]
-    - perl-dbd-sybase ==1.15 [linux]
+    - perl-pgplot ==2.19 # [linux]
+    - perl-dbd-sybase ==1.15 # [linux]
     - perl-chandra-time ==0.9.2
     - perl-app-env-ascds ==0.4
     - perl-cxc-sysarch ==1.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-perl
-  version: 2018.11.27
+  version: 2018.12.03
 
 requirements:
   run:

--- a/pkg_defs/starcheck/build.sh
+++ b/pkg_defs/starcheck/build.sh
@@ -1,0 +1,1 @@
+pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/starcheck/meta.yaml
+++ b/pkg_defs/starcheck/meta.yaml
@@ -1,0 +1,46 @@
+package:
+  name: starcheck
+  version:  {{ GIT_DESCRIBE_TAG }}
+
+build:
+  noarch: python
+  script_env:
+    - SKA_TOP_SRC_DIR
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/starcheck
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - python
+    - pip
+    - setuptools
+    - testr
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - numpy
+    - perl ==5.26.2
+    - perl-core-deps
+    - perl-ska-classic
+    - perl-chandra-time
+    - chandra_aca
+    - hopper
+    - agasc
+    - ska.matplotlib
+    - testr
+
+test:
+  imports:
+    - starcheck
+
+
+about:
+  home: git@github.com:sot/starcheck
+

--- a/ska3_flight_build_order.txt
+++ b/ska3_flight_build_order.txt
@@ -44,6 +44,7 @@ acisfp_check
 psmc_check
 dea_check
 dpa_check
+proseco
 ska3-template
 ska3-pinned
 ska3_builder

--- a/ska3_flight_build_order.txt
+++ b/ska3_flight_build_order.txt
@@ -50,4 +50,5 @@ ska3_builder
 ska3-core
 ska3-flight
 ska3-dev
+starcheck
 ska3-perl

--- a/ska3_flight_build_order.txt
+++ b/ska3_flight_build_order.txt
@@ -50,3 +50,4 @@ ska3_builder
 ska3-core
 ska3-flight
 ska3-dev
+ska3-perl

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -33,8 +33,10 @@ BUILD_LIST = [b for b in BUILD_LIST if not re.match("^\s*$", b)]
 
 if os.uname().sysname == "Darwin":
     os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
-    # Don't try to do pgplot on osx
-    for pkg in ['pgpplot', 'perl-pgplot']:
+
+if os.uname().machine == 'i686':
+    # Skip starcheck and ska3-perl on 32 bit
+    for pkg in ['starcheck', 'ska3-perl']:
         if pkg in BUILD_LIST:
             BUILD_LIST.remove(pkg)
 


### PR DESCRIPTION
Updates to chandra_aca, agasc, xija
Inclusion of starcheck and a more rigorous ska3-perl metapackage.

### `chandra_aca` 4.24

- [Infrastructure improvements to transform module](https://github.com/sot/chandra_aca/pull/66)
- [Add new grid model infrastructure and 2018-11 acq prob model](https://github.com/sot/chandra_aca/pull/65)

### `agasc` 4.7

- [Include near neighbor stars and exclude rarely used cols from miniagasc](https://github.com/sot/agasc/pull/36)
- [Update COLOR1 column to reflect AGASC 1.7 mag updates](https://github.com/sot/agasc/pull/37)

### `xija` 4.13

- Release 4.13 with step function power input from xija 3.12 (already in Ska2) and new Qt gui_fit now in 4.13

### `kadi` 3.16.3

- [Remove unused 'check' blocks in cmds task_schedules](https://github.com/sot/kadi/pull/121)
- [Do event updates on a local copy and move back](https://github.com/sot/kadi/pull/124)

### `Ska.engarchive` 4.44

- [Make update_archive.py module py3-compatible](https://github.com/sot/eng_archive/pull/143)

### `proseco` 4.2

- Updates to support include/exclude lists of stars for acq and guide
- Update to support more reasonable mag err limits for color=1.5 stars
- Update to support use of grid-acq probabilities from chandra_aca 4.24 

### `starcheck` 12.1

- Ska3 version of starcheck with -9.5C planning limit and pre-safe-mode probability thresholds