### PR TITLE
adding gcc build dependency to cxotime (until it builds in CI)

### DIFF
--- a/pkg_defs/cxotime/meta.yaml
+++ b/pkg_defs/cxotime/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - gcc
     - numpy
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.


### PR DESCRIPTION
adding more build dependencies to cxotime (until it builds in CI: https://github.com/sot/cxotime/runs/1220403139)