### PR TITLE
Update mica to 3.18

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - jplephem ==2.8
     - kadi ==3.16.4
     - maude ==3.2
-    - mica ==3.17
+    - mica ==3.18
     - parse_cm ==3.4
     - proseco ==4.5
     - psmc_check ==v1.2.0


### PR DESCRIPTION
Update mica to 3.18 to support acdc dark cals without error

Closes #144 