### PR TITLE
Update ska3-matlab in bulk for 2019_210

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - maude ==3.2
     - mica ==4.19
     - parse_cm ==3.5
-    - proseco ==4.7
+    - proseco ==4.7.1
     - psmc_check ==v1.2.0
     - pyyaks ==4.4
     - quaternion ==3.4.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - acisfp_check ==v2.7.0
     - acis_taco ==4.0.1
     - acis_thermal_check ==v2.9.0
+    - annie ==0.9
     - backstop_history ==v1.1.0
     - chandra_aca ==4.27
     - chandra.cmd_states ==3.15

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - acisfp_check ==v2.7.0
     - acis_taco ==4.0.1
     - acis_thermal_check ==v2.9.0
-    - annie ==0.8.1
+    - annie ==0.8.2
     - backstop_history ==v1.1.0
     - chandra_aca ==4.27
     - chandra.cmd_states ==3.15

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - acisfp_check ==v2.7.0
     - acis_taco ==4.0.1
     - acis_thermal_check ==v2.9.0
-    - annie ==0.9
+    - annie ==0.8
     - backstop_history ==v1.1.0
     - chandra_aca ==4.27
     - chandra.cmd_states ==3.15

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -54,5 +54,5 @@ requirements:
     - sparkles ==4.3
     - starcheck ==13.5
     - tables3_api ==0.1
-    - testr ==3.2
+    - testr ==4.3
     - xija ==4.15

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - cxotime ==3.1
     - dea_check ==v2.3.0
     - dpa_check ==v2.4.0
+    - find_attitude ==3.2
     - hopper ==4.4
     - jplephem ==2.8
     - kadi ==4.18.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - acisfp_check ==v2.7.0
     - acis_taco ==4.0.1
     - acis_thermal_check ==v2.9.0
-    - annie ==0.8
+    - annie ==0.8.1
     - backstop_history ==v1.1.0
     - chandra_aca ==4.27
     - chandra.cmd_states ==3.15

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-matlab
-  version: 2019.11.19
+  version: 2019.11.20
 
 build:
   noarch: generic
@@ -25,7 +25,6 @@ requirements:
     - cxotime ==3.1
     - dea_check ==v2.3.0
     - dpa_check ==v2.4.0
-    - find_attitude ==3.2
     - hopper ==4.4
     - jplephem ==2.8
     - kadi ==4.18.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-matlab
-  version: 2019.10.02
+  version: 2019.11.19
 
 build:
   noarch: generic
@@ -9,46 +9,48 @@ requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
-    - ska3-core ==2019.05.23
-    - ska3-template ==2018.08.12
+    - ska3-core ==2019.07.22
+    - ska3-template ==2019.09.03
+    - acdc ==4.3.1
     - agasc ==4.7
-    - acisfp_check ==v2.4.0
+    - acisfp_check ==v2.7.0
     - acis_taco ==4.0.1
-    - acis_thermal_check ==v2.8.0
+    - acis_thermal_check ==v2.9.0
     - backstop_history ==v1.1.0
-    - chandra_aca ==4.25.2
-    - chandra.cmd_states ==3.14.2
+    - chandra_aca ==4.27
+    - chandra.cmd_states ==3.15
     - chandra.maneuver ==3.7.1
     - chandra.time ==3.20.3
     - cxotime ==3.1
-    - dea_check ==v2.2.0
-    - dpa_check ==v2.3.0
+    - dea_check ==v2.3.0
+    - dpa_check ==v2.4.0
     - hopper ==4.4
     - jplephem ==2.8
-    - kadi ==3.16.4
+    - kadi ==4.18.1
     - maude ==3.2
-    - mica ==3.16
-    - parse_cm ==3.4
-    - proseco ==4.6
+    - mica ==4.19
+    - parse_cm ==3.5
+    - proseco ==4.7
     - psmc_check ==v1.2.0
-    - pyyaks ==3.3.5
+    - pyyaks ==4.4
     - quaternion ==3.4.1
     - ska.arc5gl ==3.1.1
     - ska.astro ==3.2.1
-    - ska.dbi ==3.8.2
-    - ska.engarchive ==4.45.1
+    - ska.dbi ==4.0
+    - ska.engarchive ==4.47.2
     - ska.file ==3.4.1
-    - ska.ftp ==3.5
+    - ska.ftp ==3.5.1
     - ska.numpy ==3.8.1
     - ska.matplotlib ==3.11.2
     - ska.parsecm ==3.3.1
     - ska_path ==3.1
-    - ska_sync ==4.2
+    - ska_sync ==4.5
     - ska.quatutil ==3.3.1
     - ska.shell ==3.3.3
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
     - sparkles ==4.3
+    - starcheck ==13.5
     - tables3_api ==0.1
     - testr ==3.2
     - xija ==4.15

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - ska.arc5gl ==3.1.1
     - ska.astro ==3.2.1
     - ska.dbi ==4.0
-    - ska.engarchive ==4.47.2
+    - ska.engarchive ==4.47.3
     - ska.file ==3.4.1
     - ska.ftp ==3.5.1
     - ska.numpy ==3.8.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - ska_path ==3.1
     - ska_sync ==4.5
     - ska.quatutil ==3.3.1
-    - ska.shell ==3.3.3
+    - ska.shell ==3.3.4
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
     - sparkles ==4.3


### PR DESCRIPTION
Includes these pkg updates
- acisfp_check v2.7.0
- acis_thermal_check v2.9.0
- chandra_aca 4.27
- chandra.cmd_states 3.15
- dea_check v2.3.0
- dpa_check v2.4.0
- kadi 4.18.1
- mica 4.19
- parse_cm 3.5
- proseco 4.7.1
- pyyaks 4.4
- ska.dbi 4.0
- ska.engarchive 4.47.3
- ska.ftp 3.5.1
- ska.shell 3.3.4
- ska_sync 4.5
- testr 4.3

adds pkgs
- setuptools_scm (added in ska3-core update which is not visible in the diff)
- acdc 4.3.1
- starcheck 13.5
- annie 0.8.2

