### PR TITLE
WIP: refactor, modernize, improve ska_builder.py

### DIFF
--- a/pkg_defs/Chandra.Maneuver/meta.yaml
+++ b/pkg_defs/Chandra.Maneuver/meta.yaml
@@ -20,8 +20,6 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
-    - quaternion
-    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/backstop_history/meta.yaml
+++ b/pkg_defs/backstop_history/meta.yaml
@@ -20,8 +20,6 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
-    # Mistake in backstop_history/setup.py:
-    - ska_helpers
 
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core-latest
-  version: 2020.2
+  version: 2020.2.1
 
 requirements:
   run:
@@ -13,18 +13,21 @@ requirements:
    - conda
    - conda-build
    - cython
-   - django >=3.0
+   - docxtpl
+   - django
    - git # [win]
    - gitpython
    - h5py
    - ipython
    - jinja2
+   - jira
    - jplephem
    - jupyter
    - jupyterlab
    - line_profiler
    - lxml
    - matplotlib
+   - mpld3
    - nb_conda
    - nbconvert
    - networkx
@@ -40,6 +43,7 @@ requirements:
    - flake8
    - pycrypto
    - pylint
+   - python-docx
    - pyyaml
    - qt
    - requests

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -3,13 +3,13 @@
 import sys
 import os
 import subprocess
-import git
 import re
 import argparse
 import platform
 import shutil
 from pathlib import Path
 
+import git
 from astropy.table import Table
 import jinja2
 import yaml
@@ -45,8 +45,8 @@ def get_opt():
                         help="Build version of NumPy")
     parser.add_argument("--github-https", action="store_true", default=False,
                         help="Authenticate using basic auth and https. Default is ssh.")
-    parser.add_argument("--github-org",
-                        help="Use this org instead of org in meta (mostly for forked packages)")
+    parser.add_argument("--repo-url",
+                        help="Use this URL instead of meta['about']['home']")
 
     args = parser.parse_args()
     return args

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -188,7 +188,7 @@ def main():
 
     BUILD_DIR = Path(args.build_root) / 'builds'
     SRC_DIR = Path(args.build_root) / 'src'
-    os.environ["SKA_TOP_SRC_DIR"] = str(SRC_DIR)
+    os.environ["SKA_TOP_SRC_DIR"] = str(SRC_DIR.absolute())
 
     if args.packages:
         pkg_names = args.packages

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -191,6 +191,8 @@ def main():
         else:
             pkg_names = [str(pth) for pth in PKG_DEFS_PATH.glob('*') if pth.is_dir()]
 
+    print(f'Building packages {pkg_names}')
+    
     if platform.uname().system == "Darwin":
         os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.14"  # Mojave
 


### PR DESCRIPTION
This is a WIP for making `ska_builder.py` a bit more organized, simpler and modern.

A key functional change is defaulting to just using the packages in `pkg_defs`, agreeing now with the suggestion from @javierggt.  Having looked more carefully at the diffs from what is there vs. the build order file, basically we either want to just build the packages (like the new ACIS checkers) or remove the recipe (like jplephem).

It also now allows specifying one or more packages to build by name.

Also removes the caching of git repos entirely in order to make the code simpler and more reliable.  From my experience the time for cloning is a small part of the overall build time.