### PR TITLE
Move starcheck pkg into ska3-flight

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
     - sparkles ==4.3
+    - starcheck ==13.4
     - tables3_api ==0.1
     - testr ==3.2
     - xija ==4.15

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -22,4 +22,3 @@ requirements:
     - perl-ska-web ==4.0
     - watch_cron_logs ==4.1 # [linux]
     - task_schedule ==4.1 # [linux]
-    - starcheck ==13.4 # [linux]

--- a/pkg_defs/starcheck/meta.yaml
+++ b/pkg_defs/starcheck/meta.yaml
@@ -3,6 +3,7 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
+  number: 1
   noarch: python
   script_env:
     - SKA_TOP_SRC_DIR
@@ -26,15 +27,9 @@ requirements:
   run:
     - python
     - numpy
-    - perl ==5.26.2
-    - perl-core-deps
-    - perl-ska-classic
-    - perl-ska-convert
-    - perl-chandra-time
     - chandra_aca
     - hopper
     - agasc
-    - proseco
     - ska.matplotlib
     - testr
 

--- a/ska3_flight_build_order.txt
+++ b/ska3_flight_build_order.txt
@@ -36,8 +36,8 @@ Ska.arc5gl
 Ska.astro
 mica
 cxotime
-annie
 hopper
+starcheck
 backstop_history
 acis_thermal_check
 acis_taco
@@ -47,6 +47,7 @@ dea_check
 dpa_check
 proseco
 sparkles
+annie
 ska3-template
 ska3-pinned
 ska3_builder
@@ -54,5 +55,4 @@ ska3-core
 ska3-flight
 ska3-matlab
 ska3-dev
-starcheck
 ska3-perl


### PR DESCRIPTION
Remove some starcheck dependencies from recipe

This should allow the starcheck conda package to build successfully and without the Perl dependencies.  Installing that package should make starcheck.parser available for proseco and annie without requiring a working starcheck/Perl environment.

Closes https://github.com/sot/mica/issues/204