### PR TITLE
WIP windows conda build for ska3-win

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.egg-info
 __pycache__
+builds
+.vscode

--- a/pkg_defs/Chandra.Time/build.sh
+++ b/pkg_defs/Chandra.Time/build.sh
@@ -1,1 +1,0 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .

--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -6,6 +6,7 @@ build:
   script_env:
     - SKA_TOP_SRC_DIR
   preserve_egg_dir: yes # (default no)
+  script: python setup.py install
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/Chandra.Time

--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -2,16 +2,13 @@ package:
   name: chandra.time
   version:  {{ GIT_DESCRIBE_TAG }}
 
-#build:
-# script_env:
-#   - SKA_TOP_SRC_DIR
-# preserve_egg_dir: yes # (default no)
+build:
+  script_env:
+    - SKA_TOP_SRC_DIR
+  preserve_egg_dir: yes # (default no)
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/Chandra.Time
-  #git_rev: "3.20.3"
-  #git_url: https://github.com/sot/chandra.time
-
 
 # the build and runtime requirements. Dependencies of these requirements
 # are included automatically.

--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -2,13 +2,15 @@ package:
   name: chandra.time
   version:  {{ GIT_DESCRIBE_TAG }}
 
-build:
-  script_env:
-    - SKA_TOP_SRC_DIR
-  preserve_egg_dir: yes # (default no)
+#build:
+# script_env:
+#   - SKA_TOP_SRC_DIR
+# preserve_egg_dir: yes # (default no)
 
 source:
-  path: {{ SKA_TOP_SRC_DIR }}/Chandra.Time
+  #path: {{ SKA_TOP_SRC_DIR }}/Chandra.Time
+  git_rev: "3.20.3"
+  git_url: https://github.com/sot/chandra.time
 
 
 # the build and runtime requirements. Dependencies of these requirements
@@ -18,10 +20,9 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip <10.0
     - cython >=0.20.1
     - six
-    - numpy
+    - numpy =1.12
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -8,9 +8,9 @@ package:
 # preserve_egg_dir: yes # (default no)
 
 source:
-  #path: {{ SKA_TOP_SRC_DIR }}/Chandra.Time
-  git_rev: "3.20.3"
-  git_url: https://github.com/sot/chandra.time
+  path: {{ SKA_TOP_SRC_DIR }}/Chandra.Time
+  #git_rev: "3.20.3"
+  #git_url: https://github.com/sot/chandra.time
 
 
 # the build and runtime requirements. Dependencies of these requirements

--- a/pkg_defs/Ska.Numpy/build.sh
+++ b/pkg_defs/Ska.Numpy/build.sh
@@ -1,1 +1,0 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .

--- a/pkg_defs/Ska.Numpy/meta.yaml
+++ b/pkg_defs/Ska.Numpy/meta.yaml
@@ -3,9 +3,8 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
-  script_env:
-    - SKA_TOP_SRC_DIR
   preserve_egg_dir: yes # (default no)
+  script: python setup.py install
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/Ska.Numpy
@@ -17,9 +16,7 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip <10.0
     - python
-    - setuptools
     - numpy
     - cython
     - six
@@ -27,7 +24,6 @@ requirements:
   # will be installed automatically whenever the package is installed.
   run:
     - python
-    - setuptools
     - six
     - numpy
     - nose

--- a/pkg_defs/Ska.Shell/build.sh
+++ b/pkg_defs/Ska.Shell/build.sh
@@ -1,1 +1,0 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .

--- a/pkg_defs/Ska.Shell/meta.yaml
+++ b/pkg_defs/Ska.Shell/meta.yaml
@@ -6,8 +6,7 @@ package:
 build:
   noarch: python
   preserve_egg_dir: yes
-  script_env:
-    - SKA_TOP_SRC_DIR
+  script: python setup.py install
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/Ska.Shell
@@ -15,7 +14,6 @@ source:
 requirements:
   build:
     - python
-    - pip <10.0
     - six
 
   run:

--- a/pkg_defs/Ska.engarchive/meta.yaml
+++ b/pkg_defs/Ska.engarchive/meta.yaml
@@ -3,14 +3,12 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
-  noarch: generic
-  script_env:
-    - SKA_TOP_SRC_DIR
+  noarch: python
   preserve_egg_dir: yes # (default no)
+  script: python setup.py install
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/Ska.engarchive
-
 
 # the build and runtime requirements. Dependencies of these requirements
 # are included automatically.
@@ -18,11 +16,10 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip <10.0
     - python
-    - setuptools
     - six
     - numpy
+
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
@@ -44,7 +41,6 @@ requirements:
 test:
   imports:
     - Ska.engarchive
-
 
 about:
   home: https://github.com/sot/eng_archive

--- a/pkg_defs/acdc/meta.yaml
+++ b/pkg_defs/acdc/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
-  noarch: generic
+  noarch: python
   script_env:
     - SKA_TOP_SRC_DIR
 

--- a/pkg_defs/mica/meta.yaml
+++ b/pkg_defs/mica/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
-  noarch: generic
+  noarch: python
   script_env:
     - SKA_TOP_SRC_DIR
 

--- a/pkg_defs/ska3-win/meta.yaml
+++ b/pkg_defs/ska3-win/meta.yaml
@@ -1,0 +1,52 @@
+package:
+  name: ska3-win
+  version: 0.8
+
+build:
+  noarch: generic
+
+requirements:
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+  # Ska packages
+   - agasc
+   - annie
+   - acisfp_check
+   - acis_taco
+   - acis_thermal_check
+   - backstop_history
+   - chandra.cmd_states
+   - chandra.maneuver
+   - chandra.time
+   - chandra_aca
+   - cxotime
+   - dea_check
+   - dpa_check
+   - hopper
+   - kadi
+   - maude
+   - mica
+   - parse_cm
+   - psmc_check
+   - quaternion
+   - ska.arc5gl
+   - ska.astro
+   - ska.dbi
+   - ska.engarchive
+   - ska.file
+   - ska.ftp
+   - ska.matplotlib
+   - ska.numpy
+   - ska.parsecm
+   - ska.quatutil
+   - ska.shell
+   - ska.sun
+   - ska.tdb
+   - ska3-template
+   - ska_path
+   - ska_sync
+   - pyyaks
+   - tables3_api
+   - testr
+   - xija

--- a/pkg_defs/ska3-win/meta.yaml
+++ b/pkg_defs/ska3-win/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-win
-  version: 0.8
+  version: 0.9
 
 build:
   noarch: generic
@@ -50,3 +50,71 @@ requirements:
    - tables3_api
    - testr
    - xija
+
+   # Adapted from the list from M. Baski pkgs3.conda
+   # (see email Windows Python install script Nov 14 2019)
+   - astropy
+   - beautifulsoup4
+   - configobj
+   - cryptography
+   - cython
+   - decorator
+   - docutils
+   - ipyparallel
+   - notebook
+   - jinja2
+   - jpeg
+   - jupyter
+   - libtiff
+   - lxml
+   - matplotlib
+   - networkx
+   - nose
+   - numba
+   - numpy =1.12.1
+   - openssl
+   - pandas
+   - paramiko
+   - pep8
+   - pillow
+   - ply
+   - psutil
+   - pycrypto
+   - pyflakes
+   - pygments
+   - pyparsing
+   - pyqt
+   - pytest
+   - python =3.6.2
+   - python-dateutil
+   - pytz
+   - pyyaml
+   - pyzmq
+   - qt
+   - requests
+   - runipy
+   - scipy
+   - six
+   - sphinx
+   - sqlalchemy
+   - sqlite
+   - yaml
+   - zlib
+   - setuptools
+   - conda
+   - conda-env
+   - pip
+   - libpng
+   - cffi
+   - mistune
+   - py
+   - pycparser
+   - tornado
+   - markupsafe
+   - h5py
+   - numexpr
+   - pytables
+   - git
+   - ipython=6.1.0
+   - pylint
+   - conda-build

--- a/pkg_defs/xija/build.sh
+++ b/pkg_defs/xija/build.sh
@@ -1,1 +1,0 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -3,8 +3,7 @@ package:
   version:  {{ GIT_DESCRIBE_TAG }}
 
 build:
-  script_env:
-    - SKA_TOP_SRC_DIR
+  script: python setup.py install
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/xija
@@ -16,12 +15,10 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
-    - setuptools
     - six
     - numba
-    - numpy >=1.12.1
+    - numpy =1.12
     - scipy
     - pyyaks
   # Packages required to run the package. These are the dependencies that
@@ -31,13 +28,14 @@ requirements:
     - six
     - scipy
     - numba
-    - numpy >=1.12.1
+    - numpy =1.12
     - matplotlib
     - ska.matplotlib
     - ska.numpy
     - pyyaks
     - chandra.time
     - testr
+    - ska.engarchive
 
 test:
   imports:

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -122,6 +122,7 @@ def build_package(name):
     if not args.force:
         cmd_list.append("--skip-existing")
 
+    print('Running:\n' + ' '.join(cmd_list) + '\n')
     subprocess.run(cmd_list, check=True, shell=True)
 
 

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -106,7 +106,7 @@ def build_package(name):
     cmd_list = ["conda", "build", pkg_path, 
                 "--croot", BUILD_DIR, 
                 # "--no-test", 
-                # "--old-build-string",
+                "--old-build-string",
                 "--python", "3.6",
                 "--no-anaconda-upload", 
                 # "--skip-existing", 

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -103,13 +103,13 @@ def get_repo(name, tag):
 def build_package(name):
     print("Building package %s." % name)
     pkg_path = os.path.join(pkg_defs_path, name)
-    cmd_list = ["conda", "build", pkg_path, 
-                "--croot", BUILD_DIR, 
-                "--no-test", 
+    cmd_list = ["conda", "build", pkg_path,
+                "--croot", BUILD_DIR,
+                "--no-test",
                 "--old-build-string",
                 "--python", "3.6",
-                "--no-anaconda-upload", 
-                "--skip-existing", 
+                "--no-anaconda-upload",
+                "--skip-existing",
                 "--perl", PERL
                 ]
     subprocess.run(cmd_list, check=True, shell=True)

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -105,7 +105,7 @@ def build_package(name):
     pkg_path = os.path.join(pkg_defs_path, name)
     cmd_list = ["conda", "build", pkg_path,
                 "--croot", BUILD_DIR,
-                "--no-test",
+                # "--no-test",
                 "--old-build-string",
                 "--python", "3.6",
                 "--no-anaconda-upload",

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -20,6 +20,12 @@ parser.add_argument("--build-root", default=".", type=str,
                          "Default: '.'")
 parser.add_argument("--build-list", default="./ska3_flight_build_order.txt",
                     help="List of packages to build (in order)")
+parser.add_argument("--test",
+                    action="store_true",
+                    help="Run test during build process")
+parser.add_argument("--force",
+                    action="store_true",
+                    help="Force build of package even if it exists")
 
 
 args = parser.parse_args()
@@ -105,14 +111,17 @@ def build_package(name):
     pkg_path = os.path.join(pkg_defs_path, name)
     cmd_list = ["conda", "build", pkg_path,
                 "--croot", BUILD_DIR,
-                # "--no-test",
                 "--old-build-string",
                 "--python", "3.6",
                 "--no-anaconda-upload",
-                # "--skip-existing",
                 "--numpy", NUMPY,
                 "--perl", PERL
                 ]
+    if not args.test:
+        cmd_list.append("--no-test")
+    if not args.force:
+        cmd_list.append("--skip-existing")
+
     subprocess.run(cmd_list, check=True, shell=True)
 
 

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -109,7 +109,7 @@ def build_package(name):
                 "--old-build-string",
                 "--python", "3.6",
                 "--no-anaconda-upload",
-                "--skip-existing",
+                # "--skip-existing",
                 "--perl", PERL
                 ]
     subprocess.run(cmd_list, check=True, shell=True)

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -33,7 +33,7 @@ BUILD_LIST = [b for b in BUILD_LIST if not re.match(r"^\s*#", b)]
 # And any that are just whitespace
 BUILD_LIST = [b for b in BUILD_LIST if not re.match(r"^\s*$", b)]
 
-if platform.uname().sysname == "Darwin":
+if platform.uname().system == "Darwin":
     os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
 
 if platform.uname().machine == 'i686':

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -110,7 +110,7 @@ def build_package(name):
                 "--python", "3.6",
                 "--no-anaconda-upload", 
                 # "--skip-existing", 
-                # "--perl", PERL
+                "--perl", PERL
                 ]
     subprocess.run(cmd_list, check=True, shell=True)
 

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -110,6 +110,7 @@ def build_package(name):
                 "--python", "3.6",
                 "--no-anaconda-upload",
                 # "--skip-existing",
+                "--numpy", NUMPY,
                 "--perl", PERL
                 ]
     subprocess.run(cmd_list, check=True, shell=True)

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -105,11 +105,11 @@ def build_package(name):
     pkg_path = os.path.join(pkg_defs_path, name)
     cmd_list = ["conda", "build", pkg_path, 
                 "--croot", BUILD_DIR, 
-                # "--no-test", 
+                "--no-test", 
                 "--old-build-string",
                 "--python", "3.6",
                 "--no-anaconda-upload", 
-                # "--skip-existing", 
+                "--skip-existing", 
                 "--perl", PERL
                 ]
     subprocess.run(cmd_list, check=True, shell=True)

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -103,10 +103,15 @@ def get_repo(name, tag):
 def build_package(name):
     print("Building package %s." % name)
     pkg_path = os.path.join(pkg_defs_path, name)
-    cmd_list = ["conda", "build", pkg_path, "--croot",
-                BUILD_DIR, "--no-test", "--old-build-string",
+    cmd_list = ["conda", "build", pkg_path, 
+                "--croot", BUILD_DIR, 
+                # "--no-test", 
+                # "--old-build-string",
                 "--python", "3.6",
-                "--no-anaconda-upload", "--skip-existing", "--perl", PERL]
+                "--no-anaconda-upload", 
+                # "--skip-existing", 
+                # "--perl", PERL
+                ]
     subprocess.run(cmd_list, check=True, shell=True)
 
 


### PR DESCRIPTION
This is a proof-of-concept for making Windows builds which seems to be working.  I had quite a journey getting this working so ended up doing micro-commits to allow backtracking to a configuration that works.

It seems that using `python setup.py install` in this context is fine since conda is doing the file management and so `pip` is a bit of overkill.  But perhaps more importantly, modern `pip` has dropped support for eggs and this is needed for namespace packages.  So going to `python setup.py install` should allow upgrading `pip` to the latest.

It also seems like we can just use the `build : script` directive in `meta.yaml`, but maybe there is a reason not to that @jeanconn has discovered.

Next steps would be doing the rest of the arch-specific packages and then dealing with the core packages.  I'm guessing that our totally-pinned ska3-core package won't resolve on Windows, but not sure.

There is something a bit unsettling in the build log.  I did some googling and got to some relevant pages, but couldn't quite make sense of them.
```
Packaging chandra.time
INFO:conda_build.build:Packaging chandra.time
INFO conda_build.build:build(1570): Packaging chandra.time
Packaging chandra.time-3.20.3-py36_0
INFO:conda_build.build:Packaging chandra.time-3.20.3-py36_0
INFO conda_build.build:bundle_conda(891): Packaging chandra.time-3.20.3-py36_0
compiling .pyc files...
number of files: 22
   INFO (chandra.time,Lib\site-packages\Chandra.Time-3.20.3-py3.6-win-amd64.egg\Chandra\Time\_axTime3.cp36-win_amd64.pyd): Needed DSO python36.dll found in defaults::python-3.6.9-h5500b2f_0
WARNING (chandra.time,Lib\site-packages\Chandra.Time-3.20.3-py3.6-win-amd64.egg\Chandra\Time\_axTime3.cp36-win_amd64.pyd): Needed DSO api-ms-win-crt-string-l1-1-0.dll found in ['vs2015_runtime']
WARNING (chandra.time,Lib\site-packages\Chandra.Time-3.20.3-py3.6-win-amd64.egg\Chandra\Time\_axTime3.cp36-win_amd64.pyd): .. but ['vs2015_runtime'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
WARNING (chandra.time,Lib\site-packages\Chandra.Time-3.20.3-py3.6-win-amd64.egg\Chandra\Time\_axTime3.cp36-win_amd64.pyd): Needed DSO api-ms-win-crt-runtime-l1-1-0.dll found in ['vs2015_runtime']
WARNING (chandra.time,Lib\site-packages\Chandra.Time-3.20.3-py3.6-win-amd64.egg\Chandra\Time\_axTime3.cp36-win_amd64.pyd): .. but ['vs2015_runtime'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)

... AND a bunch more like that
```
cc: @mbaski @jskrist 