### PR TITLE
No eggs

### DIFF
--- a/pkg_defs/Chandra.Maneuver/build.sh
+++ b/pkg_defs/Chandra.Maneuver/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Chandra.Maneuver/meta.yaml
+++ b/pkg_defs/Chandra.Maneuver/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pip <10.0
     - python
     - quaternion
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Chandra.Time/build.sh
+++ b/pkg_defs/Chandra.Time/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - cython >=0.20.1
     - six
     - numpy
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Chandra.cmd_states/build.sh
+++ b/pkg_defs/Chandra.cmd_states/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Chandra.cmd_states/meta.yaml
+++ b/pkg_defs/Chandra.cmd_states/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - chandra.maneuver
     - ska.parsecm
     - ska.numpy
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Quaternion/build.sh
+++ b/pkg_defs/Quaternion/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Quaternion/meta.yaml
+++ b/pkg_defs/Quaternion/meta.yaml
@@ -17,9 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - six
     - numpy
   # Packages required to run the package. These are the dependencies that

--- a/pkg_defs/Ska.DBI/build.sh
+++ b/pkg_defs/Ska.DBI/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.DBI/meta.yaml
+++ b/pkg_defs/Ska.DBI/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python
     - six
     - sqlite
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.File/build.sh
+++ b/pkg_defs/Ska.File/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.File/meta.yaml
+++ b/pkg_defs/Ska.File/meta.yaml
@@ -18,6 +18,7 @@ requirements:
   build:
     - python
     - pip <10.0
+    - setuptools_scm
 
   run:
     - python

--- a/pkg_defs/Ska.Matplotlib/build.sh
+++ b/pkg_defs/Ska.Matplotlib/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.Matplotlib/meta.yaml
+++ b/pkg_defs/Ska.Matplotlib/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - matplotlib
     - chandra.time
     - numpy
+    - setuptools_scm
 
   run:
     - python

--- a/pkg_defs/Ska.Numpy/build.sh
+++ b/pkg_defs/Ska.Numpy/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.Numpy/meta.yaml
+++ b/pkg_defs/Ska.Numpy/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - numpy
     - cython
     - six
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.ParseCM/build.sh
+++ b/pkg_defs/Ska.ParseCM/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.ParseCM/meta.yaml
+++ b/pkg_defs/Ska.ParseCM/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python
     - six
     - chandra.time
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.Shell/build.sh
+++ b/pkg_defs/Ska.Shell/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.Shell/meta.yaml
+++ b/pkg_defs/Ska.Shell/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - python
     - pip <10.0
     - six
+    - setuptools_scm
 
   run:
     - python

--- a/pkg_defs/Ska.Sun/build.sh
+++ b/pkg_defs/Ska.Sun/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.Sun/meta.yaml
+++ b/pkg_defs/Ska.Sun/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - chandra.time
     - ska.quatutil
     - numpy
+    - setuptools_scm
   run:
     - python
     - ska.quatutil

--- a/pkg_defs/Ska.arc5gl/build.sh
+++ b/pkg_defs/Ska.arc5gl/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.arc5gl/meta.yaml
+++ b/pkg_defs/Ska.arc5gl/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python
     - setuptools
     - six
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.astro/build.sh
+++ b/pkg_defs/Ska.astro/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.astro/meta.yaml
+++ b/pkg_defs/Ska.astro/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python
     - setuptools
     - six
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.engarchive/build.sh
+++ b/pkg_defs/Ska.engarchive/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.engarchive/meta.yaml
+++ b/pkg_defs/Ska.engarchive/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - setuptools
     - six
     - numpy
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.ftp/build.sh
+++ b/pkg_defs/Ska.ftp/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.ftp/meta.yaml
+++ b/pkg_defs/Ska.ftp/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pip <10.0
     - python
     - setuptools
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.quatutil/build.sh
+++ b/pkg_defs/Ska.quatutil/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.quatutil/meta.yaml
+++ b/pkg_defs/Ska.quatutil/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - six
     - numpy
     - quaternion
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.tdb/build.sh
+++ b/pkg_defs/Ska.tdb/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index --egg .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/Ska.tdb/meta.yaml
+++ b/pkg_defs/Ska.tdb/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python
     - six
     - numpy
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/acdc/build.sh
+++ b/pkg_defs/acdc/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/acdc/meta.yaml
+++ b/pkg_defs/acdc/meta.yaml
@@ -18,8 +18,8 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip
     - setuptools
+    - setuptools_scm
     - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/acis_taco/build.sh
+++ b/pkg_defs/acis_taco/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/acis_taco/meta.yaml
+++ b/pkg_defs/acis_taco/meta.yaml
@@ -16,9 +16,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - six
     - numpy
     - matplotlib

--- a/pkg_defs/acis_thermal_check/build.sh
+++ b/pkg_defs/acis_thermal_check/build.sh
@@ -1,2 +1,2 @@
 export SKA=/proj/sot/ska
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/acis_thermal_check/meta.yaml
+++ b/pkg_defs/acis_thermal_check/meta.yaml
@@ -17,10 +17,10 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - six
     - setuptools
+    - setuptools_scm
     # Looks like this needs to import acis_thermal_check.main to install
     - numpy
     - matplotlib

--- a/pkg_defs/acisfp_check/build.sh
+++ b/pkg_defs/acisfp_check/build.sh
@@ -1,2 +1,2 @@
 export SKA=/proj/sot/ska
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/acisfp_check/meta.yaml
+++ b/pkg_defs/acisfp_check/meta.yaml
@@ -17,9 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - six
     - numpy
     - matplotlib

--- a/pkg_defs/agasc/build.sh
+++ b/pkg_defs/agasc/build.sh
@@ -1,2 +1,2 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt
 

--- a/pkg_defs/agasc/meta.yaml
+++ b/pkg_defs/agasc/meta.yaml
@@ -18,7 +18,8 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip
+    - setuptools
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/annie/build.sh
+++ b/pkg_defs/annie/build.sh
@@ -1,2 +1,2 @@
 export SKA=/dev/null
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/annie/meta.yaml
+++ b/pkg_defs/annie/meta.yaml
@@ -18,8 +18,8 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip
     - setuptools
+    - setuptools_scm
     - chandra_aca
     - mica
     - testr

--- a/pkg_defs/backstop_history/build.sh
+++ b/pkg_defs/backstop_history/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/backstop_history/meta.yaml
+++ b/pkg_defs/backstop_history/meta.yaml
@@ -17,10 +17,10 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - six
     - python
     - setuptools
+    - setuptools_scm
     - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/chandra_aca/build.sh
+++ b/pkg_defs/chandra_aca/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index  .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/chandra_aca/meta.yaml
+++ b/pkg_defs/chandra_aca/meta.yaml
@@ -17,8 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
+    - setuptools_scm
+    - setuptools
     - six
     - numpy
     - chandra.time

--- a/pkg_defs/cxotime/build.sh
+++ b/pkg_defs/cxotime/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/cxotime/meta.yaml
+++ b/pkg_defs/cxotime/meta.yaml
@@ -17,9 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - numpy
     - astropy
   # Packages required to run the package. These are the dependencies that

--- a/pkg_defs/dea_check/build.sh
+++ b/pkg_defs/dea_check/build.sh
@@ -1,2 +1,2 @@
 export SKA=/proj/sot/ska
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/dea_check/meta.yaml
+++ b/pkg_defs/dea_check/meta.yaml
@@ -17,9 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - six
     - numpy
     - matplotlib

--- a/pkg_defs/dpa_check/build.sh
+++ b/pkg_defs/dpa_check/build.sh
@@ -1,2 +1,2 @@
 export SKA=/proj/sot/ska
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/dpa_check/meta.yaml
+++ b/pkg_defs/dpa_check/meta.yaml
@@ -17,9 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - six
     - numpy
     - matplotlib

--- a/pkg_defs/find_attitude/build.sh
+++ b/pkg_defs/find_attitude/build.sh
@@ -1,2 +1,2 @@
 export SKA=/dev/null
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/find_attitude/meta.yaml
+++ b/pkg_defs/find_attitude/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - quaternion
     - ska.quatutil
     - sherpa
-    - ska_helpesr
+    - ska_helpers
 
 test:
   imports:

--- a/pkg_defs/find_attitude/meta.yaml
+++ b/pkg_defs/find_attitude/meta.yaml
@@ -18,7 +18,8 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip
+    - setuptools
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
@@ -32,7 +33,7 @@ requirements:
     - quaternion
     - ska.quatutil
     - sherpa
-    - ska_helpers
+    - ska_helpesr
 
 test:
   imports:

--- a/pkg_defs/hopper/build.sh
+++ b/pkg_defs/hopper/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/hopper/meta.yaml
+++ b/pkg_defs/hopper/meta.yaml
@@ -17,8 +17,8 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - setuptools
+    - setuptools_scm
     - python
     - six
     - quaternion

--- a/pkg_defs/kadi/build.sh
+++ b/pkg_defs/kadi/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/kadi/meta.yaml
+++ b/pkg_defs/kadi/meta.yaml
@@ -17,8 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
+    - setuptools
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/maude/build.sh
+++ b/pkg_defs/maude/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/maude/meta.yaml
+++ b/pkg_defs/maude/meta.yaml
@@ -18,9 +18,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - requests
     - six
     - numpy

--- a/pkg_defs/mica/build.sh
+++ b/pkg_defs/mica/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/mica/meta.yaml
+++ b/pkg_defs/mica/meta.yaml
@@ -17,9 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/parse_cm/build.sh
+++ b/pkg_defs/parse_cm/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/parse_cm/meta.yaml
+++ b/pkg_defs/parse_cm/meta.yaml
@@ -17,8 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
+    - setuptools
+    - setuptools_scm
     - astropy
     - numpy
     - six

--- a/pkg_defs/proseco/build.sh
+++ b/pkg_defs/proseco/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/proseco/meta.yaml
+++ b/pkg_defs/proseco/meta.yaml
@@ -18,8 +18,8 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip
     - setuptools
+    - setuptools_scm
     - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/psmc_check/build.sh
+++ b/pkg_defs/psmc_check/build.sh
@@ -1,2 +1,2 @@
 export SKA=/proj/sot/ska
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/psmc_check/meta.yaml
+++ b/pkg_defs/psmc_check/meta.yaml
@@ -17,9 +17,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - six
     - numpy
     - matplotlib

--- a/pkg_defs/pyyaks/build.sh
+++ b/pkg_defs/pyyaks/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/pyyaks/meta.yaml
+++ b/pkg_defs/pyyaks/meta.yaml
@@ -18,7 +18,8 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip
+    - setuptools
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/ska_helpers/build.sh
+++ b/pkg_defs/ska_helpers/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/ska_helpers/meta.yaml
+++ b/pkg_defs/ska_helpers/meta.yaml
@@ -15,13 +15,12 @@ source:
 
 requirements:
   build:
-    - pip
     - python
     - pytest
+    - setuptools
     - setuptools_scm
   run:
     - python
-    - setuptools_scm
 
 
 about:

--- a/pkg_defs/ska_path/build.sh
+++ b/pkg_defs/ska_path/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/ska_path/meta.yaml
+++ b/pkg_defs/ska_path/meta.yaml
@@ -15,8 +15,9 @@ source:
 
 requirements:
   build:
-    - pip
     - python
+    - setuptools
+    - setuptools_scm
   run:
     - python
 

--- a/pkg_defs/ska_sync/build.sh
+++ b/pkg_defs/ska_sync/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/ska_sync/meta.yaml
+++ b/pkg_defs/ska_sync/meta.yaml
@@ -15,9 +15,9 @@ source:
 
 requirements:
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
   run:
     - python
     - yaml

--- a/pkg_defs/sparkles/build.sh
+++ b/pkg_defs/sparkles/build.sh
@@ -1,2 +1,2 @@
 export SKA=/dev/null
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/sparkles/meta.yaml
+++ b/pkg_defs/sparkles/meta.yaml
@@ -18,7 +18,8 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip
+    - setuptools
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/starcheck/build.sh
+++ b/pkg_defs/starcheck/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/starcheck/meta.yaml
+++ b/pkg_defs/starcheck/meta.yaml
@@ -19,8 +19,8 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip
     - setuptools
+    - setuptools_scm
     - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/tables3_api/build.sh
+++ b/pkg_defs/tables3_api/build.sh
@@ -1,2 +1,2 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt
 

--- a/pkg_defs/tables3_api/meta.yaml
+++ b/pkg_defs/tables3_api/meta.yaml
@@ -17,7 +17,8 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
+    - setuptools
+    - setuptools_scm
     - python
     - pytables
   # Packages required to run the package. These are the dependencies that

--- a/pkg_defs/testr/build.sh
+++ b/pkg_defs/testr/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/testr/meta.yaml
+++ b/pkg_defs/testr/meta.yaml
@@ -18,7 +18,8 @@ requirements:
   # listed explicitly if they are required.
   build:
     - python
-    - pip
+    - setuptools
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/xija/build.sh
+++ b/pkg_defs/xija/build.sh
@@ -1,1 +1,1 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -16,9 +16,9 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - pip
     - python
     - setuptools
+    - setuptools_scm
     - six
     - numba
     - numpy >=1.12.1


### PR DESCRIPTION
This PR changes the build of namespace packages to not use eggs.

While doing that, I also replace all uses of `pip` by `python setup.py` and this required explicitly adding setuptools_scm to requirements.

And while doing that... I went and did it also for non-namespace packages.

Now... will this be a testing nightmare?