### PR TITLE
Update default Python version to 3.8

### DIFF
--- a/ska_builder.py
+++ b/ska_builder.py
@@ -37,8 +37,8 @@ def get_opt():
                         action="store_true",
                         help="Force build of package even if it exists")
     parser.add_argument("--python",
-                        default="3.7",
-                        help="Target version of Python (default=3.6)")
+                        default="3.8",
+                        help="Target version of Python (default=3.8)")
     parser.add_argument("--perl",
                         default="5.26.2",
                         help="Target version of Perl (default=5.26.2)")


### PR DESCRIPTION
Shiny is now targeting Python 3.8.