### PR TITLE
Add a recipe for the ACISpy package

### DIFF
--- a/pkg_defs/acispy/meta.yaml
+++ b/pkg_defs/acispy/meta.yaml
@@ -1,0 +1,37 @@
+package:
+  name: acispy
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/acispy
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - python
+    - setuptools
+    - setuptools_scm
+    - setuptools_scm_git_archive
+
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - numpy
+    - requests
+    - astropy
+
+test:
+  imports:
+    - acispy
+
+about:
+  home: https://github.com/acisops/acispy
+


### PR DESCRIPTION
The run requirements come from the setup.py. This is done as arch-specific because of the script files.