### PR TITLE
Updates for Feb 2019 MATLAB release (the second one)

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - jplephem ==2.8
     - kadi ==3.16.3
     - maude ==3.2
-    - mica ==3.15
+    - mica ==3.16
     - parse_cm ==3.4
     - proseco ==4.4
     - psmc_check ==v1.2.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-matlab
-  version: 2019.01.10
+  version: 2019.01.29
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - ska.shell ==3.3.3
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
-    - sparkles ==4.1
+    - sparkles ==4.1.1
     - tables3_api ==0.1
     - testr ==3.2
     - xija ==4.13

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - dpa_check ==v2.3.0
     - hopper ==4.4
     - jplephem ==2.8
-    - kadi ==3.16.3
+    - kadi ==3.16.4
     - maude ==3.2
     - mica ==3.16
     - parse_cm ==3.4

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - acis_taco ==4.0.1
     - acis_thermal_check ==v2.8.0
     - backstop_history ==v1.1.0
-    - chandra_aca ==4.25.1
+    - chandra_aca ==4.25.2
     - chandra.cmd_states ==3.14.2
     - chandra.maneuver ==3.7.1
     - chandra.time ==3.20.3

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -11,6 +11,7 @@ requirements:
   run:
     - ska3-core ==2018.08.27
     - ska3-template ==2018.08.12
+    - aca_preview ==4.0
     - agasc ==4.7
     - annie ==0.5
     - acisfp_check ==v2.4.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - maude ==3.2
     - mica ==3.16
     - parse_cm ==3.4
-    - proseco ==4.4
+    - proseco ==4.4.1
     - psmc_check ==v1.2.0
     - pyyaks ==3.3.5
     - quaternion ==3.4.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - maude ==3.2
     - mica ==3.15
     - parse_cm ==3.4
-    - proseco ==4.3.3
+    - proseco ==4.4
     - psmc_check ==v1.2.0
     - pyyaks ==3.3.5
     - quaternion ==3.4.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-matlab
-  version: 2019.02.26
+  version: 2019.03.01
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - acis_taco ==4.0.1
     - acis_thermal_check ==v2.8.0
     - backstop_history ==v1.1.0
-    - chandra_aca ==4.24
+    - chandra_aca ==4.25.1
     - chandra.cmd_states ==3.14.2
     - chandra.maneuver ==3.7.1
     - chandra.time ==3.20.3

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - maude ==3.2
     - mica ==3.15
     - parse_cm ==3.4
-    - proseco ==4.3.2
+    - proseco ==4.3.3
     - psmc_check ==v1.2.0
     - pyyaks ==3.3.5
     - quaternion ==3.4.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -11,7 +11,6 @@ requirements:
   run:
     - ska3-core ==2018.08.27
     - ska3-template ==2018.08.12
-    - aca_preview ==4.0
     - agasc ==4.7
     - annie ==0.5
     - acisfp_check ==v2.4.0
@@ -50,6 +49,7 @@ requirements:
     - ska.shell ==3.3.3
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
+    - sparkles ==4.1
     - tables3_api ==0.1
     - testr ==3.2
     - xija ==4.13

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -9,7 +9,7 @@ requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
-    - ska3-core ==2018.08.27
+    - ska3-core ==2019.02.20
     - ska3-template ==2018.08.12
     - agasc ==4.7
     - annie ==0.5

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - parse_cm ==3.4
     - proseco ==4.3.2
     - psmc_check ==v1.2.0
-    - pyyaks ==3.3.4
+    - pyyaks ==3.3.5
     - quaternion ==3.4.1
     - ska.arc5gl ==3.1.1
     - ska.astro ==3.2.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - ska.shell ==3.3.3
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
-    - sparkles ==4.1.1
+    - sparkles ==4.1.2
     - tables3_api ==0.1
     - testr ==3.2
     - xija ==4.13

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-matlab
-  version: 2019.02.19
+  version: 2019.02.26
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-matlab
-  version: 2019.03.01
+  version: 2019.03.05
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-matlab
-  version: 2019.01.29
+  version: 2019.02.19
 
 build:
   noarch: generic


### PR DESCRIPTION
Updates for Feb 2019 Matlab release.  Updates include

1. proseco 4.4.1
2. aca_preview 4.0 -> sparkles 4.1.2
3. chandra_aca 4.25.2
4. mica 3.16
5. pyyaks 3.3.5 (included in previous update list for the unreleased MATLAB tools)
6. kadi 3.16.4