### PR TITLE
Add conda itself (at version 4.3.21) to ska3-core

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -42,6 +42,7 @@ requirements:
    - cffi ==1.10.0
    - chardet ==3.0.4
    - clyent ==1.2.2
+   - conda ==4.3.21
    - configobj ==5.0.6
    - cryptography ==1.8.1
    - curl ==7.54.1


### PR DESCRIPTION
Add conda itself (at version 4.3.21) to ska3-core

