### PR TITLE
Release 2020.6

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - hopper ==4.4.1
     - jplephem ==2.8
     - kadi ==5.2.0
-    - maude ==3.3.1
+    - maude ==3.3.2
     - mica ==4.21.1
     - parse_cm ==3.5.2
     - proseco ==4.8.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.5
+  version: 2020.6
 
 build:
   noarch: generic
@@ -20,9 +20,9 @@ requirements:
     - annie ==0.10.1
     - backstop_history ==1.1.3
     - bep_pcb_check ==3.0.0
-    - chandra.cmd_states ==3.15.1
-    - chandra.maneuver ==3.7.2
-    - chandra.time ==3.20.4
+    - chandra.cmd_states ==3.15.2
+    - chandra.maneuver ==3.7.3
+    - chandra.time ==3.20.6
     - chandra_aca ==4.29.1
     - cxotime ==3.1.1
     - dea_check ==3.0.0
@@ -32,7 +32,7 @@ requirements:
     - fep1_mong_check ==3.0.0
     - hopper ==4.4.1
     - jplephem ==2.8
-    - kadi ==5.0.1
+    - kadi ==5.1.0
     - maude ==3.3.1
     - mica ==4.21.1
     - parse_cm ==3.5.2
@@ -40,22 +40,22 @@ requirements:
     - psmc_check ==3.0.0
     - pyyaks ==4.4.2
     - quaternion ==3.5.2
-    - ska.arc5gl ==3.1.3
-    - ska.astro ==3.2.3
-    - ska.dbi ==4.0.1
-    - ska.engarchive ==4.47.4
-    - ska.file ==3.4.3
-    - ska.ftp ==3.5.2
-    - ska.numpy ==3.8.2
-    - ska.matplotlib ==3.11.3
-    - ska.parsecm ==3.3.3
-    - ska_helpers ==0.1.0
+    - ska.arc5gl ==3.1.4
+    - ska.astro ==3.2.4
+    - ska.dbi ==4.0.2
+    - ska.engarchive ==4.48.0
+    - ska.file ==3.4.4
+    - ska.ftp ==3.5.3
+    - ska.numpy ==3.8.4
+    - ska.matplotlib ==3.11.4
+    - ska.parsecm ==3.3.4
+    - ska_helpers ==0.1.1
     - ska_path ==3.1.1
     - ska_sync ==4.6.0
-    - ska.quatutil ==3.3.2
-    - ska.shell ==3.4.0
-    - ska.sun ==3.5.2
-    - ska.tdb ==3.5.2
+    - ska.quatutil ==3.3.3
+    - ska.shell ==3.4.1
+    - ska.sun ==3.5.3
+    - ska.tdb ==3.5.3
     - sparkles ==4.6.0
     - starcheck ==13.5.1
     - tables3_api ==0.1.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - agasc ==4.8.1
     - acisfp_check ==3.0.0
     - acis_taco ==4.1.0
-    - acis_thermal_check ==3.0.0
+    - acis_thermal_check ==3.1.0
     - annie ==0.10.1
     - backstop_history ==1.1.3
     - bep_pcb_check ==3.0.0
@@ -32,7 +32,7 @@ requirements:
     - fep1_mong_check ==3.0.0
     - hopper ==4.4.1
     - jplephem ==2.8
-    - kadi ==5.1.0
+    - kadi ==5.2.0
     - maude ==3.3.1
     - mica ==4.21.1
     - parse_cm ==3.5.2
@@ -57,7 +57,7 @@ requirements:
     - ska.sun ==3.5.3
     - ska.tdb ==3.5.3
     - sparkles ==4.6.0
-    - starcheck ==13.5.1
+    - starcheck ==13.6.0
     - tables3_api ==0.1.1
     - testr ==4.3.1
     - xija ==4.18.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - jplephem ==2.8
     - kadi ==5.2.0
     - maude ==3.3.2
-    - mica ==4.21.1
+    - mica ==4.21.2
     - parse_cm ==3.5.2
     - proseco ==4.8.1
     - psmc_check ==3.0.0


### PR DESCRIPTION
# ska3-flight 2020.6

## Summary:
The ska3-flight 2020.6 release includes:
   * starcheck updates to
      * work better with the April ACA CCD limit increase
      * support RLTT and schedule stop
   * kadi commands-related updates to
      * support the starcheck RLTT and schedule stop change
      * add support for ACIS FP state
   * eng_archive update to support computed msids
   * Ska and Chandra are now "native namespace packages". This is a purely technical change that makes maintenance easier. 
   * Documentation for acis_thermal_check

## Interface Impacts:
   * None
## Testing:
   * Standard suite of regression tests was run on HEAD (summary below)
   * One Ska.engarchive test fails. This test was reported failing in the previous release, so here we note again: this test failure is a known and non-impacting issue with the sync process / sync test.
## Review:
   * PRs (see changes below) have been reviewed by the ACA team.
## Deployment:
   *  The 2020.6 ska3-flight release will be deployed on HEAD and GRETA ska3/flight after the release and products for the week are approved.
# Code changes

## ska3-flight (2020.5 -> 2020.6rc3)

**acisops/acis_thermal_check:** 3.0.0 -> 3.1.0 (3.0.0 -> 3.1.0)
  - [PR 27](https://github.com/acisops/acis_thermal_check/pull/27): Documentation for acis_thermal_check

**sot/Chandra.Maneuver:** 3.7.2 -> 3.7.3 (3.7.2 -> 3.7.3)
  - [PR 17](https://github.com/sot/Chandra.Maneuver/pull/17): Setting up automated builds
  - [PR 16](https://github.com/sot/Chandra.Maneuver/pull/16): Make namespace package native

**sot/Chandra.Time:** 3.20.4 -> 3.20.6 (3.20.4 -> 3.20.5 -> 3.20.6)
  - [PR 38](https://github.com/sot/Chandra.Time/pull/38): Setting up automated builds
  - [PR 37](https://github.com/sot/Chandra.Time/pull/37): Make namespace package native
  - [PR 39](https://github.com/sot/Chandra.Time/pull/39): Fix the location of the C extension

**sot/cmd_states:** 3.15.1 -> 3.15.2 (3.15.1 -> 3.15.2)
  - [PR 49](https://github.com/sot/cmd_states/pull/49): Setting up automated builds
  - [PR 48](https://github.com/sot/cmd_states/pull/48): Make namespace package native

**sot/eng_archive:** 4.47.4 -> 4.48.0 (4.47.4 -> 4.48.0)
  - [PR 190](https://github.com/sot/eng_archive/pull/190): Setting up automated builds
  - [PR 188](https://github.com/sot/eng_archive/pull/188): Allow a fixed number of sync dirs instead of removing by date
  - [PR 191](https://github.com/sot/eng_archive/pull/191): Add code to support and test computed MSIDs
  - [PR 193](https://github.com/sot/eng_archive/pull/193): Add MSID title and unit y-label to plot
  - [PR 189](https://github.com/sot/eng_archive/pull/189): Make namespace package native

**sot/kadi:** 5.0.1 -> 5.2.0 (5.0.1 -> 5.1.0 -> 5.2.0)
  - [PR 159](https://github.com/sot/kadi/pull/159): Fix test to run on Windows
  - [PR 162](https://github.com/sot/kadi/pull/162): Improve get_cmds_from_backstop
  - [PR 161](https://github.com/sot/kadi/pull/161): Add acisfp_setpoint state
  - [PR 163](https://github.com/sot/kadi/pull/163): Add inclusive_stop kwarg to get_cmds
  - [PR 164](https://github.com/sot/kadi/pull/164): Allow start and stop in get_states() with cmds

**sot/maude:** 3.3.1 -> 3.3.2 (3.3.1 -> 3.3.2)
  - [PR 20](https://github.com/sot/maude/pull/20): Setting up automated builds
  - [PR 21](https://github.com/sot/maude/pull/21): Update regression test to reflect new MAUDE FLIGHT processing

**sot/mica:** 4.21.1 -> 4.21.2 (4.21.1 -> 4.21.2)
  - [PR 221](https://github.com/sot/mica/pull/221): Recast dark cal image to native byte order
  - [PR 222](https://github.com/sot/mica/pull/222): Change sybase skip test to check for more restrictive vv creds
  - [PR 223](https://github.com/sot/mica/pull/223): Use github token authentication in workflow

**sot/Ska.arc5gl:** 3.1.3 -> 3.1.4 (3.1.3 -> 3.1.4)
  - [PR 8](https://github.com/sot/Ska.arc5gl/pull/8): Setting up automated builds
  - [PR 7](https://github.com/sot/Ska.arc5gl/pull/7): Make namespace package native

**sot/Ska.astro:** 3.2.3 -> 3.2.4 (3.2.3 -> 3.2.4)
  - [PR 8](https://github.com/sot/Ska.astro/pull/8): Setting up automated builds
  - [PR 7](https://github.com/sot/Ska.astro/pull/7): Make namespace package native

**sot/Ska.DBI:** 4.0.1 -> 4.0.2 (4.0.1 -> 4.0.2)
  - [PR 15](https://github.com/sot/Ska.DBI/pull/15): Setting up automated builds
  - [PR 16](https://github.com/sot/Ska.DBI/pull/16): Fix / improve tests to run on Windows
  - [PR 14](https://github.com/sot/Ska.DBI/pull/14): Make namespace package native

**sot/Ska.File:** 3.4.3 -> 3.4.4 (3.4.3 -> 3.4.4)
  - [PR 9](https://github.com/sot/Ska.File/pull/9): Setting up automated builds
  - [PR 8](https://github.com/sot/Ska.File/pull/8): Make namespace package native

**sot/Ska.ftp:** 3.5.2 -> 3.5.3 (3.5.2 -> 3.5.3)
  - [PR 19](https://github.com/sot/Ska.ftp/pull/19): Setting up automated builds
  - [PR 20](https://github.com/sot/Ska.ftp/pull/20): Windows compatibility
  - [PR 18](https://github.com/sot/Ska.ftp/pull/18): Make namespace package native

**sot/Ska.Matplotlib:** 3.11.3 -> 3.11.4 (3.11.3 -> 3.11.4)
  - [PR 12](https://github.com/sot/Ska.Matplotlib/pull/12): Setting up automated builds
  - [PR 11](https://github.com/sot/Ska.Matplotlib/pull/11): Make namespace package native

**sot/Ska.Numpy:** 3.8.2 -> 3.8.4 (3.8.2 -> 3.8.3 -> 3.8.4)
  - [PR 5](https://github.com/sot/Ska.Numpy/pull/5): Setting up automated builds
  - [PR 4](https://github.com/sot/Ska.Numpy/pull/4): Make namespace package native
  - [PR 6](https://github.com/sot/Ska.Numpy/pull/6): Fix the location of the C extension

**sot/Ska.ParseCM:** 3.3.3 -> 3.3.4 (3.3.3 -> 3.3.4)
  - [PR 7](https://github.com/sot/Ska.ParseCM/pull/7): Setting up automated builds
  - [PR 6](https://github.com/sot/Ska.ParseCM/pull/6): Make namespace package native

**sot/Ska.quatutil:** 3.3.2 -> 3.3.3 (3.3.2 -> 3.3.3)
  - [PR 9](https://github.com/sot/Ska.quatutil/pull/9): Setting up automated builds
  - [PR 8](https://github.com/sot/Ska.quatutil/pull/8): Make namespace package native

**sot/Ska.Shell:** 3.4.0 -> 3.4.1 (3.4.0 -> 3.4.1)
  - [PR 17](https://github.com/sot/Ska.Shell/pull/17): Setting up automated builds
  - [PR 18](https://github.com/sot/Ska.Shell/pull/18): Skip all tests on Windows
  - [PR 16](https://github.com/sot/Ska.Shell/pull/16): Make namespace package native

**sot/Ska.Sun:** 3.5.2 -> 3.5.3 (3.5.2 -> 3.5.3)
  - [PR 11](https://github.com/sot/Ska.Sun/pull/11): Setting up automated builds
  - [PR 10](https://github.com/sot/Ska.Sun/pull/10): Make namespace package native

**sot/Ska.tdb:** 3.5.2 -> 3.5.3 (3.5.2 -> 3.5.3)
  - [PR 11](https://github.com/sot/Ska.tdb/pull/11): Setting up automated builds
  - [PR 10](https://github.com/sot/Ska.tdb/pull/10): Make namespace package native

**sot/ska_helpers:** 0.1.0 -> 0.1.1 (0.1.0 -> 0.1.1)
  - [PR 9](https://github.com/sot/ska_helpers/pull/9): Setting up automated builds
  - [PR 10](https://github.com/sot/ska_helpers/pull/10): when running testr, avoid emitting this warning

**sot/starcheck:** 13.5.1 -> 13.6.0 (13.5.1 -> 13.6.0)
  - [PR 339](https://github.com/sot/starcheck/pull/339): Setting up automated builds
  - [PR 342](https://github.com/sot/starcheck/pull/342): Update ccd red/yellow limits for Apr2020 increase
  - [PR 343](https://github.com/sot/starcheck/pull/343): Use chandra_aca's guide_count for the perigee bright star check
  - [PR 344](https://github.com/sot/starcheck/pull/344): Use RLTT and schedule_stop in thermal calculation

# Testing

```
**************************************************************
***      Package                  Script            Status ***
*** ------------------ ---------------------------- ------ ***
***   Chandra.Maneuver                 test_unit.py   pass ***
***   Chandra.Maneuver           post_check_logs.py   pass ***
***       Chandra.Time                 test_unit.py   pass ***
***       Chandra.Time           post_check_logs.py   pass ***
*** Chandra.cmd_states                 test_unit.py   pass ***
*** Chandra.cmd_states           post_check_logs.py   pass ***
***         Quaternion                 test_unit.py   pass ***
***         Quaternion           post_check_logs.py   pass ***
***            Ska.DBI                 test_unit.py   pass ***
***            Ska.DBI           post_check_logs.py   pass ***
***          Ska.Numpy                 test_unit.py   pass ***
***          Ska.Numpy           post_check_logs.py   pass ***
***        Ska.ParseCM             test_unit_git.sh   pass ***
***        Ska.ParseCM           post_check_logs.py   pass ***
***          Ska.Shell                 test_unit.py   pass ***
***          Ska.Shell           post_check_logs.py   pass ***
***          Ska.Table             test_unit_git.sh   ---- ***
***          Ska.Table           post_check_logs.py   ---- ***
***     Ska.engarchive    test_make_archive_long.sh   ---- ***
***     Ska.engarchive                 test_unit.py   FAIL ***
***     Ska.engarchive           post_check_logs.py   FAIL ***
***            Ska.ftp                 test_unit.py   pass ***
***            Ska.ftp           post_check_logs.py   pass ***
***       Ska.quatutil             test_unit_git.sh   pass ***
***       Ska.quatutil           post_check_logs.py   pass ***
***            Ska.tdb                 test_unit.py   pass ***
***            Ska.tdb           post_check_logs.py   pass ***
***          acis_taco                 test_unit.py   pass ***
***          acis_taco           post_check_logs.py   pass ***
***       acisfp_check              test_regress.sh   pass ***
***       acisfp_check         test_regress_head.sh   pass ***
***       acisfp_check           post_check_logs.py   pass ***
***       acisfp_check              post_regress.py   pass ***
***       acisfp_check         post_regress_head.py   pass ***
***              agasc                 test_unit.py   pass ***
***              agasc           post_check_logs.py   pass ***
***              annie                 test_unit.py   pass ***
***              annie           post_check_logs.py   pass ***
***        chandra_aca                 test_unit.py   pass ***
***        chandra_aca           post_check_logs.py   pass ***
***            cxotime                 test_unit.py   pass ***
***            cxotime           post_check_logs.py   pass ***
***          dea_check              test_regress.sh   pass ***
***          dea_check         test_regress_head.sh   pass ***
***          dea_check           post_check_logs.py   pass ***
***          dea_check              post_regress.py   pass ***
***          dea_check         post_regress_head.py   pass ***
***          dpa_check              test_regress.sh   pass ***
***          dpa_check         test_regress_head.sh   pass ***
***          dpa_check           post_check_logs.py   pass ***
***          dpa_check              post_regress.py   pass ***
***          dpa_check         post_regress_head.py   pass ***
***               kadi         test_regress_long.sh   ---- ***
***               kadi                 test_unit.py   pass ***
***               kadi           post_check_logs.py   pass ***
***               kadi         post_regress_long.py   ---- ***
***              maude                 test_unit.py   pass ***
***              maude           post_check_logs.py   pass ***
***               mica                 test_unit.py   pass ***
***               mica           post_check_logs.py   pass ***
***   package_manifest              test_regress.sh   pass ***
***   package_manifest           post_check_logs.py   pass ***
***   package_manifest              post_regress.py   pass ***
***           parse_cm                 test_unit.py   pass ***
***           parse_cm           post_check_logs.py   pass ***
***            proseco                 test_unit.py   pass ***
***            proseco           post_check_logs.py   pass ***
***         psmc_check              test_regress.sh   pass ***
***         psmc_check         test_regress_head.sh   pass ***
***         psmc_check           post_check_logs.py   pass ***
***         psmc_check              post_regress.py   pass ***
***         psmc_check         post_regress_head.py   pass ***
***             pyyaks                 test_unit.py   pass ***
***             pyyaks           post_check_logs.py   pass ***
***           sparkles                 test_unit.py   pass ***
***           sparkles           post_check_logs.py   pass ***
***          starcheck              test_regress.sh   pass ***
***          starcheck           post_check_logs.py   pass ***
***          starcheck              post_regress.py   pass ***
***          timelines test_unit_git_sybase_long.sh   ---- ***
***          timelines           post_check_logs.py   ---- ***
***               xija                 test_unit.py   pass ***
***               xija           post_check_logs.py   pass ***
**************************************************************
```
# Related Issues

Fixes #371
Fixes #376
Fixes #377
Fixes #353
Fixes #375
Fixes #354
Fixes #355
Fixes #361
Fixes #362
Fixes #364
Fixes #365
Fixes #366
Fixes #368
Fixes #369
Fixes #359
Fixes #360
Fixes #363
Fixes #367
Fixes #370
Fixes #356
Fixes #357
Fixes #358
Fixes #381
