### PR TITLE
Updates for ska3-flight for week of 2019.08.19

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - chandra.maneuver ==3.7.1
     - chandra.time ==3.20.3
     - cxotime ==3.1
-    - dea_check ==v2.2.0
+    - dea_check ==v2.3.0
     - dpa_check ==v2.4.0
     - hopper ==4.4
     - jplephem ==2.8

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -53,4 +53,4 @@ requirements:
     - sparkles ==4.2.1
     - tables3_api ==0.1
     - testr ==3.2
-    - xija ==4.14
+    - xija ==4.15

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2019.08.12
+  version: 2019.08.19
 
 build:
   noarch: generic


### PR DESCRIPTION
Updates for ska3-flight for week of 2019.08.19

Includes xija 4.15 and dea_check v2.3.0 .

Closes #190 

