### PR TITLE
Update recipes to allow some ska packages to use more modern numpy

### DIFF
--- a/pkg_defs/mica/meta.yaml
+++ b/pkg_defs/mica/meta.yaml
@@ -3,7 +3,6 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
-  number: 1
   noarch: generic
   script_env:
     - SKA_TOP_SRC_DIR

--- a/pkg_defs/mica/meta.yaml
+++ b/pkg_defs/mica/meta.yaml
@@ -3,6 +3,7 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
+  number: 1
   noarch: generic
   script_env:
     - SKA_TOP_SRC_DIR
@@ -27,7 +28,7 @@ requirements:
     - python
     - six
     - matplotlib
-    - numpy ==1.12.1
+    - numpy >=1.12.1
     - pytest
     - jinja2
     - astropy

--- a/pkg_defs/sparkles/meta.yaml
+++ b/pkg_defs/sparkles/meta.yaml
@@ -3,6 +3,7 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
+  number: 1
   noarch: python
   script_env:
     - SKA_TOP_SRC_DIR
@@ -23,19 +24,17 @@ requirements:
     - chandra_aca
     - proseco
     - testr
-    - llvmlite ==0.18.0
-    - numpy ==1.12.1
+    - numpy >=1.12.1
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
     - python
-    - numpy ==1.12.1
+    - numpy >=1.12.1
     - matplotlib
     - astropy
     - pytest
     - chandra_aca
     - proseco
-    - llvmlite ==0.18.0
     - quaternion
     - testr
 

--- a/pkg_defs/sparkles/meta.yaml
+++ b/pkg_defs/sparkles/meta.yaml
@@ -3,7 +3,6 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
-  number: 1
   noarch: python
   script_env:
     - SKA_TOP_SRC_DIR

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -3,6 +3,7 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
+  number: 1
   script_env:
     - SKA_TOP_SRC_DIR
 
@@ -20,9 +21,8 @@ requirements:
     - python
     - setuptools
     - six
-    - llvmlite ==0.18.0
     - numba
-    - numpy ==1.12.1
+    - numpy >=1.12.1
     - scipy
     - pyyaks
   # Packages required to run the package. These are the dependencies that
@@ -31,9 +31,8 @@ requirements:
     - python
     - six
     - scipy
-    - llvmlite ==0.18.0
     - numba
-    - numpy ==1.12.1
+    - numpy >=1.12.1
     - matplotlib
     - ska.matplotlib
     - ska.numpy

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -3,7 +3,6 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
-  number: 1
   script_env:
     - SKA_TOP_SRC_DIR
 


### PR DESCRIPTION
Update recipes to allow some ska packages to use more modern numpy

It would be great if we can make these recipes successfully build on CentOS5 but make packages that have requirements such that they can work on CentOS7 and OSX in a ska3-dev environment with more modern numpy (for testing and dev work).

There are still other packages that have numpy 1.12 hardcoded requirements (astropy, jplephem) but my hope would be that we could use those packages from a more modern repo from continuum in the more modern environment, instead of needing to build them in skare3.