### PR TITLE
Use the anaconda compilers on osx and linux

### DIFF
--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -14,6 +14,7 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
+    - clangxx_osx-64 # [osx]
     - python
     - setuptools
     - setuptools_scm

--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -14,6 +14,7 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
+    - gxx_linux-64 # [linux]
     - clangxx_osx-64 # [osx]
     - python
     - setuptools

--- a/pkg_defs/Ska.Numpy/meta.yaml
+++ b/pkg_defs/Ska.Numpy/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
+    - gcc_linux-64 # [linux]
     - clang_osx-64 # [osx]
     - python
     - numpy

--- a/pkg_defs/Ska.Numpy/meta.yaml
+++ b/pkg_defs/Ska.Numpy/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
+    - clang_osx-64 # [osx]
     - python
     - numpy
     - setuptools

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
+    - gcc_linux-64 # [linux]
     - clang_osx-64 # [osx]
     - python
     - setuptools

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
+    - clang_osx-64 # [osx]
     - python
     - setuptools
     - setuptools_scm


### PR DESCRIPTION
Use the anaconda compilers on osx and linux

My understanding is that the anaconda clang on OSX will need access to an SDK and is configured by default to use /opt/MacOSX10.9.sdk.  I haven't figured out how to use a different one or how to get it to respect MACOSX_DEPLOYMENT_TARGET and CONDA_BUILD_SYSROOT . 

It also looks to me like if /opt/MacOSX10.9.sdk isn't present but there is an SDK installed in /Library from Xcode, the anaconda clang seems to work with that without error.