### PR TITLE
Update recipes to make bin dir

### DIFF
--- a/pkg_defs/task_schedule/build.sh
+++ b/pkg_defs/task_schedule/build.sh
@@ -1,3 +1,4 @@
+mkdir ${PREFIX}/bin
 cp -p task_schedule3.pl ${PREFIX}/bin
 chmod +x ${PREFIX}/bin/task_schedule3.pl
 

--- a/pkg_defs/watch_cron_logs/build.sh
+++ b/pkg_defs/watch_cron_logs/build.sh
@@ -1,3 +1,4 @@
+mkdir ${PREFIX}/bin
 cp -p watch_cron_logs3.pl ${PREFIX}/bin
 chmod +x ${PREFIX}/bin/watch_cron_logs3.pl
 


### PR DESCRIPTION
Update recipes to make bin dir

These simple builds don't work with modern conda without this change.