### PR TITLE
Release 2020.2

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - find_attitude ==3.3.2
     - hopper ==4.4.1
     - jplephem ==2.8
-    - kadi ==5.0.0
+    - kadi ==5.0.1
     - maude ==3.3.1
     - mica ==4.20.0
     - parse_cm ==3.5.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.02.05
+  version: 2020.02.12
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - proseco ==4.7.2
     - psmc_check ==1.3.1
     - pyyaks ==4.4.1
-    - quaternion ==3.4.1
+    - quaternion ==3.5.1
     - ska.arc5gl ==3.1.3
     - ska.astro ==3.2.3
     - ska.dbi ==4.0.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -13,18 +13,18 @@ requirements:
     - ska3-template ==2019.09.03
     - acdc ==4.4.1
     - agasc ==4.8.0
-    - acisfp_check ==2.7.1
+    - acisfp_check ==2.7.2
     - acis_taco ==4.1.0
-    - acis_thermal_check ==2.9.1
+    - acis_thermal_check ==2.9.2
     - annie ==0.9.1
-    - backstop_history ==1.1.1
+    - backstop_history ==1.1.2
     - chandra_aca ==4.28.1
     - chandra.cmd_states ==3.15.1
     - chandra.maneuver ==3.7.2
     - chandra.time ==3.20.4
     - cxotime ==3.1.1
-    - dea_check ==2.3.1
-    - dpa_check ==2.5.1
+    - dea_check ==2.3.2
+    - dpa_check ==2.5.2
     - find_attitude ==3.3.2
     - hopper ==4.4.1
     - jplephem ==2.8
@@ -33,7 +33,7 @@ requirements:
     - mica ==4.20.0
     - parse_cm ==3.5.1
     - proseco ==4.7.2
-    - psmc_check ==1.3.0
+    - psmc_check ==1.3.1
     - pyyaks ==4.4.1
     - quaternion ==3.4.1
     - ska.arc5gl ==3.1.3


### PR DESCRIPTION
**Quaternion**
Minor version increase. Interface changes backward compatible.

- sot/Quaternion/issues/5 New vectorized interface: allows handling of arrays of quaternions without using for loops.
- sot/Quaternion/issues/22 Implementation of setuptools_scm, to provide better handling of package versions.
- sot/Quaternion/issues/25 Setting up automated build of conda packages.
- sot/Quaternion/issues/16 Improving documentation.

**Kadi 5.0.1:**
patch version increase
- sot/Kadi/issues/157 Setting up automated builds.
- sot/Kadi/issues/156 Implementation of setuptools_scm.
- sot/Kadi/issues/154 Alerts to aca@head and remove OCC task_schedule configs.

**ACIS packages**
(patch version increases: acisfp_check 2.7.2, acis_thermal_check 2.9.2, backstop_history 1.1.2, dea_check 2.3.2, dpa_check 2.5.2, psmc_check 1.3.1):
- "lightweight" building. Removing dependencies required at build time. 

