### PR TITLE
ska3-flight update for Matlab 2019_158

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -52,4 +52,4 @@ requirements:
     - sparkles ==4.2.1
     - tables3_api ==0.1
     - testr ==3.2
-    - xija ==4.13
+    - xija ==4.14

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -9,7 +9,7 @@ requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
-    - ska3-core ==2019.02.20
+    - ska3-core ==2019.05.23
     - ska3-template ==2018.08.12
     - agasc ==4.7
     - annie ==0.5

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - maude ==3.2
     - mica ==3.17
     - parse_cm ==3.4
-    - proseco ==4.4.1
+    - proseco ==4.5
     - psmc_check ==v1.2.0
     - pyyaks ==3.3.5
     - quaternion ==3.4.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2019.06.10
+  version: 2019.06.17
 
 build:
   noarch: generic


### PR DESCRIPTION
ska3-flight update for Matlab 2019_158

This includes xija 4.14, astropy-healpix, and proseco 4.5 .
