### PR TITLE
Release 2020.5

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: ska3-core
   version: 2020.5
 
+build:
+  number: 1
+
 requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core
-  version: 2020.01.10
+  version: 2020.5
 
 requirements:
   # Packages required to run the package. These are the dependencies that

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -198,6 +198,6 @@ requirements:
 
   # new additions
    - docxtpl ==0.6.3
-   - jira ==2.0.0
+   - jira ==2.0.0 # [not linux32]
    - mpld3 ==0.3
    - python-docx ==0.8.7

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -205,10 +205,10 @@ requirements:
    - mpld3 ==0.3
    - python-docx ==0.8.7
   # jira dependecies
-   - blinker ==1.4
-   - defusedxml ==0.6.0
-   - oauthlib ==3.1.0
-   - pbr ==5.4.4
-   - pyjwt ==1.7.1
-   - requests-oauthlib ==1.3.0
-   - requests-toolbelt ==0.9.1
+   - blinker ==1.4 # [not linux32]
+   - defusedxml ==0.6.0 # [not linux32]
+   - oauthlib ==3.1.0 # [not linux32]
+   - pbr ==5.4.4 # [not linux32]
+   - pyjwt ==1.7.1 # [not linux32]
+   - requests-oauthlib ==1.3.0 # [not linux32]
+   - requests-toolbelt ==0.9.1 # [not linux32]

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -195,3 +195,9 @@ requirements:
    - zeromq ==4.1.5 # [linux]
    - zlib ==1.2.8 # [linux32]
    - zlib ==1.2.11 # [linux64 or osx]
+
+  # new additions
+   - docxtpl ==0.6.3
+   - jira ==2.0.0
+   - mpld3 ==0.3
+   - python-docx ==0.8.7

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -201,3 +201,11 @@ requirements:
    - jira ==2.0.0 # [not linux32]
    - mpld3 ==0.3
    - python-docx ==0.8.7
+  # jira dependecies
+   - blinker ==1.4
+   - defusedxml ==0.6.0
+   - oauthlib ==3.1.0
+   - pbr ==5.4.4
+   - pyjwt ==1.7.1
+   - requests-oauthlib ==1.3.0
+   - requests-toolbelt ==0.9.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -34,9 +34,9 @@ requirements:
     - jplephem ==2.8
     - kadi ==5.0.1
     - maude ==3.3.1
-    - mica ==4.21.0
+    - mica ==4.21.1
     - parse_cm ==3.5.2
-    - proseco ==4.8.0
+    - proseco ==4.8.1
     - psmc_check ==3.0.0
     - pyyaks ==4.4.2
     - quaternion ==3.5.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.4
+  version: 2020.5
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -9,7 +9,7 @@ requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
-    - ska3-core ==2020.01.10
+    - ska3-core ==2020.5
     - ska3-template ==2019.09.03
     - aca_view ==0.3.0
     - acdc ==4.5.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-matlab
-  version: 2020.02.27
+  version: 2020.4
 
 build:
   noarch: generic
@@ -11,31 +11,35 @@ requirements:
   run:
     - ska3-core ==2020.01.10
     - ska3-template ==2019.09.03
-    - acdc ==4.4.1
-    - agasc ==4.8.0
-    - acisfp_check ==2.7.1
+    - aca_view ==0.3.0
+    - acdc ==4.5.0
+    - agasc ==4.8.1
+    - acisfp_check ==3.0.0
     - acis_taco ==4.1.0
-    - acis_thermal_check ==2.9.1
-    - annie ==0.9.1
-    - backstop_history ==1.1.1
-    - chandra_aca ==4.29.0
+    - acis_thermal_check ==3.0.0
+    - annie ==0.10.1
+    - backstop_history ==1.1.3
+    - bep_pcb_check ==3.0.0
     - chandra.cmd_states ==3.15.1
     - chandra.maneuver ==3.7.2
     - chandra.time ==3.20.4
+    - chandra_aca ==4.29.1
     - cxotime ==3.1.1
-    - dea_check ==2.3.1
-    - dpa_check ==2.5.1
+    - dea_check ==3.0.0
+    - dpa_check ==3.0.0
     - find_attitude ==3.3.2
+    - fep1_actel_check ==3.0.0
+    - fep1_mong_check ==3.0.0
     - hopper ==4.4.1
     - jplephem ==2.8
     - kadi ==5.0.1
     - maude ==3.3.1
-    - mica ==4.20.0
-    - parse_cm ==3.5.1
-    - proseco ==4.8.0
-    - psmc_check ==1.3.0
-    - pyyaks ==4.4.1
-    - quaternion ==3.5.1
+    - mica ==4.21.1
+    - parse_cm ==3.5.2
+    - proseco ==4.8.1
+    - psmc_check ==3.0.0
+    - pyyaks ==4.4.2
+    - quaternion ==3.5.2
     - ska.arc5gl ==3.1.3
     - ska.astro ==3.2.3
     - ska.dbi ==4.0.1
@@ -52,8 +56,8 @@ requirements:
     - ska.shell ==3.4.0
     - ska.sun ==3.5.2
     - ska.tdb ==3.5.2
-    - sparkles ==4.5.0
+    - sparkles ==4.6.0
     - starcheck ==13.5.1
     - tables3_api ==0.1.1
     - testr ==4.3.1
-    - xija ==4.17.1
+    - xija ==4.18.2

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-matlab
-  version: 2020.4
+  version: 2020.5
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -9,7 +9,7 @@ requirements:
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:
-    - ska3-core ==2020.01.10
+    - ska3-core ==2020.5
     - ska3-template ==2019.09.03
     - aca_view ==0.3.0
     - acdc ==4.5.0


### PR DESCRIPTION
Release 2020.5 includes two package updates to ska3-flight and "catches up" ska3-matlab to ska3-flight.  As the package set described by ska3-matlab and ska3-flight for this release is the same, this has been tested and reviewed as single release candidate.  Changes summarized and described below for the two environments.

# ska3-flight 2020.5

## Summary:

The ska3-flight 2020 release includes:
   * a small bugfix to proseco required to correctly calculate and use acquisition probabilities in starcheck   
   * a small update to the mica package to fix issues in its cron jobs related to the Python 3 migration

## Interface Impacts:
   * None

## Testing:
   * Release passes Python Ska3 functional and integration testing.

## Review:
   * All PRs reviewed by ACA team.

## Deployment:
   * The 2020.5 ska3-flight release will be deployed on HEAD and GRETA ska3/flight after the release and products for the week are approved.

## Code changes:

**sot/proseco: 4.8.0 -> 4.8.1** (4.8.0 -> 4.8.1)
  - [PR 325](https://github.com/sot/proseco/pull/325): **Fix bug in halfws for force-include acq stars**

**sot/mica: 4.21.0 -> 4.21.1** (4.21.0 -> 4.21.1)
  - [PR 220](https://github.com/sot/mica/pull/220): Silly process fixes (Small updates mostly to the scripts that run the cron jobs that fetch mica archive data and process pieces for mica derived products such as mica.vv and mica.report.  These fixes accompany the PY3 updates that went in the last release).

## "core" packages additions:

These packages will be added and are not used by any ska package:
 
- python-docx & docxtpl: #345
```
   docxtpl:     0.6.3-py_0
   python-docx: 0.8.7-py_0
```
- mpld3 (#341)
```
   mpld3: 0.3-py_2
```
- jira (#315)
```
   jira:              2.0.0-py_0
   blinker:           1.4-py36_0
   defusedxml:        0.6.0-py_0
   oauthlib:          3.1.0-py_0
   pbr:               5.4.4-py_0
   pyjwt:             1.7.1-py36_0
   requests-oauthlib: 1.3.0-py_0
   requests-toolbelt: 0.9.1-py_0
```

# ska3-matlab 2020.5

## Summary:

The ska3-matlab 2020.5 release includes:
   * a small bugfix to proseco 
and a collection of updates that are expected to be non-impacting in the Matlab tools including:
   * the new ACIS bep fep checkers  
   * updates to the ACIS checkers to support acis_thermal_check 3.0   
   * the improved gui_fit in xija  
   * the addition of aca_view, the new graphical interface to ACA telemetry data

## Code changes:
   * Full list of PRs / changes included below

## Interface Impacts:
   * None

## Testing:
   * Release passes Python Ska3 functional and integration testing.

## Review:
   * All PRs reviewed by ACA team and ACIS team as appropriate.  
   * This will go to FMTCB and FDB for review before promotion to ska3/matlab*/flight
## Deployment:
   * The 2020.5 ska3-matlab release wil be deployed on GRETA ska3/matlab*/test for integration testing immediately.  After approval at FMTCB and FDB, the release will be deployed to ska3/matlab*/flight on GRETA and FOT laptops.

## Full list of PRs / changes

**acisops/acis_thermal_check:** 2.9.1 -> 3.0.0 (2.9.1 -> 2.9.2 -> 2.9.3 -> 3.0.0)
  - [PR 24](https://github.com/acisops/acis_thermal_check/pull/24): Remove unnecessary stuff in setup.py
  - [PR 26](https://github.com/acisops/acis_thermal_check/pull/26): Setting up automated builds
  - [PR 25](https://github.com/acisops/acis_thermal_check/pull/25): acis_thermal_check 3.0

**acisops/acisfp_check: 2.7.1 -> 3.0.0** (2.7.1 -> 2.7.2 -> 2.7.3 -> 3.0.0)
  - [PR 18](https://github.com/acisops/acisfp_check/pull/18): Clear out setup.py of unnecessary stuff
  - [PR 19](https://github.com/acisops/acisfp_check/pull/19): Setting up automated builds
  - [PR 21](https://github.com/acisops/acisfp_check/pull/21): update acisfp_check for acis_thermal_check 3.0

**acisops/backstop_history: 1.1.1 -> 1.1.3** (1.1.1 -> 1.1.2 -> 1.1.3)
  - [PR 7](https://github.com/acisops/backstop_history/pull/7): Remove version from setup.py
  - [PR 8](https://github.com/acisops/backstop_history/pull/8): Setting up automated builds

**acisops/dea_check: 2.3.1 -> 3.0.0** (2.3.1 -> 2.3.2 -> 2.3.3 -> 3.0.0)
  - [PR 20](https://github.com/acisops/dea_check/pull/20): Don't use version in setup.py
  - [PR 21](https://github.com/acisops/dea_check/pull/21): Setting up automated builds
  - [PR 22](https://github.com/acisops/dea_check/pull/22): update dea_check for acis_thermal_check 3.0

**acisops/dpa_check: 2.5.1 -> 3.0.0** (2.5.1 -> 2.5.2 -> 2.5.3 -> 3.0.0)
  - [PR 19](https://github.com/acisops/dpa_check/pull/19): Remove version from setup.py
  - [PR 20](https://github.com/acisops/dpa_check/pull/20): Setting up automated builds
  - [PR 21](https://github.com/acisops/dpa_check/pull/21): update dpa_check for acis_thermal_check 3.0

**acisops/psmc_check: 1.3.0 -> 3.0.0** (1.3.0 -> 1.3.1 -> 1.3.2 -> 3.0.0)
  - [PR 18](https://github.com/acisops/psmc_check/pull/18): Remove version from setup.py
  - [PR 19](https://github.com/acisops/psmc_check/pull/19): Setting up automated builds
  - [PR 20](https://github.com/acisops/psmc_check/pull/20): update psmc_check for acis_thermal_check 3.0

**sot/acdc: 4.4.1 -> 4.5.0** (4.4.1 -> 4.5.0)
  - [PR 46](https://github.com/sot/acdc/pull/46): Setting up automated builds
  - [PR 48](https://github.com/sot/acdc/pull/48): Write out updated sparkles pkl
  - [PR 47](https://github.com/sot/acdc/pull/47): Fiddle with the scaling for the warm pix plot

**sot/agasc: 4.8.0 -> 4.8.1** (4.8.0 -> 4.8.1)
  - [PR 41](https://github.com/sot/agasc/pull/41): Setting up automated builds
  - [PR 42](https://github.com/sot/agasc/pull/42): Make tests pass on Windows

**sot/annie: 0.9.1 -> 0.10.1** (0.9.1 -> 0.10.0 -> 0.10.1)
  - [PR 98](https://github.com/sot/annie/pull/98): Setting up automated builds
  - [PR 97](https://github.com/sot/annie/pull/97): End simulation at large att offset
  - [PR 100](https://github.com/sot/annie/pull/100): Minor test fix to pass on windows

**sot/chandra_aca: 4.29.0 -> 4.29.1** (4.29.0 -> 4.29.1)
  - [PR 93](https://github.com/sot/chandra_aca/pull/93): change to fix release workflow
  - [PR 96](https://github.com/sot/chandra_aca/pull/96): Make test_get_aimpoint work without being on VPN

**sot/mica: 4.20.0 -> 4.21.1** (4.20.0 -> 4.21.0 -> 4.21.1)
  - [PR 173](https://github.com/sot/mica/pull/173): Refactor stats into update and get_stats modules
  - [PR 215](https://github.com/sot/mica/pull/215): Setting up automated builds
  - [PR 214](https://github.com/sot/mica/pull/214): Remove dark model
  - [PR 219](https://github.com/sot/mica/pull/219): Mag stats
  - [PR 218](https://github.com/sot/mica/pull/218): Minor PY3 updates and DS10.8.3 update for mica vv processing
  - [PR 220](https://github.com/sot/mica/pull/220): Silly process fixes

**sot/parse_cm: 3.5.1 -> 3.5.2** (3.5.1 -> 3.5.2)
  - [PR 20](https://github.com/sot/parse_cm/pull/20): Setting up automated builds
  - [PR 21](https://github.com/sot/parse_cm/pull/21): Fix tests and code to pass on Windows

**sot/proseco: 4.8.0 -> 4.8.1** (4.8.0 -> 4.8.1)
  - [PR 325](https://github.com/sot/proseco/pull/325): **Fix bug in halfws for force-include acq stars**

**sot/pyyaks: 4.4.1 -> 4.4.2** (4.4.1 -> 4.4.2)
  - [PR 10](https://github.com/sot/pyyaks/pull/10): Setting up automated builds
  - [PR 11](https://github.com/sot/pyyaks/pull/11): Fix tests to pass on Windows

**sot/Quaternion: 3.5.1 -> 3.5.2** (3.5.1 -> 3.5.2)
  - [PR 28](https://github.com/sot/Quaternion/pull/28): Properly unpickle quaternions from versions earlier than 3.5

**sot/sparkles: 4.5.0 -> 4.6.0** (4.5.0 -> 4.6.0)
  - [PR 140](https://github.com/sot/sparkles/pull/140): Add info statement for include / exclude

**sot/xija: 4.17.1 -> 4.18.2** (4.17.1 -> 4.18.0 -> 4.18.1 -> 4.18.2)
  - [PR 69](https://github.com/sot/xija/pull/69): gui_fit upgrades
  - [PR 83](https://github.com/sot/xija/pull/83): [bugfix] Wrong line is updated in gui_fit
  - [PR 84](https://github.com/sot/xija/pull/84): Fix bug in looking for bad times


# Testing status

The test failures have been reviewed and are acceptable:

   * Ska.engarchive test failure is a known and non-impacting issue with the sync process / sync test.
   * Ska.quatutil failure is due to a know and non-impacting test defect.
   * maude failure is due to an acceptable regression caused by the recent MAUDE data updates

## test_spec_SKA3_HEAD on kady
```
**************************************************************
***      Package                  Script            Status ***
*** ------------------ ---------------------------- ------ ***
***   Chandra.Maneuver                 test_unit.py   pass ***
***   Chandra.Maneuver           post_check_logs.py   pass ***
***       Chandra.Time                 test_unit.py   pass ***
***       Chandra.Time           post_check_logs.py   pass ***
*** Chandra.cmd_states                 test_unit.py   pass ***
*** Chandra.cmd_states           post_check_logs.py   pass ***
***         Quaternion                 test_unit.py   pass ***
***         Quaternion           post_check_logs.py   pass ***
***            Ska.DBI                 test_unit.py   pass ***
***            Ska.DBI           post_check_logs.py   pass ***
***          Ska.Numpy                 test_unit.py   pass ***
***          Ska.Numpy           post_check_logs.py   pass ***
***        Ska.ParseCM             test_unit_git.sh   pass ***
***        Ska.ParseCM           post_check_logs.py   pass ***
***          Ska.Shell                 test_unit.py   pass ***
***          Ska.Shell           post_check_logs.py   pass ***
***          Ska.Table             test_unit_git.sh   ---- ***
***          Ska.Table           post_check_logs.py   ---- ***
***     Ska.engarchive    test_make_archive_long.sh   ---- ***
***     Ska.engarchive                 test_unit.py   FAIL ***
***     Ska.engarchive           post_check_logs.py   FAIL ***
***            Ska.ftp                 test_unit.py   pass ***
***            Ska.ftp           post_check_logs.py   pass ***
***       Ska.quatutil             test_unit_git.sh   pass ***
***       Ska.quatutil           post_check_logs.py   FAIL ***
***            Ska.tdb                 test_unit.py   pass ***
***            Ska.tdb           post_check_logs.py   pass ***
***          acis_taco                 test_unit.py   pass ***
***          acis_taco           post_check_logs.py   pass ***
***       acisfp_check              test_regress.sh   pass ***
***       acisfp_check         test_regress_head.sh   pass ***
***       acisfp_check           post_check_logs.py   pass ***
***       acisfp_check              post_regress.py   pass ***
***       acisfp_check         post_regress_head.py   pass ***
***              agasc                 test_unit.py   pass ***
***              agasc           post_check_logs.py   pass ***
***              annie                 test_unit.py   pass ***
***              annie           post_check_logs.py   pass ***
***        chandra_aca                 test_unit.py   pass ***
***        chandra_aca           post_check_logs.py   pass ***
***            cxotime                 test_unit.py   pass ***
***            cxotime           post_check_logs.py   pass ***
***          dea_check              test_regress.sh   pass ***
***          dea_check         test_regress_head.sh   pass ***
***          dea_check           post_check_logs.py   pass ***
***          dea_check              post_regress.py   pass ***
***          dea_check         post_regress_head.py   pass ***
***          dpa_check              test_regress.sh   pass ***
***          dpa_check         test_regress_head.sh   pass ***
***          dpa_check           post_check_logs.py   pass ***
***          dpa_check              post_regress.py   pass ***
***          dpa_check         post_regress_head.py   pass ***
***               kadi         test_regress_long.sh   ---- ***
***               kadi                 test_unit.py   pass ***
***               kadi           post_check_logs.py   pass ***
***               kadi         post_regress_long.py   ---- ***
***              maude                 test_unit.py   FAIL ***
***              maude           post_check_logs.py   FAIL ***
***               mica                 test_unit.py   pass ***
***               mica           post_check_logs.py   pass ***
***   package_manifest              test_regress.sh   pass ***
***   package_manifest           post_check_logs.py   pass ***
***   package_manifest              post_regress.py   pass ***
***           parse_cm                 test_unit.py   pass ***
***           parse_cm           post_check_logs.py   pass ***
***            proseco                 test_unit.py   pass ***
***            proseco           post_check_logs.py   pass ***
***         psmc_check              test_regress.sh   pass ***
***         psmc_check         test_regress_head.sh   pass ***
***         psmc_check           post_check_logs.py   pass ***
***         psmc_check              post_regress.py   pass ***
***         psmc_check         post_regress_head.py   pass ***
***             pyyaks                 test_unit.py   pass ***
***             pyyaks           post_check_logs.py   pass ***
***           sparkles                 test_unit.py   pass ***
***           sparkles           post_check_logs.py   pass ***
***          starcheck              test_regress.sh   pass ***
***          starcheck           post_check_logs.py   pass ***
***          starcheck              post_regress.py   pass ***
***          timelines test_unit_git_sybase_long.sh   ---- ***
***          timelines           post_check_logs.py   ---- ***
***               xija                 test_unit.py   pass ***
***               xija           post_check_logs.py   pass ***
**************************************************************
```
# Fixes Issues

Fixes #345
Fixes #341
Fixes #315
Fixes #346
Fixes #348
Fixes #347




