### PR TITLE
Allow for meta.yaml compiler option in ska_builder

### DIFF
--- a/ska_builder.py
+++ b/ska_builder.py
@@ -67,7 +67,8 @@ def clone_repo(name, args, src_dir):
         return None
 
     # Stub out the jinja context variables and read meta.yaml
-    meta = yaml.safe_load(jinja2.Template(meta_text).render())
+    macro = '{% macro compiler(arg) %}{% endmacro %}\n'
+    meta = yaml.safe_load(jinja2.Template(macro + meta_text).render())
 
     # Upstream (home) URL is for the tags
     upstream_url = meta['about']['home']


### PR DESCRIPTION
## Description

Allow there to be text like `{{ compiler('c') }}` in the `meta.yaml` file.

## Testing

- [N/A] Unit tests
- [x] Functional testing

Used this patch to build `sherpa` which contains:
```
requirements:
 build:
  - {{ compiler('cxx') }}
  - {{ compiler('c') }}
  - make
  - bison
  - flex
```

### Verification

Doing the build includes this output, which seems to indicate using local compilers:
```
+CLANG=$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-clang
+CMAKE_PREFIX_PATH=:$PREFIX
+INDR=$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-indr
+INSTALL_NAME_TOOL=$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-install_name_tool
+LD=$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-ld
...
+CLANGXX=$BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-clang++
+CXX=x86_64-apple-darwin13.4.0-clang++
```


Fixes #391