### PR TITLE
Fix preprocessing selector logic bugs in ska3-core

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core
-  version: 2018.08.27
+  version: 2019.02.20
 
 requirements:
   # Packages required to run the package. These are the dependencies that
@@ -55,7 +55,7 @@ requirements:
    - fontconfig ==2.12.1 # [linux64]
    - freetype ==2.5.5
    - git ==2.9.3 # [linux32]
-   - git ==2.11.1 # [linux64 and osx]
+   - git ==2.11.1 # [linux64 or osx]
    - gitdb2 ==2.0.0
    - gitpython ==2.1.3
    - glib ==2.50.2 # [linux]
@@ -66,7 +66,7 @@ requirements:
    - html5lib ==0.999
    - icu ==54.1
    - idna ==2.5 # [linux32]
-   - idna ==2.6 # [linux64 and osx]
+   - idna ==2.6 # [linux64 or osx]
    - imagesize ==0.7.1
    - ipykernel ==4.6.1
    - ipyparallel ==6.0.2
@@ -137,7 +137,7 @@ requirements:
    - pycodestyle ==2.3.1
    - pycosat ==0.6.2 # [linux32]
    - pycparser ==2.17 # [linux32]
-   - pycparser ==2.18 # [linux64 and osx]
+   - pycparser ==2.18 # [linux64 or osx]
    - pycrypto ==2.6.1
    - pyflakes ==1.6.0
    - pygments ==2.2.0
@@ -164,7 +164,7 @@ requirements:
    - scikit-learn ==0.19.0
    - scipy ==0.19.1
    - setuptools ==27.2.0 # [linux32]
-   - setuptools ==36.4.0 # [linux64 and osx]
+   - setuptools ==36.4.0 # [linux64 or osx]
    - simplegeneric ==0.8.1
    - singledispatch ==3.4.0.3
    - sip ==4.18
@@ -175,7 +175,7 @@ requirements:
    - sphinxcontrib ==1.0
    - sphinxcontrib-websupport ==1.0.1
    - spyder ==3.2.2 # [linux32]
-   - spyder ==3.2.3 # [linux64 and osx]
+   - spyder ==3.2.3 # [linux64 or osx]
    - sqlite ==3.13.0
    - terminado ==0.6
    - testpath ==0.3.1
@@ -186,9 +186,9 @@ requirements:
    - wheel ==0.29.0
    - wrapt ==1.10.11
    - xz ==5.2.2 # [linux32]
-   - xz ==5.2.3 # [linux64 and osx]
+   - xz ==5.2.3 # [linux64 or osx]
    - yaml ==0.1.6
    - zeromq ==4.1.3 # [osx]
    - zeromq ==4.1.5 # [linux]
    - zlib ==1.2.8 # [linux32]
-   - zlib ==1.2.11 # [linux64 and osx]
+   - zlib ==1.2.11 # [linux64 or osx]


### PR DESCRIPTION
Fix preprocessing selector logic bugs

All of the "and" statements were wrong as when building a platform cannot both be linux64 and osx.  I think this was just not noticed as most of these explicit package includes get pulled in by other packages.  The incorrect boolean logic resulted in the lines just being silently dropped when the linux64 and osx metapackages were built.

Closes #111 