### PR TITLE
Add recipe for sherpa

### DIFF
--- a/pkg_defs/sherpa/build.sh
+++ b/pkg_defs/sherpa/build.sh
@@ -1,0 +1,12 @@
+
+sed -i.orig "s|#install_dir=build|install_dir=$PREFIX|" setup.cfg
+git update-index --assume-unchanged setup.cfg
+
+export PYTHON_LDFLAGS=" "
+
+$PYTHON setup.py build
+$PYTHON setup.py install
+
+# This headers are known to collide with astropy's extensions and would prevent astropy from building
+rm -f $PREFIX/include/wcs*.h
+

--- a/pkg_defs/sherpa/meta.yaml
+++ b/pkg_defs/sherpa/meta.yaml
@@ -1,0 +1,42 @@
+package:
+ name: sherpa
+ version: {{ SKA_PKG_VERSION }}
+
+source:
+ path: {{ SKA_TOP_SRC_DIR }}/sherpa
+ patches:
+  - multiprocess_patch.txt # [osx-64]
+
+requirements:
+ build:
+  - {{ compiler('cxx') }}
+  - {{ compiler('c') }}
+  - make
+  - bison
+  - flex
+
+ host:
+  - python
+  - numpy
+  - setuptools
+  - six
+
+ run:
+  - python
+  - numpy >1.11
+  - setuptools
+  - pytest
+  - six
+
+test:
+  imports:
+    - sherpa.ui
+
+  commands:
+    - sherpa_smoke
+
+about:
+ home: https://github.com/sherpa/sherpa
+ summary: Sherpa is the CIAO modeling and fitting application. It enables the user to construct complex models from simple definitions and fit those models to data, using a variety of statistics and optimization methods
+ license: GPLv3
+

--- a/pkg_defs/sherpa/multiprocess_patch.txt
+++ b/pkg_defs/sherpa/multiprocess_patch.txt
@@ -1,0 +1,24 @@
+diff --git a/sherpa/estmethods/__init__.py b/sherpa/estmethods/__init__.py
+index a4878971..0d276b82 100644
+--- a/sherpa/estmethods/__init__.py
++++ b/sherpa/estmethods/__init__.py
+@@ -28,6 +28,7 @@ import sherpa.estmethods._est_funcs
+
+ try:
+     import multiprocessing
++    multiprocessing.set_start_method('fork', force=True)
+ except:
+     pass
+
+diff --git a/sherpa/optmethods/opt.py b/sherpa/optmethods/opt.py
+index ae06c706..1176cfb0 100755
+--- a/sherpa/optmethods/opt.py
++++ b/sherpa/optmethods/opt.py
+@@ -21,6 +21,8 @@
+
+ import numpy as np
+ import multiprocessing
++multiprocessing.set_start_method('fork', force=True)
++
+ import random
+ from sherpa.utils import Knuth_close, _multi, _ncpus, run_tasks, func_counter


### PR DESCRIPTION
## Description

Add a recipe for building sherpa.  This is intended to be temporary and to be removed once an official conda package for Sherpa is available for Python 3.8 on linux and Mac.  The recipe was adapted with minimal modification from the recipe included in the sherpa source.

## Testing

### MacOSX and Linux

Used `python ska_builder.py --python=3.8 sherpa` to successfully build `sherpa` 4.12.1.  This package was installed and passed `sherpa_test`.  I also ran `xija_gui_fit` using this and was able to successfully run a simple fit without any crash.