### PR TITLE
Add astropy-healpix recipe

### DIFF
--- a/pkg_defs/astropy-healpix/meta.yaml
+++ b/pkg_defs/astropy-healpix/meta.yaml
@@ -1,0 +1,54 @@
+# Recipe largely borrowed from https://github.com/conda-forge/astropy-healpix-feedstock
+# but the build and run requirements have been set manually to ska3 requirements
+
+{% set name = "astropy-healpix" %}
+{% set version = "0.4" %}
+{% set sha256 = "8c9709ac923759c92eca6d2e623e734d0f417eed40ba835b77d99dec09e51aa2" %}
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 1001
+  script: python setup.py install --single-version-externally-managed --record record.txt --offline --no-git
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy ==1.12.1
+    - llvmlite ==0.18.0
+    - gcc ==4.8.5 # [linux64]
+    - libgcc ==4.8.5 # [linux64]
+    - astropy
+  run:
+    - python
+    - llvmlite ==0.18.0
+    - numpy ==1.12.1
+    - astropy >=2.0
+    - libgcc ==4.8.5
+    - astropy >=2.0
+
+test:
+  imports:
+    - astropy_healpix
+
+about:
+  home: http://github.com/astropy/astropy-healpix
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: BSD-licensed HEALPix for Astropy
+  description: BSD-licensed HEALPix for Astropy
+  doc_url: https://astropy-healpix.readthedocs.io
+  dev_url: https://github.com/astropy/astropy-healpix
+
+extra:
+  recipe-maintainers:
+    - astrofrog-conda-forge
+    - cdeil

--- a/pkg_defs/astropy-healpix/meta.yaml
+++ b/pkg_defs/astropy-healpix/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - setuptools
     - numpy ==1.12.1
     # Pin llvmlite at 0.18.0 version for old gcc and centos5 compatibility
+    # This is in ska3-pinned but doesn't seem respected in build context.
     - llvmlite ==0.18.0
     - gcc ==4.8.5 # [linux64]
     - libgcc ==4.8.5 # [linux64]

--- a/pkg_defs/astropy-healpix/meta.yaml
+++ b/pkg_defs/astropy-healpix/meta.yaml
@@ -22,12 +22,14 @@ requirements:
     - python
     - setuptools
     - numpy ==1.12.1
+    # Pin llvmlite at 0.18.0 version for old gcc and centos5 compatibility
     - llvmlite ==0.18.0
     - gcc ==4.8.5 # [linux64]
     - libgcc ==4.8.5 # [linux64]
     - astropy >=2.0
   run:
     - python
+    # Pin llvmlite at 0.18.0 version for old gcc and centos5 compatibility
     - llvmlite ==0.18.0
     - numpy ==1.12.1
     - libgcc ==4.8.5

--- a/pkg_defs/astropy-healpix/meta.yaml
+++ b/pkg_defs/astropy-healpix/meta.yaml
@@ -25,12 +25,11 @@ requirements:
     - llvmlite ==0.18.0
     - gcc ==4.8.5 # [linux64]
     - libgcc ==4.8.5 # [linux64]
-    - astropy
+    - astropy >=2.0
   run:
     - python
     - llvmlite ==0.18.0
     - numpy ==1.12.1
-    - astropy >=2.0
     - libgcc ==4.8.5
     - astropy >=2.0
 

--- a/pkg_defs/astropy-healpix/run_test.py
+++ b/pkg_defs/astropy-healpix/run_test.py
@@ -1,0 +1,4 @@
+# The test suite runs in <20 seconds so is worth running here to
+# make sure there are no issues with the C/Cython extensions
+import astropy_healpix
+astropy_healpix.test()

--- a/ska3_flight_build_order.txt
+++ b/ska3_flight_build_order.txt
@@ -4,6 +4,7 @@ pytest-openfiles
 pytest-remotedata
 pytest-astropy
 astropy
+astropy-healpix
 widgetsnbextension
 ipywidgets
 Ska.Shell


### PR DESCRIPTION
As noted in recipe comment, this recipe largely borrowed from

https://github.com/conda-forge/astropy-healpix-feedstock

but the build and run requirements have been set manually to ska3 requirements.