### PR TITLE
Release 2020.7 , update dea_check to 3.1.0

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.6
+  version: 2020.7
 
 build:
   noarch: generic
@@ -25,7 +25,7 @@ requirements:
     - chandra.time ==3.20.6
     - chandra_aca ==4.29.1
     - cxotime ==3.1.1
-    - dea_check ==3.0.0
+    - dea_check ==3.1.0
     - dpa_check ==3.0.0
     - find_attitude ==3.3.2
     - fep1_actel_check ==3.0.0


### PR DESCRIPTION
# ska3-flight 2020.7

## Summary:

The ska3-flight 2020.6 release includes:

* Update dea_check to 3.1.0

## Interface Impacts:
   * None

## Testing:
   * Standard suite of regression tests was run on HEAD (summary below)
   * One Ska.engarchive test fails. This test was reported failing in the previous release, so here we note again: this test failure is a known and non-impacting issue with the sync process / sync test.

# Code changes

# Testing

```
**************************************************************
***      Package                  Script            Status ***
*** ------------------ ---------------------------- ------ ***
***   Chandra.Maneuver                 test_unit.py   pass ***
***   Chandra.Maneuver           post_check_logs.py   pass ***
***       Chandra.Time                 test_unit.py   pass ***
***       Chandra.Time           post_check_logs.py   pass ***
*** Chandra.cmd_states                 test_unit.py   pass ***
*** Chandra.cmd_states           post_check_logs.py   pass ***
***         Quaternion                 test_unit.py   pass ***
***         Quaternion           post_check_logs.py   pass ***
***            Ska.DBI                 test_unit.py   pass ***
***            Ska.DBI           post_check_logs.py   pass ***
***          Ska.Numpy                 test_unit.py   pass ***
***          Ska.Numpy           post_check_logs.py   pass ***
***          Ska.Shell                 test_unit.py   pass ***
***          Ska.Shell           post_check_logs.py   pass ***
***          Ska.Table             test_unit_git.sh   ---- ***
***          Ska.Table           post_check_logs.py   ---- ***
***     Ska.engarchive    test_make_archive_long.sh   ---- ***
***     Ska.engarchive                 test_unit.py   FAIL ***
***     Ska.engarchive           post_check_logs.py   FAIL ***
***            Ska.ftp                 test_unit.py   pass ***
***            Ska.ftp           post_check_logs.py   pass ***
***       Ska.quatutil             test_unit_git.sh   pass ***
***       Ska.quatutil           post_check_logs.py   pass ***
***            Ska.tdb                 test_unit.py   pass ***
***            Ska.tdb           post_check_logs.py   pass ***
***          acis_taco                 test_unit.py   pass ***
***          acis_taco           post_check_logs.py   pass ***
***       acisfp_check              test_regress.sh   pass ***
***       acisfp_check         test_regress_head.sh   pass ***
***       acisfp_check           post_check_logs.py   pass ***
***       acisfp_check              post_regress.py   pass ***
***       acisfp_check         post_regress_head.py   pass ***
***              agasc                 test_unit.py   pass ***
***              agasc           post_check_logs.py   pass ***
***              annie                 test_unit.py   pass ***
***              annie           post_check_logs.py   pass ***
***        chandra_aca                 test_unit.py   pass ***
***        chandra_aca           post_check_logs.py   pass ***
***            cxotime                 test_unit.py   pass ***
***            cxotime           post_check_logs.py   pass ***
***          dea_check              test_regress.sh   pass ***
***          dea_check         test_regress_head.sh   pass ***
***          dea_check           post_check_logs.py   pass ***
***          dea_check              post_regress.py   pass ***
***          dea_check         post_regress_head.py   pass ***
***          dpa_check              test_regress.sh   pass ***
***          dpa_check         test_regress_head.sh   pass ***
***          dpa_check           post_check_logs.py   pass ***
***          dpa_check              post_regress.py   pass ***
***          dpa_check         post_regress_head.py   pass ***
***               kadi         test_regress_long.sh   ---- ***
***               kadi                 test_unit.py   pass ***
***               kadi           post_check_logs.py   pass ***
***               kadi         post_regress_long.py   ---- ***
***              maude                 test_unit.py   pass ***
***              maude           post_check_logs.py   pass ***
***               mica                 test_unit.py   pass ***
***               mica           post_check_logs.py   pass ***
***   package_manifest              test_regress.sh   pass ***
***   package_manifest           post_check_logs.py   pass ***
***   package_manifest              post_regress.py   pass ***
***           parse_cm                 test_unit.py   pass ***
***           parse_cm           post_check_logs.py   pass ***
***            proseco                 test_unit.py   pass ***
***            proseco           post_check_logs.py   pass ***
***         psmc_check              test_regress.sh   pass ***
***         psmc_check         test_regress_head.sh   pass ***
***         psmc_check           post_check_logs.py   pass ***
***         psmc_check              post_regress.py   pass ***
***         psmc_check         post_regress_head.py   pass ***
***             pyyaks                 test_unit.py   pass ***
***             pyyaks           post_check_logs.py   pass ***
***           sparkles                 test_unit.py   pass ***
***           sparkles           post_check_logs.py   pass ***
***          starcheck              test_regress.sh   pass ***
***          starcheck           post_check_logs.py   pass ***
***          starcheck              post_regress.py   pass ***
***          timelines test_unit_git_sybase_long.sh   ---- ***
***          timelines           post_check_logs.py   ---- ***
***               xija                 test_unit.py   pass ***
***               xija           post_check_logs.py   pass ***
**************************************************************
```

# Related Issues

Closes #395 
Closes #403