### PR TITLE
fixed acisfp_check build.sh.

### DIFF
--- a/pkg_defs/acisfp_check/build.sh
+++ b/pkg_defs/acisfp_check/build.sh
@@ -1,1 +1,2 @@
+export SKA=/proj/sot/ska
 pip install --no-deps --verbose --no-binary :all: --no-index .


### PR DESCRIPTION
Defined SKA=/proj/sot/ska and this worked in the build environment. Otherwise, the error was "no local Ska data found and remote access is not selected"