### PR TITLE
Changed some meta-data

### DIFF
--- a/pkg_defs/Chandra.Maneuver/meta.yaml
+++ b/pkg_defs/Chandra.Maneuver/meta.yaml
@@ -39,4 +39,4 @@ test:
 
 
 about:
-  home: git@github.com:sot/Chandra.Maneuver
+  home: https://github.com/sot/Chandra.Maneuver

--- a/pkg_defs/acdc/meta.yaml
+++ b/pkg_defs/acdc/meta.yaml
@@ -44,5 +44,5 @@ test:
 
 
 about:
-  home: git@github.com:sot/acdc
+  home: https://github.com/sot/acdc
 

--- a/pkg_defs/annie/meta.yaml
+++ b/pkg_defs/annie/meta.yaml
@@ -44,5 +44,5 @@ test:
 
 
 about:
-  home: git@github.com:sot/annie
+  home: https://github.com/sot/annie
 

--- a/pkg_defs/maude/meta.yaml
+++ b/pkg_defs/maude/meta.yaml
@@ -41,4 +41,4 @@ test:
 
 
 about:
-  home: git@github.com:sot/maude
+  home: https://github.com/sot/maude

--- a/pkg_defs/parse_cm/meta.yaml
+++ b/pkg_defs/parse_cm/meta.yaml
@@ -34,5 +34,5 @@ test:
     - parse_cm
 
 about:
-  home: git@github.com:sot/parse_cm
+  home: https://github.com/sot/parse_cm
 


### PR DESCRIPTION
- In all cases where home was a github repository, changed it to the corresponding https address.

I thought of also defining the doc_url and summary  fields (like I did with [skare3_tools](https://github.com/sot/skare3/blob/master/pkg_defs/skare3_tools/meta.yaml#L37)). Anyway the doc address will change after we overhaul the documentation. Still, I could do it...