### PR TITLE
Remove nbpresent from ska3-core

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -108,7 +108,6 @@ requirements:
    - nb_conda_kernels ==2.1.0
    - nbconvert ==5.2.1
    - nbformat ==4.4.0
-   - nbpresent ==3.0.2
    - networkx ==1.11
    - nose ==1.3.7
    - notebook ==5.0.0


### PR DESCRIPTION
This package is mostly just annoying as it makes it easy to lose the jupyter top menu bar in favor of the bottom nbpresent bar that we never use.

Closes #90