### PR TITLE
Add conda recipe for skare3 tools

### DIFF
--- a/pkg_defs/skare3_tools/build.sh
+++ b/pkg_defs/skare3_tools/build.sh
@@ -1,1 +1,0 @@
-python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/skare3_tools/build.sh
+++ b/pkg_defs/skare3_tools/build.sh
@@ -1,0 +1,1 @@
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/skare3_tools/meta.yaml
+++ b/pkg_defs/skare3_tools/meta.yaml
@@ -3,9 +3,8 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
   noarch: python
-  script_env:
-    - SKA_TOP_SRC_DIR
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/skare3_tools
@@ -30,6 +29,8 @@ requirements:
     - google-auth-oauthlib
     - google-api-python-client
     - sphinx-argparse
+    - keyring
+    - jinja2
 
 about:
   home: https://github.com/sot/skare3_tools

--- a/pkg_defs/skare3_tools/meta.yaml
+++ b/pkg_defs/skare3_tools/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: skare3_tools
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  noarch: python
+  script_env:
+    - SKA_TOP_SRC_DIR
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/skare3_tools
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - pip
+    - python
+    - setuptools
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - setuptools_scm
+    - pyyaml
+    - jinja2
+    - google-auth-oauthlib
+    - google-api-python-client
+    - sphinx-argparse
+
+about:
+  home: https://github.com/sot/skare3_tools


### PR DESCRIPTION
This recipe ends up pulling several packages that are not currently in our repository. That is thanks to these three dependencies:
- google-auth-oauthlib
- google-api-python-client
- sphinx-argparse
The last one is just for documentation (useful for documenting scripts).

Where this goes is an open question. At least I wanted to have it somewhere documented.