### PR TITLE
skare3_tools arch

### DIFF
--- a/pkg_defs/skare3_tools/meta.yaml
+++ b/pkg_defs/skare3_tools/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  noarch: python
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/skare3_tools


### PR DESCRIPTION
even if we are not explicitly supporting windows, this package defines entrypoints, so to even hava a chance needs to be arch-dependent