### PR TITLE
2020.4

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -11,31 +11,31 @@ requirements:
   run:
     - ska3-core ==2020.01.10
     - ska3-template ==2019.09.03
-    - acdc ==4.4.1
-    - agasc ==4.8.0
-    - acisfp_check ==2.7.2
+    - acdc ==4.5.0
+    - agasc ==4.8.1
+    - acisfp_check ==3.0.0
     - acis_taco ==4.1.0
-    - acis_thermal_check ==2.9.2
-    - annie ==0.9.1
-    - backstop_history ==1.1.2
-    - chandra_aca ==4.28.1
+    - acis_thermal_check ==3.0.0
+    - annie ==0.10.1
+    - backstop_history ==1.1.3
     - chandra.cmd_states ==3.15.1
     - chandra.maneuver ==3.7.2
     - chandra.time ==3.20.4
+    - chandra_aca ==4.29.1
     - cxotime ==3.1.1
-    - dea_check ==2.3.2
-    - dpa_check ==2.5.2
+    - dea_check ==3.0.0
+    - dpa_check ==3.0.0
     - find_attitude ==3.3.2
     - hopper ==4.4.1
     - jplephem ==2.8
     - kadi ==5.0.1
     - maude ==3.3.1
     - mica ==4.20.0
-    - parse_cm ==3.5.1
-    - proseco ==4.7.2
-    - psmc_check ==1.3.1
-    - pyyaks ==4.4.1
-    - quaternion ==3.5.1
+    - parse_cm ==3.5.2
+    - proseco ==4.8.0
+    - psmc_check ==3.0.0
+    - pyyaks ==4.4.2
+    - quaternion ==3.5.2
     - ska.arc5gl ==3.1.3
     - ska.astro ==3.2.3
     - ska.dbi ==4.0.1
@@ -52,8 +52,8 @@ requirements:
     - ska.shell ==3.4.0
     - ska.sun ==3.5.2
     - ska.tdb ==3.5.2
-    - sparkles ==4.4.0
+    - sparkles ==4.6.0
     - starcheck ==13.5.1
     - tables3_api ==0.1.1
     - testr ==4.3.1
-    - xija ==4.16.0
+    - xija ==4.18.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -11,6 +11,7 @@ requirements:
   run:
     - ska3-core ==2020.01.10
     - ska3-template ==2019.09.03
+    - aca_view ==0.3.0
     - acdc ==4.5.0
     - agasc ==4.8.1
     - acisfp_check ==3.0.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - acis_thermal_check ==3.0.0
     - annie ==0.10.1
     - backstop_history ==1.1.3
+    - bep_pcb_check ==3.0.0
     - chandra.cmd_states ==3.15.1
     - chandra.maneuver ==3.7.2
     - chandra.time ==3.20.4
@@ -26,6 +27,8 @@ requirements:
     - dea_check ==3.0.0
     - dpa_check ==3.0.0
     - find_attitude ==3.3.2
+    - fep1_actel_check ==3.0.0
+    - fep1_mong_check ==3.0.0
     - hopper ==4.4.1
     - jplephem ==2.8
     - kadi ==5.0.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.02.12
+  version: 2020.04.24
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.04.24
+  version: 2020.4
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - jplephem ==2.8
     - kadi ==5.0.1
     - maude ==3.3.1
-    - mica ==4.20.0
+    - mica ==4.21.0
     - parse_cm ==3.5.2
     - proseco ==4.8.0
     - psmc_check ==3.0.0


### PR DESCRIPTION
The 2020.4 release includes:

*  the approved-last-week-at-LR updates to the ACIS checkers and adds the new ACIS bep fep checkers to the ska3-flight package set.
* updates to proseco, sparkles, and chandra_aca in support of the ACA limit increase 
* the updates to xija (new ODE solver) already promoted in the Matlab 2020_005 environment
* the recent major enhancements to xija's gui_fit

These substantive updates and a few others are also called out in bold in the full list of changes below.


# New Packages

**aca_view 0.3.0** 

**bep_pcb_check 3.0.0**
**fep1_actel_check 3.0.0**
**fep1_actel_check 3.0.0**

# Changes

**acis_thermal_check: 2.9.2 -> 3.0.0** (2.9.2 -> 2.9.3 -> 3.0.0)
  - [PR 26](https://github.com/acisops/acis_thermal_check/pull/26): Setting up automated builds
  - [PR 25](https://github.com/acisops/acis_thermal_check/pull/25): **acis_thermal_check 3.0**

**acisfp_check: 2.7.2 -> 3.0.0** (2.7.2 -> 2.7.3 -> 3.0.0)
  - [PR 19](https://github.com/acisops/acisfp_check/pull/19): Setting up automated builds
  - [PR 21](https://github.com/acisops/acisfp_check/pull/21): **update acisfp_check for acis_thermal_check 3.0**

**backstop_history: 1.1.2 -> 1.1.3** (1.1.2 -> 1.1.3)
  - [PR 8](https://github.com/acisops/backstop_history/pull/8): Setting up automated builds

**dea_check: 2.3.2 -> 3.0.0** (2.3.2 -> 2.3.3 -> 3.0.0)
  - [PR 21](https://github.com/acisops/dea_check/pull/21): Setting up automated builds
  - [PR 22](https://github.com/acisops/dea_check/pull/22): **update dea_check for acis_thermal_check 3.0**

**dpa_check: 2.5.2 -> 3.0.0** (2.5.2 -> 2.5.3 -> 3.0.0)
  - [PR 20](https://github.com/acisops/dpa_check/pull/20): Setting up automated builds
  - [PR 21](https://github.com/acisops/dpa_check/pull/21): **update dpa_check for acis_thermal_check 3.0**

**psmc_check: 1.3.1 -> 3.0.0** (1.3.1 -> 1.3.2 -> 3.0.0)
  - [PR 19](https://github.com/acisops/psmc_check/pull/19): Setting up automated builds
  - [PR 20](https://github.com/acisops/psmc_check/pull/20): **update psmc_check for acis_thermal_check 3.0**

**acdc: 4.4.1 -> 4.5.0** (4.4.1 -> 4.5.0)
  - [PR 46](https://github.com/sot/acdc/pull/46): Setting up automated builds
  - [PR 48](https://github.com/sot/acdc/pull/48): Write out updated sparkles pkl
  - [PR 47](https://github.com/sot/acdc/pull/47): Fiddle with the scaling for the warm pix plot

**agasc: 4.8.0 -> 4.8.1** (4.8.0 -> 4.8.1)
  - [PR 41](https://github.com/sot/agasc/pull/41): Setting up automated builds
  - [PR 42](https://github.com/sot/agasc/pull/42): Make tests pass on Windows

**annie: 0.9.1 -> 0.10.1** (0.9.1 -> 0.10.0 -> 0.10.1)
  - [PR 98](https://github.com/sot/annie/pull/98): Setting up automated builds
  - [PR 97](https://github.com/sot/annie/pull/97): End simulation at large att offset
  - [PR 100](https://github.com/sot/annie/pull/100): Minor test fix to pass on windows

**chandra_aca: 4.28.1 -> 4.29.1** (4.28.1 -> 4.29.0 -> 4.29.1)
  - [PR 91](https://github.com/sot/chandra_aca/pull/91): Setting up automated builds
  - [PR 92](https://github.com/sot/chandra_aca/pull/92): Use repository_dispatch to trigger build
  - [PR 88](https://github.com/sot/chandra_aca/pull/88): **Add acquisition probability model 2020-02 and make it default** (supports new ACA limit)
  - [PR 93](https://github.com/sot/chandra_aca/pull/93): change to fix release workflow
  - [PR 96](https://github.com/sot/chandra_aca/pull/96): Make test_get_aimpoint work without being on VPN

**mica: 4.20.0 -> 4.21.0** (4.20.0 -> 4.21.0)
- [PR 218](https://github.com/sot/mica/pull/218): **Minor PY3 updates and DS10.8.3 update for mica vv processing** (These mica updates will allow us to move its cron task from an old Python 2 to new Python 3 job, and also support the minor changes to dy, dz, dtheta asol data due to the new AXISCORRECT changes in DS10.8.3)
- [PR 219](https://github.com/sot/mica/pull/219): Mag stats update
- [PR 214](https://github.com/sot/mica/pull/214): Remove dark model
- [PR 215](https://github.com/sot/mica/pull/215): Setting up automated builds
- [PR 173](https://github.com/sot/mica/pull/173): Refactor stats into update and get_stats modules

**parse_cm: 3.5.1 -> 3.5.2** (3.5.1 -> 3.5.2)
  - [PR 20](https://github.com/sot/parse_cm/pull/20): Setting up automated builds
  - [PR 21](https://github.com/sot/parse_cm/pull/21): Fix tests and code to pass on Windows

**proseco: 4.7.2 -> 4.8.0** (4.7.2 -> 4.8.0)
  - [PR 315](https://github.com/sot/proseco/pull/315): **Apply temperature scaling to guide faint mag limit** (supports new ACA limit)
  - [PR 316](https://github.com/sot/proseco/pull/316): **Update penalty limit to -8.1C (to support -7.1C planning limit).** (supports new ACA limit)
  - [PR 297](https://github.com/sot/proseco/pull/297): **Allow optimizing acq halfw for included star** 
  - [PR 320](https://github.com/sot/proseco/pull/320): Update tests for 2020-02 acq model update
  - [PR 319](https://github.com/sot/proseco/pull/319): Setting up automated builds
  - [PR 321](https://github.com/sot/proseco/pull/321): Fix optimizing halfw for case of many include_ids
  - [PR 322](https://github.com/sot/proseco/pull/322): Add a test of calc_p_safe for two identical catalogs

**pyyaks: 4.4.1 -> 4.4.2** (4.4.1 -> 4.4.2)
  - [PR 10](https://github.com/sot/pyyaks/pull/10): Setting up automated builds
  - [PR 11](https://github.com/sot/pyyaks/pull/11): Fix tests to pass on Windows

**quaternion: 3.5.1 -> 3.5.2** (3.5.1 -> 3.5.2)
  - [PR 28](https://github.com/sot/Quaternion/pull/28): Properly unpickle quaternions from versions earlier than 3.5

**sparkles: 4.4.0 -> 4.6.0** (4.4.0 -> 4.5.0 -> 4.6.0)
  - [PR 134](https://github.com/sot/sparkles/pull/134): Add clickable call args output and chandra_aca version
  - [PR 135](https://github.com/sot/sparkles/pull/135): Fix a bug introduced in PR #134
  - [PR 137](https://github.com/sot/sparkles/pull/137): Update regress data for 2020-02 acq model
  - [PR 136](https://github.com/sot/sparkles/pull/136): Setting up automated builds
  - [PR 140](https://github.com/sot/sparkles/pull/140): Add info statement for include / exclude

**xija: 4.16.0 -> 4.18.2** (4.16.0 -> 4.17.0 -> 4.17.1 -> 4.18.0 -> 4.18.1 -> 4.18.2)
  - [PR 76](https://github.com/sot/xija/pull/76): Setting up automated builds
  - [PR 77](https://github.com/sot/xija/pull/77): enable triggering conda build using repository dispatch
  - [PR 79](https://github.com/sot/xija/pull/79): change to fix release workflow
  - [PR 75](https://github.com/sot/xija/pull/75): **New ODE solver**
  - [PR 80](https://github.com/sot/xija/pull/80): Rename dev/core.pyx to alt_core/core.pyx
  - [PR 82](https://github.com/sot/xija/pull/82): Bugfix to build on Windows from mbaski
  - [PR 69](https://github.com/sot/xija/pull/69): **gui_fit upgrades**
  - [PR 83](https://github.com/sot/xija/pull/83): [bugfix] Wrong line is updated in gui_fit
  - [PR 84](https://github.com/sot/xija/pull/84): Fix bug in looking for bad times

# Testing status

We note two test failures that we consider non-issues for this release:

*  Ska.engarchive:  The Ska.engarchive failure is a test failure in the sync tests.  The test now does not pass in current HEAD ska3/flight (previous installed version) and the 2020.4 release does not touch Ska.engarchive, so this is not a regression.  Additionally, the HEAD ska3/flight code is not actually run to make the sync files.  We have an open action to investigate the test failure but consider it a non-issue for this release.
* Ska.quatutil:  The module passes unit tests when run in the test environment (the point of the integration testing).  We have a minor testing defect when run from the automated integration testing of ska_testr and consider it a non-issue for this release

```
**************************************************************
***      Package                  Script            Status ***
*** ------------------ ---------------------------- ------ ***
***   Chandra.Maneuver                 test_unit.py   pass ***
***   Chandra.Maneuver           post_check_logs.py   pass ***
***       Chandra.Time                 test_unit.py   pass ***
***       Chandra.Time           post_check_logs.py   pass ***
*** Chandra.cmd_states                 test_unit.py   pass ***
*** Chandra.cmd_states           post_check_logs.py   pass ***
***         Quaternion                 test_unit.py   pass ***
***         Quaternion           post_check_logs.py   pass ***
***            Ska.DBI                 test_unit.py   pass ***
***            Ska.DBI           post_check_logs.py   pass ***
***          Ska.Numpy                 test_unit.py   pass ***
***          Ska.Numpy           post_check_logs.py   pass ***
***        Ska.ParseCM             test_unit_git.sh   pass ***
***        Ska.ParseCM           post_check_logs.py   pass ***
***          Ska.Shell                 test_unit.py   pass ***
***          Ska.Shell           post_check_logs.py   pass ***
***          Ska.Table             test_unit_git.sh   ---- ***
***          Ska.Table           post_check_logs.py   ---- ***
***     Ska.engarchive    test_make_archive_long.sh   ---- ***
***     Ska.engarchive                 test_unit.py   FAIL ***
***     Ska.engarchive           post_check_logs.py   FAIL ***
***            Ska.ftp                 test_unit.py   pass ***
***            Ska.ftp           post_check_logs.py   pass ***
***       Ska.quatutil             test_unit_git.sh   pass ***
***       Ska.quatutil           post_check_logs.py   FAIL ***
***            Ska.tdb                 test_unit.py   pass ***
***            Ska.tdb           post_check_logs.py   pass ***
***          acis_taco                 test_unit.py   pass ***
***          acis_taco           post_check_logs.py   pass ***
***       acisfp_check              test_regress.sh   pass ***
***       acisfp_check         test_regress_head.sh   pass ***
***       acisfp_check           post_check_logs.py   pass ***
***       acisfp_check              post_regress.py   pass ***
***       acisfp_check         post_regress_head.py   pass ***
***              agasc                 test_unit.py   pass ***
***              agasc           post_check_logs.py   pass ***
***              annie                 test_unit.py   pass ***
***              annie           post_check_logs.py   pass ***
***        chandra_aca                 test_unit.py   pass ***
***        chandra_aca           post_check_logs.py   pass ***
***            cxotime                 test_unit.py   pass ***
***            cxotime           post_check_logs.py   pass ***
***          dea_check              test_regress.sh   pass ***
***          dea_check         test_regress_head.sh   pass ***
***          dea_check           post_check_logs.py   pass ***
***          dea_check              post_regress.py   pass ***
***          dea_check         post_regress_head.py   pass ***
***          dpa_check              test_regress.sh   pass ***
***          dpa_check         test_regress_head.sh   pass ***
***          dpa_check           post_check_logs.py   pass ***
***          dpa_check              post_regress.py   pass ***
***          dpa_check         post_regress_head.py   pass ***
***               kadi         test_regress_long.sh   ---- ***
***               kadi                 test_unit.py   pass ***
***               kadi           post_check_logs.py   pass ***
***               kadi         post_regress_long.py   ---- ***
***              maude                 test_unit.py   pass ***
***              maude           post_check_logs.py   pass ***
***               mica                 test_unit.py   pass ***
***               mica           post_check_logs.py   pass ***
***   package_manifest              test_regress.sh   pass ***
***   package_manifest           post_check_logs.py   pass ***
***   package_manifest              post_regress.py   pass ***
***           parse_cm                 test_unit.py   pass ***
***           parse_cm           post_check_logs.py   pass ***
***            proseco                 test_unit.py   pass ***
***            proseco           post_check_logs.py   pass ***
***         psmc_check              test_regress.sh   pass ***
***         psmc_check         test_regress_head.sh   pass ***
***         psmc_check           post_check_logs.py   pass ***
***         psmc_check              post_regress.py   pass ***
***         psmc_check         post_regress_head.py   pass ***
***             pyyaks                 test_unit.py   pass ***
***             pyyaks           post_check_logs.py   pass ***
***           sparkles                 test_unit.py   pass ***
***           sparkles           post_check_logs.py   pass ***
***          starcheck              test_regress.sh   pass ***
***          starcheck           post_check_logs.py   pass ***
***          starcheck              post_regress.py   pass ***
***          timelines test_unit_git_sybase_long.sh   ---- ***
***          timelines           post_check_logs.py   ---- ***
***               xija                 test_unit.py   pass ***
***               xija           post_check_logs.py   pass ***
**************************************************************
```

# Checklist

- [x] Document all changes
- [x] Build all packages
   - [x] noarch
   - [x] linux 64
   - [x] mac 64
- [x] Packages copied to test channel
- [x] test status documented
- [x] get approval 
- [x] Individual packages moved to main conda channel
- [x] Update production systems:
   - [x] announce to aca@cfa
   - [x] ska3-flight package moved to main conda channel
   - [x] update aca@HEAD
   - [x] run testr@HEAD
   - [x] update sot@cheru
   - [x] update sot@chimchim
   - [x] announce to chandracode and mpweekly

# Fixes Issues

Fixes #325
Fixes #318
Fixes #331
Fixes #336
Fixes #335
Fixes #334
Fixes #337
Fixes #324
Fixes #319
Fixes #316
Fixes #327
Fixes #328
Fixes #330
Fixes #339
Fixes #313



