### PR TITLE
Improvements related to arch-specific packages

### DIFF
--- a/pkg_defs/Ska.engarchive/meta.yaml
+++ b/pkg_defs/Ska.engarchive/meta.yaml
@@ -3,7 +3,6 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  noarch: python
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 source:

--- a/pkg_defs/aca_view/build.sh
+++ b/pkg_defs/aca_view/build.sh
@@ -1,1 +1,0 @@
-pip install --no-deps --verbose --no-binary :all: --no-index .

--- a/pkg_defs/aca_view/meta.yaml
+++ b/pkg_defs/aca_view/meta.yaml
@@ -3,9 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  noarch: python
-  script_env:
-    - SKA_TOP_SRC_DIR
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/aca_view

--- a/pkg_defs/aca_view/meta.yaml
+++ b/pkg_defs/aca_view/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - pip
     - python
     - setuptools
+    - setuptools_scm
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/acdc/meta.yaml
+++ b/pkg_defs/acdc/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  noarch: python
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/acdc

--- a/pkg_defs/kadi/meta.yaml
+++ b/pkg_defs/kadi/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  noarch: python
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/kadi

--- a/pkg_defs/sherpa/meta.yaml
+++ b/pkg_defs/sherpa/meta.yaml
@@ -7,6 +7,9 @@ source:
  patches:
   - multiprocess_patch.txt # [osx-64]
 
+build:
+  skip: True  # [win]
+
 requirements:
  build:
   - {{ compiler('cxx') }}

--- a/pkg_defs/ska_sync/meta.yaml
+++ b/pkg_defs/ska_sync/meta.yaml
@@ -5,7 +5,6 @@ package:
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  noarch: python
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/ska_sync

--- a/pkg_defs/sparkles/meta.yaml
+++ b/pkg_defs/sparkles/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  noarch: python
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/sparkles

--- a/pkg_defs/testr/meta.yaml
+++ b/pkg_defs/testr/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  noarch: python
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/testr

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -24,10 +24,10 @@ def get_opt():
                         help="Package to build (default=build all packages)")
     parser.add_argument("--tag", type=str,
                         help="Optional tag, branch, or commit to build for single package build"
-                            " (default is tag with most recent commit)")
+                        " (default is tag with most recent commit)")
     parser.add_argument("--build-root", default=".", type=str,
                         help="Path to root directory for output conda build packages."
-                            "Default: '.'")
+                        "Default: '.'")
     parser.add_argument("--build-list", default="./ska3_flight_build_order.txt",
                         help="List of packages to build (in order)")
     parser.add_argument("--test",
@@ -36,6 +36,9 @@ def get_opt():
     parser.add_argument("--force",
                         action="store_true",
                         help="Force build of package even if it exists")
+    parser.add_argument("--arch-specific",
+                        action="store_true",
+                        help="Build only architecture-specific packages")
     parser.add_argument("--python",
                         default="3.8",
                         help="Target version of Python (default=3.8)")
@@ -55,20 +58,10 @@ def get_opt():
     return args
 
 
-def clone_repo(name, args, src_dir):
+def clone_repo(name, args, src_dir, meta):
     tag = args.tag
     print("  - Cloning or updating source source %s." % name)
     clone_path = os.path.join(src_dir, name)
-
-    metayml = PKG_DEFS_PATH / name / "meta.yaml"
-    meta_text = metayml.read_text()
-    has_git = re.search(r'SKA_PKG_VERSION|GIT_DESCRIBE_TAG', meta_text)
-    if not has_git:
-        return None
-
-    # Stub out the jinja context variables and read meta.yaml
-    macro = '{% macro compiler(arg) %}{% endmacro %}\n'
-    meta = yaml.safe_load(jinja2.Template(macro + meta_text).render())
 
     # Upstream (home) URL is for the tags
     upstream_url = meta['about']['home']
@@ -165,9 +158,23 @@ def build_package(name, args, src_dir, build_dir):
 def build_list_packages(pkg_names, args, src_dir, build_dir):
     failures = []
     for pkg_name in pkg_names:
+        # Read package meta.yaml text
+        meta_file = PKG_DEFS_PATH / pkg_name / "meta.yaml"
+        meta_text = meta_file.read_text()
+        has_git = re.search(r'SKA_PKG_VERSION|GIT_DESCRIBE_TAG', meta_text)
+
+        # Stub out the jinja context variables and parse meta.yaml
+        macro = '{% macro compiler(arg) %}{% endmacro %}\n'
+        meta = yaml.safe_load(jinja2.Template(macro + meta_text).render())
+
+        if args.arch_specific and 'noarch' in meta.get('build', {}):
+            print(f'Skipping noarch package {pkg_name}')
+            continue
+
+        print("- Building package %s." % pkg_name)
         try:
-            print("- Building package %s." % pkg_name)
-            clone_repo(pkg_name, args, src_dir)
+            if has_git:
+                clone_repo(pkg_name, args, src_dir, meta)
             build_package(pkg_name, args, src_dir, build_dir)
             print('')
         except Exception:

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -28,7 +28,7 @@ def get_opt():
     parser.add_argument("--build-root", default=".", type=str,
                         help="Path to root directory for output conda build packages."
                         "Default: '.'")
-    parser.add_argument("--build-list", default="./ska3_flight_build_order.txt",
+    parser.add_argument("--build-list",
                         help="List of packages to build (in order)")
     parser.add_argument("--test",
                         action="store_true",


### PR DESCRIPTION
This makes some improvements related to arch-specific packages:

- Allow only building them (convenient on linux and Windows, assuming noarch packages are built on Mac)
- Make every package with entry point scripts be arch-specific
- Make sherpa build be skipped on Windows