### PR TITLE
2020.9

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - ska.numpy ==3.8.4
     - ska.matplotlib ==3.11.4
     - ska.parsecm ==3.3.4
-    - ska_helpers ==0.1.1
+    - ska_helpers ==0.1.2
     - ska_path ==3.1.1
     - ska_sync ==4.6.0
     - ska.quatutil ==3.3.3
@@ -60,4 +60,4 @@ requirements:
     - starcheck ==13.6.0
     - tables3_api ==0.1.1
     - testr ==4.3.1
-    - xija ==4.18.2
+    - xija ==4.19.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight
-  version: 2020.7
+  version: 2020.9
 
 build:
   noarch: generic


### PR DESCRIPTION
# ska3-flight 2020.9

## Summary:

The ska3-flight 2020.9 release includes the latest xija release 4.19.0. These changes have been approved by the thermal WG.

## Interface Impacts:
   * None
## Testing:

  - One Ska.engarchive test fails. This test was reported failing in the previous release, so here we note again: this test failure is a known and non-impacting issue with the sync process / sync test.
  - Ska.ParseCM/post_check_logs.py fails because it is testing the wrong version. It tests master, which is not what is in ska3-flight 2020.9. In master, Ska.ParseCM is deprecated and produces a warning that is caught by the test.

All these issues have no impact, and will be fixed in the next version.

## Review:
   * PRs (see changes below) have been reviewed by the ACA team.
## Deployment:
   *  The 2020.9 ska3-flight release will be deployed on HEAD and GRETA ska3/flight after the release and products for the week are approved.
# Code changes

## ska3-flight

**sot/ska_helpers: 0.1.1 -> 0.1.2** (0.1.1 -> 0.1.2)
  - [PR 12](https://github.com/sot/ska_helpers/pull/12): get version without importing

**sot/xija: 4.18.2 -> 4.19.0** (4.18.2 -> 4.19.0)
  - [PR 86](https://github.com/sot/xija/pull/86): Fix bug in component param set attribute
  - [PR 90](https://github.com/sot/xija/pull/90): Enhance StepFunctionPower component to allow multiple instances

# Testing

## ska3-flight 

```
**************************************************************
***      Package                  Script            Status ***
*** ------------------ ---------------------------- ------ ***
***   Chandra.Maneuver                 test_unit.py   pass ***
***   Chandra.Maneuver           post_check_logs.py   pass ***
***       Chandra.Time                 test_unit.py   pass ***
***       Chandra.Time           post_check_logs.py   pass ***
*** Chandra.cmd_states                 test_unit.py   pass ***
*** Chandra.cmd_states           post_check_logs.py   pass ***
***         Quaternion                 test_unit.py   pass ***
***         Quaternion           post_check_logs.py   pass ***
***            Ska.DBI                 test_unit.py   pass ***
***            Ska.DBI           post_check_logs.py   pass ***
***          Ska.Numpy                 test_unit.py   pass ***
***          Ska.Numpy           post_check_logs.py   pass ***
***        Ska.ParseCM             test_unit_git.sh   pass ***
***        Ska.ParseCM           post_check_logs.py   FAIL ***
***          Ska.Shell                 test_unit.py   pass ***
***          Ska.Shell           post_check_logs.py   pass ***
***          Ska.Table             test_unit_git.sh   ---- ***
***          Ska.Table           post_check_logs.py   ---- ***
***     Ska.engarchive    test_make_archive_long.sh   ---- ***
***     Ska.engarchive                 test_unit.py   FAIL ***
***     Ska.engarchive           post_check_logs.py   FAIL ***
***            Ska.ftp                 test_unit.py   pass ***
***            Ska.ftp           post_check_logs.py   pass ***
***       Ska.quatutil             test_unit_git.sh   pass ***
***       Ska.quatutil           post_check_logs.py   pass ***
***            Ska.tdb                 test_unit.py   pass ***
***            Ska.tdb           post_check_logs.py   pass ***
***          acis_taco                 test_unit.py   pass ***
***          acis_taco           post_check_logs.py   pass ***
***       acisfp_check              test_regress.sh   pass ***
***       acisfp_check         test_regress_head.sh   pass ***
***       acisfp_check           post_check_logs.py   pass ***
***       acisfp_check              post_regress.py   pass ***
***       acisfp_check         post_regress_head.py   pass ***
***              agasc                 test_unit.py   pass ***
***              agasc           post_check_logs.py   pass ***
***              annie                 test_unit.py   pass ***
***              annie           post_check_logs.py   pass ***
***        chandra_aca                 test_unit.py   pass ***
***        chandra_aca           post_check_logs.py   pass ***
***            cxotime                 test_unit.py   pass ***
***            cxotime           post_check_logs.py   pass ***
***          dea_check              test_regress.sh   pass ***
***          dea_check         test_regress_head.sh   pass ***
***          dea_check           post_check_logs.py   pass ***
***          dea_check              post_regress.py   pass ***
***          dea_check         post_regress_head.py   pass ***
***          dpa_check              test_regress.sh   pass ***
***          dpa_check         test_regress_head.sh   pass ***
***          dpa_check           post_check_logs.py   pass ***
***          dpa_check              post_regress.py   pass ***
***          dpa_check         post_regress_head.py   pass ***
***               kadi         test_regress_long.sh   ---- ***
***               kadi                 test_unit.py   pass ***
***               kadi           post_check_logs.py   pass ***
***               kadi         post_regress_long.py   ---- ***
***              maude                 test_unit.py   pass ***
***              maude           post_check_logs.py   pass ***
***               mica                 test_unit.py   pass ***
***               mica           post_check_logs.py   pass ***
***   package_manifest              test_regress.sh   pass ***
***   package_manifest           post_check_logs.py   pass ***
***   package_manifest              post_regress.py   pass ***
***           parse_cm                 test_unit.py   pass ***
***           parse_cm           post_check_logs.py   pass ***
***            proseco                 test_unit.py   pass ***
***            proseco           post_check_logs.py   pass ***
***         psmc_check              test_regress.sh   pass ***
***         psmc_check         test_regress_head.sh   pass ***
***         psmc_check           post_check_logs.py   pass ***
***         psmc_check              post_regress.py   pass ***
***         psmc_check         post_regress_head.py   pass ***
***             pyyaks                 test_unit.py   pass ***
***             pyyaks           post_check_logs.py   pass ***
***           sparkles                 test_unit.py   pass ***
***           sparkles           post_check_logs.py   pass ***
***          starcheck              test_regress.sh   pass ***
***          starcheck           post_check_logs.py   pass ***
***          starcheck              post_regress.py   pass ***
***          timelines test_unit_git_sybase_long.sh   ---- ***
***          timelines           post_check_logs.py   ---- ***
***               xija                 test_unit.py   pass ***
***               xija           post_check_logs.py   pass ***
**************************************************************
```

# Related Issues

Fixes #424 