### PR TITLE
Remove annie from ska3-matlab

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -12,7 +12,6 @@ requirements:
     - ska3-core ==2019.05.23
     - ska3-template ==2018.08.12
     - agasc ==4.7
-    - annie ==0.5
     - acisfp_check ==v2.4.0
     - acis_taco ==4.0.1
     - acis_thermal_check ==v2.8.0


### PR DESCRIPTION
Annie is not used in MATLAB tools.

Closes #137 