### PR TITLE
Add aca view to skare3

### DIFF
--- a/pkg_defs/aca_view/build.sh
+++ b/pkg_defs/aca_view/build.sh
@@ -1,0 +1,1 @@
+pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/aca_view/meta.yaml
+++ b/pkg_defs/aca_view/meta.yaml
@@ -1,0 +1,50 @@
+package:
+  name: aca_view
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  noarch: python
+  script_env:
+    - SKA_TOP_SRC_DIR
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/aca_view
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - pip
+    - python
+    - setuptools
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - psutil
+    - numpy
+    - scipy
+    - matplotlib
+    - ipython
+    - PyQt5
+    - qtconsole
+    - astropy
+    - testr
+    - maude
+    - chandra_aca
+    - mica
+    - cxotime
+    - kadi
+    - Quaternion
+    - Ska
+
+test:
+  imports:
+    - aca_view
+
+
+about:
+  home: https://github.com/sot/aca_view

--- a/pkg_defs/aca_view/meta.yaml
+++ b/pkg_defs/aca_view/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - scipy
     - matplotlib
     - ipython
-    - PyQt5
+    - pyqt
     - qtconsole
     - astropy
     - testr
@@ -38,8 +38,8 @@ requirements:
     - mica
     - cxotime
     - kadi
-    - Quaternion
-    - Ska
+    - quaternion
+    - ska.matplotlib
 
 test:
   imports:

--- a/pkg_defs/aca_view/run_test.py
+++ b/pkg_defs/aca_view/run_test.py
@@ -1,0 +1,3 @@
+import sys
+import aca_view
+sys.exit(aca_view.test())


### PR DESCRIPTION
This PR does not add aca_view to ska3-flight. I think that is ok. One can still do `conda install aca_view`. Would you prefer to add it to ska3-flight?