### PR TITLE
Add fep1_actel_check, fep1_mong_check, bep_pcb_check to skare3

### DIFF
--- a/pkg_defs/bep_pcb_check/build.sh
+++ b/pkg_defs/bep_pcb_check/build.sh
@@ -1,0 +1,2 @@
+export SKA=/proj/sot/ska
+pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/bep_pcb_check/meta.yaml
+++ b/pkg_defs/bep_pcb_check/meta.yaml
@@ -1,0 +1,44 @@
+package:
+  name: bep_pcb_check
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  noarch: python
+  script_env:
+    - SKA_TOP_SRC_DIR
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/bep_pcb_check
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - pip
+    - python
+    - setuptools
+    - six
+    - numpy
+    - matplotlib
+    - acis_thermal_check
+    - xija
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - six
+    - numpy
+    - matplotlib
+    - acis_thermal_check
+    - xija
+
+test:
+  imports:
+    - bep_pcb_check
+
+about:
+  home: https://github.com/acisops/bep_pcb_check
+

--- a/pkg_defs/fep1_actel_check/build.sh
+++ b/pkg_defs/fep1_actel_check/build.sh
@@ -1,0 +1,2 @@
+export SKA=/proj/sot/ska
+pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/fep1_actel_check/meta.yaml
+++ b/pkg_defs/fep1_actel_check/meta.yaml
@@ -1,0 +1,44 @@
+package:
+  name: fep1_actel_check
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  noarch: python
+  script_env:
+    - SKA_TOP_SRC_DIR
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/fep1_actel_check
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - pip
+    - python
+    - setuptools
+    - six
+    - numpy
+    - matplotlib
+    - acis_thermal_check
+    - xija
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - six
+    - numpy
+    - matplotlib
+    - acis_thermal_check
+    - xija
+
+test:
+  imports:
+    - fep1_actel_check
+
+about:
+  home: https://github.com/acisops/fep1_actel_check
+

--- a/pkg_defs/fep1_mong_check/build.sh
+++ b/pkg_defs/fep1_mong_check/build.sh
@@ -1,0 +1,2 @@
+export SKA=/proj/sot/ska
+pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/fep1_mong_check/meta.yaml
+++ b/pkg_defs/fep1_mong_check/meta.yaml
@@ -1,0 +1,44 @@
+package:
+  name: fep1_mong_check
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  noarch: python
+  script_env:
+    - SKA_TOP_SRC_DIR
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/fep1_mong_check
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - pip
+    - python
+    - setuptools
+    - six
+    - numpy
+    - matplotlib
+    - acis_thermal_check
+    - xija
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - six
+    - numpy
+    - matplotlib
+    - acis_thermal_check
+    - xija
+
+test:
+  imports:
+    - fep1_mong_check
+
+about:
+  home: https://github.com/acisops/fep1_mong_check
+


### PR DESCRIPTION
This PR adds the following packages to skare3:

http://github.com/acisops/fep1_actel_check
http://github.com/acisops/fep1_mong_check
http://github.com/acisops/fep1_actel_check

which are getting upgrades in conjunction with acis_thermal_check v3.0.

I would like to have them in ska3-flight, but we can decide when that should happen. 