### PR TITLE
Release 2020.1

### DIFF
--- a/pkg_defs/Chandra.Maneuver/meta.yaml
+++ b/pkg_defs/Chandra.Maneuver/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   build:
     - pip <10.0
     - python
+    - quaternion
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Chandra.Maneuver/meta.yaml
+++ b/pkg_defs/Chandra.Maneuver/meta.yaml
@@ -20,12 +20,6 @@ requirements:
   build:
     - pip <10.0
     - python
-    - setuptools
-    - numpy
-    - six
-    - chandra.time
-    - quaternion
-    - ska.sun
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
@@ -34,7 +28,7 @@ requirements:
     - quaternion
     - chandra.time
     - ska.sun
-
+    - ska_helpers
 test:
   requires:
     - agasc

--- a/pkg_defs/Ska.Shell/meta.yaml
+++ b/pkg_defs/Ska.Shell/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - six
     - pexpect
     - testr
+    - ska_helpers
 
 test:
   imports:

--- a/pkg_defs/acis_thermal_check/build.sh
+++ b/pkg_defs/acis_thermal_check/build.sh
@@ -1,1 +1,2 @@
+export SKA=/proj/sot/ska
 pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/acis_thermal_check/meta.yaml
+++ b/pkg_defs/acis_thermal_check/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: acis_thermal_check
-  version:  {{ GIT_DESCRIBE_TAG }}
+  version:  {{ SKA_PKG_VERSION }}
 
 build:
   noarch: python

--- a/pkg_defs/acisfp_check/meta.yaml
+++ b/pkg_defs/acisfp_check/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: acisfp_check
-  version:  {{ GIT_DESCRIBE_TAG }}
+  version:  {{ SKA_PKG_VERSION }}
 
 build:
   noarch: python

--- a/pkg_defs/agasc/meta.yaml
+++ b/pkg_defs/agasc/meta.yaml
@@ -18,15 +18,7 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - setuptools
     - pip
-    - six
-    - numpy
-    - numexpr
-    - pytables
-    - ska_path
-    - chandra.time
-    - astropy
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
@@ -41,6 +33,7 @@ requirements:
     - astropy
     - h5py
     - testr
+    - ska_helpers
 
 test:
   imports:

--- a/pkg_defs/backstop_history/meta.yaml
+++ b/pkg_defs/backstop_history/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: backstop_history
-  version:  {{ GIT_DESCRIBE_TAG }}
+  version:  {{ SKA_PKG_VERSION }}
 
 build:
   noarch: python

--- a/pkg_defs/backstop_history/meta.yaml
+++ b/pkg_defs/backstop_history/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - six
     - python
     - setuptools
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/dea_check/build.sh
+++ b/pkg_defs/dea_check/build.sh
@@ -1,1 +1,2 @@
+export SKA=/proj/sot/ska
 pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/dea_check/meta.yaml
+++ b/pkg_defs/dea_check/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: dea_check
-  version:  {{ GIT_DESCRIBE_TAG }}
+  version:  {{ SKA_PKG_VERSION }}
 
 build:
   noarch: python

--- a/pkg_defs/dpa_check/meta.yaml
+++ b/pkg_defs/dpa_check/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: dpa_check
-  version:  {{ GIT_DESCRIBE_TAG }}
+  version:  {{ SKA_PKG_VERSION }}
 
 build:
   noarch: python

--- a/pkg_defs/find_attitude/build.sh
+++ b/pkg_defs/find_attitude/build.sh
@@ -1,0 +1,2 @@
+export SKA=/dev/null
+pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/find_attitude/meta.yaml
+++ b/pkg_defs/find_attitude/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - astropy
     - numpy
     - networkx
-    - tables
+    - pytables
     - pyyaks
     - quaternion
     - ska.quatutil

--- a/pkg_defs/find_attitude/meta.yaml
+++ b/pkg_defs/find_attitude/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   build:
     - python
     - pip
-    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
@@ -32,6 +31,8 @@ requirements:
     - pyyaks
     - quaternion
     - ska.quatutil
+    - sherpa
+    - ska_helpers
 
 test:
   imports:

--- a/pkg_defs/find_attitude/meta.yaml
+++ b/pkg_defs/find_attitude/meta.yaml
@@ -1,0 +1,43 @@
+package:
+  name: find_attitude
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  noarch: python
+  script_env:
+    - SKA_TOP_SRC_DIR
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/find_attitude
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - python
+    - pip
+    - ska_helpers
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - testr
+    - astropy
+    - numpy
+    - networkx
+    - tables
+    - pyyaks
+    - quaternion
+    - ska.quatutil
+
+test:
+  imports:
+    - find_attitude
+
+
+about:
+  home: git@github.com:sot/find_attitude
+

--- a/pkg_defs/kadi/meta.yaml
+++ b/pkg_defs/kadi/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  noarch: python
+  noarch: generic
   script_env:
     - SKA_TOP_SRC_DIR
 

--- a/pkg_defs/kadi/meta.yaml
+++ b/pkg_defs/kadi/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - configobj
     - requests
     - tables3_api
-    - django <2.0
+    - django >= 3.0.1
     - pyyaks
     - ska.dbi
     - ska.file

--- a/pkg_defs/kadi/meta.yaml
+++ b/pkg_defs/kadi/meta.yaml
@@ -19,8 +19,6 @@ requirements:
   build:
     - pip
     - python
-    - six
-    - numpy
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
@@ -30,7 +28,7 @@ requirements:
     - configobj
     - requests
     - tables3_api
-    - django >= 3.0.1
+    - django >=3.0.1
     - pyyaks
     - ska.dbi
     - ska.file
@@ -42,7 +40,10 @@ requirements:
     - ska.engarchive
     - chandra.cmd_states
     - numpy
+    - mica
+    - find_attitude
     - testr
+    - ska_helpers
 
 test:
   imports:

--- a/pkg_defs/mica/meta.yaml
+++ b/pkg_defs/mica/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - testr
     - ska.arc5gl
     - ska.astro
+    - ska_helpers
 
 test:
   imports:

--- a/pkg_defs/psmc_check/build.sh
+++ b/pkg_defs/psmc_check/build.sh
@@ -1,1 +1,2 @@
+export SKA=/proj/sot/ska
 pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/psmc_check/meta.yaml
+++ b/pkg_defs/psmc_check/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: psmc_check
-  version:  {{ GIT_DESCRIBE_TAG }}
+  version:  {{ SKA_PKG_VERSION }}
 
 build:
   noarch: python

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core
-  version: 2020.01.09
+  version: 2020.01.10
 
 requirements:
   # Packages required to run the package. These are the dependencies that

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -9,8 +9,8 @@ requirements:
 
   # Note that sherpa is not in the defaults channel and may be missed
   # if trying to automatically update ska3-core
-   - sherpa ==4.9.1 [linux64 and osx]
-
+   - sherpa ==4.9.1 # [linux64]
+   - sherpa ==4.11.1 # [osx]
   # And note that these packages are presently built out of skare3.
   # If the versions we request become available in conda default channels,
   # it will be fine to move to those default packages and deprecate the
@@ -86,6 +86,7 @@ requirements:
    - jupyter_core ==4.3.0
    - krb5 ==1.13.2
    - lazy-object-proxy ==1.3.1
+   - libcxx ==9.0.1 # [osx]
    - libffi ==3.2.1 # [linux]
    - libgcc ==4.8.5
    - libgfortran ==3.0.0

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   # If the versions we request become available in conda default channels,
   # it will be fine to move to those default packages and deprecate the
   # skare3 builds
+   - asgiref ==3.2.3
    - astropy ==3.0.3
    - astropy-healpix ==0.4
    - ipywidgets ==7.3.0
@@ -49,7 +50,7 @@ requirements:
    - cython ==0.26
    - dbus ==1.10.20 # [linux]
    - decorator ==4.1.2
-   - django ==1.11.3
+   - django ==3.0.1
    - docutils ==0.14
    - entrypoints ==0.2.3
    - expat ==2.1.0
@@ -179,6 +180,7 @@ requirements:
    - spyder ==3.2.2 # [linux32]
    - spyder ==3.2.3 # [linux64 or osx]
    - sqlite ==3.13.0
+   - sqlparse ==0.3.0
    - terminado ==0.6
    - testpath ==0.3.1
    - tk ==8.5.18

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core
-  version: 2019.07.22
+  version: 2020.01.09
 
 requirements:
   # Packages required to run the package. These are the dependencies that

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -166,7 +166,7 @@ requirements:
    - scipy ==0.19.1
    - setuptools ==27.2.0 # [linux32]
    - setuptools ==36.4.0 # [linux64 or osx]
-   - setuptools_scm ==1.15.0
+   - setuptools_scm ==3.3.3
    - simplegeneric ==0.8.1
    - singledispatch ==3.4.0.3
    - sip ==4.18

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -177,8 +177,6 @@ requirements:
    - sphinx ==1.6.3
    - sphinxcontrib ==1.0
    - sphinxcontrib-websupport ==1.0.1
-   - spyder ==3.2.2 # [linux32]
-   - spyder ==3.2.3 # [linux64 or osx]
    - sqlite ==3.13.0
    - sqlparse ==0.3.0
    - terminado ==0.6

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -9,7 +9,7 @@ requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
-    - ska3-core ==2019.07.22
+    - ska3-core ==2020.01.09
     - ska3-template ==2019.09.03
     - acdc ==4.4
     - agasc ==4.8

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.01.17
+  version: 2020.01.21
 
 build:
   noarch: generic
@@ -13,18 +13,18 @@ requirements:
     - ska3-template ==2019.09.03
     - acdc ==4.4.1
     - agasc ==4.8.0
-    - acisfp_check ==v2.7.0
+    - acisfp_check ==2.7.1
     - acis_taco ==4.1.0
-    - acis_thermal_check ==v2.9.0
+    - acis_thermal_check ==2.9.1
     - annie ==0.9.1
-    - backstop_history ==v1.1.0
+    - backstop_history ==1.1.1
     - chandra_aca ==4.28.1
     - chandra.cmd_states ==3.15.1
     - chandra.maneuver ==3.7.2
     - chandra.time ==3.20.4
     - cxotime ==3.1.1
-    - dea_check ==v2.3.0
-    - dpa_check ==v2.5.0
+    - dea_check ==2.3.1
+    - dpa_check ==2.5.1
     - find_attitude ==3.3.2
     - hopper ==4.4.1
     - jplephem ==2.8
@@ -33,7 +33,7 @@ requirements:
     - mica ==4.20.0
     - parse_cm ==3.5.1
     - proseco ==4.7.2
-    - psmc_check ==v1.2.0
+    - psmc_check ==1.2.1
     - pyyaks ==4.4.1
     - quaternion ==3.4.1
     - ska.arc5gl ==3.1.3

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -21,10 +21,11 @@ requirements:
     - chandra_aca ==4.28
     - chandra.cmd_states ==3.15
     - chandra.maneuver ==3.7.2
-    - chandra.time ==3.20.3
+    - chandra.time ==3.20.4
     - cxotime ==3.1
     - dea_check ==v2.3.0
     - dpa_check ==v2.5.0
+    - find_attitude ==3.3.1
     - hopper ==4.4
     - jplephem ==2.8
     - kadi ==4.18.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - jplephem ==2.8
     - kadi ==4.18.1
     - maude ==3.3
-    - mica ==4.19
+    - mica ==4.20
     - parse_cm ==3.5
     - proseco ==4.7.1
     - psmc_check ==v1.2.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - ska_path ==3.1
     - ska_sync ==4.6
     - ska.quatutil ==3.3.1
-    - ska.shell ==3.3.5
+    - ska.shell ==3.4
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
     - sparkles ==4.4

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2019.12.18
+  version: 2020.01.09
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.01.10
+  version: 2020.01.13
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - find_attitude ==3.3.1
     - hopper ==4.4
     - jplephem ==2.8
-    - kadi ==4.18.1
+    - kadi ==5.0
     - maude ==3.3
     - mica ==4.20
     - parse_cm ==3.5

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -47,7 +47,7 @@ requirements:
     - ska_path ==3.1
     - ska_sync ==4.5
     - ska.quatutil ==3.3.1
-    - ska.shell ==3.3.4
+    - ska.shell ==3.3.5
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
     - sparkles ==4.3

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - ska.arc5gl ==3.1.2
     - ska.astro ==3.2.2
     - ska.dbi ==4.0.1
-    - ska.engarchive ==4.47.3
+    - ska.engarchive ==4.47.4
     - ska.file ==3.4.2
     - ska.ftp ==3.5.2
     - ska.numpy ==3.8.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - proseco ==4.7.2
     - psmc_check ==v1.2.0
     - pyyaks ==4.4.1
-    - quaternion ==3.5.0
+    - quaternion ==3.4.1
     - ska.arc5gl ==3.1.3
     - ska.astro ==3.2.3
     - ska.dbi ==4.0.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.01.14
+  version: 2020.01.15
 
 build:
   noarch: generic
@@ -11,49 +11,49 @@ requirements:
   run:
     - ska3-core ==2020.01.10
     - ska3-template ==2019.09.03
-    - acdc ==4.4
+    - acdc ==4.4.1
     - agasc ==4.8.0
     - acisfp_check ==v2.7.0
-    - acis_taco ==4.0.1
+    - acis_taco ==4.1.0
     - acis_thermal_check ==v2.9.0
-    - annie ==0.8.2
+    - annie ==0.9.1
     - backstop_history ==v1.1.0
-    - chandra_aca ==4.28
-    - chandra.cmd_states ==3.15
+    - chandra_aca ==4.28.1
+    - chandra.cmd_states ==3.15.1
     - chandra.maneuver ==3.7.2
     - chandra.time ==3.20.4
-    - cxotime ==3.1
+    - cxotime ==3.1.1
     - dea_check ==v2.3.0
     - dpa_check ==v2.5.0
     - find_attitude ==3.3.2
-    - hopper ==4.4
+    - hopper ==4.4.1
     - jplephem ==2.8
     - kadi ==5.0.0
-    - maude ==3.3
+    - maude ==3.3.1
     - mica ==4.20.0
-    - parse_cm ==3.5
-    - proseco ==4.7.1
+    - parse_cm ==3.5.1
+    - proseco ==4.7.2
     - psmc_check ==v1.2.0
-    - pyyaks ==4.4
-    - quaternion ==3.4.1
-    - ska.arc5gl ==3.1.1
-    - ska.astro ==3.2.1
-    - ska.dbi ==4.0
+    - pyyaks ==4.4.1
+    - quaternion ==3.5.0
+    - ska.arc5gl ==3.1.2
+    - ska.astro ==3.2.2
+    - ska.dbi ==4.0.1
     - ska.engarchive ==4.47.3
-    - ska.file ==3.4.1
-    - ska.ftp ==3.5.1
-    - ska.numpy ==3.8.1
-    - ska.matplotlib ==3.11.2
-    - ska.parsecm ==3.3.1
+    - ska.file ==3.4.2
+    - ska.ftp ==3.5.2
+    - ska.numpy ==3.8.2
+    - ska.matplotlib ==3.11.3
+    - ska.parsecm ==3.3.2
     - ska_helpers ==0.1.0
-    - ska_path ==3.1
+    - ska_path ==3.1.1
     - ska_sync ==4.6.0
-    - ska.quatutil ==3.3.1
+    - ska.quatutil ==3.3.2
     - ska.shell ==3.4.0
-    - ska.sun ==3.5
-    - ska.tdb ==3.5.1
+    - ska.sun ==3.5.1
+    - ska.tdb ==3.5.2
     - sparkles ==4.4.0
-    - starcheck ==13.5
-    - tables3_api ==0.1
-    - testr ==4.3
+    - starcheck ==13.5.1
+    - tables3_api ==0.1.1
+    - testr ==4.3.1
     - xija ==4.15

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - ska.shell ==3.3.5
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
-    - sparkles ==4.3
+    - sparkles ==4.4
     - starcheck ==13.5
     - tables3_api ==0.1
     - testr ==4.3

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - ska.matplotlib ==3.11.2
     - ska.parsecm ==3.3.1
     - ska_path ==3.1
-    - ska_sync ==4.5
+    - ska_sync ==4.6
     - ska.quatutil ==3.3.1
     - ska.shell ==3.3.5
     - ska.sun ==3.5

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.01.13
+  version: 2020.01.14
 
 build:
   noarch: generic
@@ -12,7 +12,7 @@ requirements:
     - ska3-core ==2020.01.10
     - ska3-template ==2019.09.03
     - acdc ==4.4
-    - agasc ==4.8
+    - agasc ==4.8.0
     - acisfp_check ==v2.7.0
     - acis_taco ==4.0.1
     - acis_thermal_check ==v2.9.0
@@ -28,9 +28,9 @@ requirements:
     - find_attitude ==3.3.2
     - hopper ==4.4
     - jplephem ==2.8
-    - kadi ==5.0
+    - kadi ==5.0.0
     - maude ==3.3
-    - mica ==4.20
+    - mica ==4.20.0
     - parse_cm ==3.5
     - proseco ==4.7.1
     - psmc_check ==v1.2.0
@@ -45,14 +45,14 @@ requirements:
     - ska.numpy ==3.8.1
     - ska.matplotlib ==3.11.2
     - ska.parsecm ==3.3.1
-    - ska_helpers ==0.1
+    - ska_helpers ==0.1.0
     - ska_path ==3.1
-    - ska_sync ==4.6
+    - ska_sync ==4.6.0
     - ska.quatutil ==3.3.1
-    - ska.shell ==3.4
+    - ska.shell ==3.4.0
     - ska.sun ==3.5
     - ska.tdb ==3.5.1
-    - sparkles ==4.4
+    - sparkles ==4.4.0
     - starcheck ==13.5
     - tables3_api ==0.1
     - testr ==4.3

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - backstop_history ==v1.1.0
     - chandra_aca ==4.28
     - chandra.cmd_states ==3.15
-    - chandra.maneuver ==3.7.1
+    - chandra.maneuver ==3.7.2
     - chandra.time ==3.20.3
     - cxotime ==3.1
     - dea_check ==v2.3.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -12,7 +12,7 @@ requirements:
     - ska3-core ==2019.07.22
     - ska3-template ==2019.09.03
     - acdc ==4.4
-    - agasc ==4.7
+    - agasc ==4.8
     - acisfp_check ==v2.7.0
     - acis_taco ==4.0.1
     - acis_thermal_check ==v2.9.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.01.16
+  version: 2020.01.17
 
 build:
   noarch: generic
@@ -36,21 +36,21 @@ requirements:
     - psmc_check ==v1.2.0
     - pyyaks ==4.4.1
     - quaternion ==3.5.0
-    - ska.arc5gl ==3.1.2
-    - ska.astro ==3.2.2
+    - ska.arc5gl ==3.1.3
+    - ska.astro ==3.2.3
     - ska.dbi ==4.0.1
     - ska.engarchive ==4.47.4
-    - ska.file ==3.4.2
+    - ska.file ==3.4.3
     - ska.ftp ==3.5.2
     - ska.numpy ==3.8.2
     - ska.matplotlib ==3.11.3
-    - ska.parsecm ==3.3.2
+    - ska.parsecm ==3.3.3
     - ska_helpers ==0.1.0
     - ska_path ==3.1.1
     - ska_sync ==4.6.0
     - ska.quatutil ==3.3.2
     - ska.shell ==3.4.0
-    - ska.sun ==3.5.1
+    - ska.sun ==3.5.2
     - ska.tdb ==3.5.2
     - sparkles ==4.4.0
     - starcheck ==13.5.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.01.09
+  version: 2020.01.10
 
 build:
   noarch: generic
@@ -9,7 +9,7 @@ requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
-    - ska3-core ==2020.01.09
+    - ska3-core ==2020.01.10
     - ska3-template ==2019.09.03
     - acdc ==4.4
     - agasc ==4.8

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.01.15
+  version: 2020.01.16
 
 build:
   noarch: generic
@@ -56,4 +56,4 @@ requirements:
     - starcheck ==13.5.1
     - tables3_api ==0.1.1
     - testr ==4.3.1
-    - xija ==4.15
+    - xija ==4.16.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -44,6 +44,7 @@ requirements:
     - ska.numpy ==3.8.1
     - ska.matplotlib ==3.11.2
     - ska.parsecm ==3.3.1
+    - ska_helpers ==0.1
     - ska_path ==3.1
     - ska_sync ==4.6
     - ska.quatutil ==3.3.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - cxotime ==3.1
     - dea_check ==v2.3.0
     - dpa_check ==v2.5.0
-    - find_attitude ==3.3.1
+    - find_attitude ==3.3.2
     - hopper ==4.4
     - jplephem ==2.8
     - kadi ==5.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-perl
-  version: 2020.01.10
+  version: 2020.01.13
 
 requirements:
   run:
@@ -20,5 +20,5 @@ requirements:
     - perl-ska-classic ==0.6
     - perl-ska-convert ==4.3
     - perl-ska-web ==4.0
-    - watch_cron_logs ==4.2 # [linux]
-    - task_schedule ==4.2 # [linux]
+    - watch_cron_logs ==4.2
+    - task_schedule ==4.2

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-perl
-  version: 2019.12.10
+  version: 2020.01.10
 
 requirements:
   run:
@@ -20,5 +20,5 @@ requirements:
     - perl-ska-classic ==0.6
     - perl-ska-convert ==4.3
     - perl-ska-web ==4.0
-    - watch_cron_logs ==4.1 # [linux]
-    - task_schedule ==4.1 # [linux]
+    - watch_cron_logs ==4.2 # [linux]
+    - task_schedule ==4.2 # [linux]

--- a/pkg_defs/ska3_builder/meta.yaml
+++ b/pkg_defs/ska3_builder/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3_builder
-  version: 2018.08.11
+  version: 2020.01.13
 
 build:
   noarch: generic

--- a/pkg_defs/ska3_builder/meta.yaml
+++ b/pkg_defs/ska3_builder/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - gitpython
     - git
   run:
+    - cython
     - python
     - ipython
     - gitpython

--- a/pkg_defs/ska_sync/meta.yaml
+++ b/pkg_defs/ska_sync/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - yaml
     - ska_path
-
+    - ska_helpers
 
 test:
   imports:

--- a/pkg_defs/sparkles/meta.yaml
+++ b/pkg_defs/sparkles/meta.yaml
@@ -19,11 +19,6 @@ requirements:
   build:
     - python
     - pip
-    - setuptools
-    - chandra_aca
-    - proseco
-    - testr
-    - numpy >=1.12.1
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
@@ -36,6 +31,7 @@ requirements:
     - proseco
     - quaternion
     - testr
+    - ska_helpers
 
 test:
   imports:


### PR DESCRIPTION
## Release Notes

The 2020.1 skare3 release is significant in that it includes substantive changes to a few packages and includes setuptools_scm modernization of most of our Python modules.

### Package Updates

**[acis_taco](https://github.com/sot/acis_taco/releases/tag/4.1.0)**
 - [x] https://github.com/sot/acis_taco/pull/13 Allow specifying p_earth_body in call to calc_earth_vis
    - This code was used to make the xija file in flight use, but an updated acis_taco was not installed at that time

**[agasc](https://github.com/sot/agasc/releases/tag/4.8.0)**
- [x] https://github.com/sot/agasc/pull/40 Add get_stars() function to get multiple ids / dates

**[annie](https://github.com/sot/annie/releases/tag/0.9.1)**
  - [x] https://github.com/sot/annie/pull/96 Add bgd init value to track_stars_setup

**[Chandra.Maneuver](https://github.com/sot/Chandra.Maneuver/releases/tag/3.7.2)**
- [x] https://github.com/sot/Chandra.Maneuver/pull/14 Cast number of steps to int

**[Chandra.Time](https://github.com/sot/Chandra.Time/releases/tag/3.20.4)**
- [x] https://github.com/sot/Chandra.Time/pull/34 Add compile arg for building on MacOS Catalina / Xcode 11.2

**[find_attitude](https://github.com/sot/find_attitude/releases/tag/3.3.2)**
- [x] https://github.com/sot/find_attitude/pull/7 Changes to go along with the py3-server kadi branch
  - Mostly just a change in a module name.  Django 3.0 requires web apps to have a unique name as determined by the module name.

**[kadi](https://github.com/sot/kadi/releases/tag/5.0.0)**
- [x] https://github.com/sot/kadi/pull/152 Add ACIS raw-mode SI modes to ACIS states 
- [x] https://github.com/sot/kadi/pull/143 Py3 server with + event/cmd cron jobs processing with django 3.0
   - **Interface impacts**:  Makes and uses new, not-back-compatible events3.db3
   - Make the django server run with Python 3 and django 3.0
   - Make the events update work on Python 3
   - Add `obsid` as a standard field for telemetry-based events
   - Change name of event database file from `events.db3` to `events3.db3`.  New file and schema are not compatible with previous version.
   - Flake8 changes

**[mica](https://github.com/sot/mica/releases/tag/4.20.0)**
- [x] https://github.com/sot/mica/pull/213 Small fix for PCAD table generation + SCM version changes
  - Tiny one-line change in the way kadi.events are imported required by django 3.0

**[ska_helpers](https://github.com/sot/ska_helpers/releases/tag/0.1.0)**
- [x] [Initial Release 0.1.0](https://github.com/sot/ska_helpers/releases/tag/0.1.0)
   - This new package includes a module `version.py` that provides functionality for getting a package version using either distribution metadata or git tag and commit data.
   - Also includes convenience methods to get and/or log runtime information like user, machine name etc for scripts.

**[ska.quatutil](https://github.com/sot/Ska.quatutil/releases/tag/3.3.2)**
 - [x] PR #7: Refactor test

**[ska_sync](https://github.com/sot/ska_sync/releases/tag/4.6.0)**
- [x] https://github.com/sot/ska_sync/pull/15 Add kadi/events3.db3, remove eng_archive in favor of cheta_sync
  - Interface changes: Changes the default files that are synced with the tool if user creates new working sync config

**[Ska.Shell](https://github.com/sot/Ska.Shell/releases/tag/3.4.0)**
- [x] https://github.com/sot/Ska.Shell/pull/15 Fix bash support on catalina + modernize
  - Fix a problem that came up because Mac catalina outputs some cruft when you start a bash shell.
  - Also removes Python 2.7 support.

**[sparkles](https://github.com/sot/sparkles/releases/tag/4.4.0)**
- [x] https://github.com/sot/sparkles/pull/130 Add --open-html option to open HTML in browser
- [x] https://github.com/sot/sparkles/pull/131 Add check that guide star is a valid guide candidate

**[task_schedule](https://github.com/sot/task_schedule/releases/tag/4.2)**
- [x] https://github.com/sot/task_schedule/pull/15 Initial steps to modernizing task_schedule

**[watch_cron_logs](https://github.com/sot/watch_cron_logs/releases/tag/4.2)**
- [x] https://github.com/sot/watch_cron_logs/pull/6 Modernize

**[xija](https://github.com/sot/xija/releases/tag/4.16.0)**
 - [x] https://github.com/sot/xija/pull/48 Allow the timestep to be set from the model specification

**Includes just package changes for setuptools-scm**
- acdc, chandra_aca, Chandra.cmd_states, cxotime, hopper, maude, parse_cm, proseco, pyyaks, Ska.arc5gl, Ska.astro, Ska.DBI, Ska.File, Ska.Numpy, Ska.Matplotlib, Ska.ParseCM, Ska.tdb, starcheck, tables3_api, testr

**ACIS packages with changes for setuptools-scm**
- acis_thermal_check, acisfp_check, backstop_history, dea_check, dpa_check, psmc_check

**Updates to core/not-ska packages**
 - [x] setuptools_scm 3.3.3
 - [x] django 3.0.1
 - [x] sherpa to 4.11.1 on OSX

The spyder package has been removed from ska3-core
  - [x] Remove spyder

### Interface impacts

The package interface impacts are called out above (kadi and ska_sync).

xija has back-compatible API changes.  xija allows models to specify timestep from the spec (but uses the default of 328 seconds for back-compatibility). 

### Review

All changes have been reviewed by the aspect team.

### Testing

The updated set of modules pass unit and integration testing.  In addition, the more involved testing for the kadi+django update was documented by Tom in [kadi PR 143](https://github.com/sot/kadi/pull/143

### Promotion

After approval, updated ska3-flight and ska3-perl will be installed on HEAD and GRETA ska3/flight.

The kadi package update will require minor updates to the kadi cron jobs.

The removal of spyder from the ska3-core package does not require that it be removed from HEAD/GRETA ska3/flight , though we do believe that no one is actually using the package.

### Github

Closes #255 
Closes #253 
Closes #252 
Closes #251 
Closes #250 
Closes #249 
Closes #247 
Closes #246 
Closes #245 
Closes #243 
Closes #239 
Closes #238 
Closes #229
Closes #224 
Closes #232 

---

