### PR TITLE
Revert "Weekly release 2019.09.17"

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2019.09.17
+  version: 2019.09.09
 
 build:
   noarch: generic
@@ -27,7 +27,7 @@ requirements:
     - dpa_check ==v2.4.0
     - hopper ==4.4
     - jplephem ==2.8
-    - kadi ==4.18
+    - kadi ==4.17
     - maude ==3.2
     - mica ==4.18
     - parse_cm ==3.5


### PR DESCRIPTION
I recommend not installing kadi 4.18 into flight (the only change for Weekly release 2019.09.17) at this time and waiting to cut a kadi release with real code changes of some kind.  As such, this PR reverts the ska3-flight update for kadi 4.18.

Reverts sot/skare3#203