### PR TITLE
add option to overwrite ska3-* meta-package versions

### DIFF
--- a/ska_builder.py
+++ b/ska_builder.py
@@ -230,13 +230,17 @@ def overwrite_skare3_version(current_version, new_version, pkg_path):
         data['package']['version'] = new_version
     else:
         print(f'  - NOT changing version on {pkg_path}')
-    for section in data['requirements']:
-        for i, requirement in enumerate(data['requirements'][section]):
-            if '==' in requirement:
-                name, pkg_version = requirement.split('==')
-                name = name.strip()
-                if re.match(r'ska3-\S+$', name) and pkg_version == current_version:
-                    data['requirements'][section][i] = f'{name} =={new_version}'
+        # the intention of this function is for pre-releases.
+        # in this case, if a meta-package version is not `new_version`,
+        # it better not have any dependency with version `new_version`.
+        # Not modifying requirements will then cause tests to fail (as they should).
+        for section in data['requirements']:
+            for i, requirement in enumerate(data['requirements'][section]):
+                if '==' in requirement:
+                    name, pkg_version = requirement.split('==')
+                    name = name.strip()
+                    if re.match(r'ska3-\S+$', name) and pkg_version == current_version:
+                        data['requirements'][section][i] = f'{name} =={new_version}'
     t = yaml.dump(data, indent=4)
     with open(meta_file, 'w') as f:
         f.write(t)

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -243,11 +243,13 @@ def overwrite_skare3_version(current_version, new_version, pkg_path):
         if m:
             version = m.groupdict()['version']
             if version == str(current_version):
+                print(f'    - version: {current_version} -> {new_version}')
                 lines[i] = line.replace(current_version, new_version)
         m = re.search(r'(\s+)?(?P<name>\S+)(\s+)?==(\s+)?(?P<version>(\S+)+)', line)
         if m:
             info = m.groupdict()
             if re.match(r'ska3-\S+$', info['name']) and info['version'] == current_version:
+                print(f'    - {info["name"]} dependency: {current_version} -> {new_version}')
                 lines[i] = line.replace(current_version, new_version)
 
     with open(meta_file, 'w') as f:

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -228,8 +228,6 @@ def overwrite_skare3_version(current_version, new_version, pkg_path):
             data = yaml.load(fh, Loader=yaml.BaseLoader)
     if str(data['package']['version']) == str(current_version):
         data['package']['version'] = new_version
-    else:
-        print(f'  - NOT changing version on {pkg_path}')
         # the intention of this function is for pre-releases.
         # in this case, if a meta-package version is not `new_version`,
         # it better not have any dependency with version `new_version`.
@@ -241,6 +239,8 @@ def overwrite_skare3_version(current_version, new_version, pkg_path):
                     name = name.strip()
                     if re.match(r'ska3-\S+$', name) and pkg_version == current_version:
                         data['requirements'][section][i] = f'{name} =={new_version}'
+    else:
+        print(f'  - NOT changing version on {pkg_path}')
     t = yaml.dump(data, indent=4)
     with open(meta_file, 'w') as f:
         f.write(t)

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -222,17 +222,18 @@ def overwrite_skare3_version(current_version, new_version, pkg_path):
             data = yaml.load(fh, Loader=yaml.BaseLoader)
     if str(data['package']['version']) == str(current_version):
         data['package']['version'] = new_version
-        for i in range(len(data['requirements'])):
-            if re.search('==', data['requirements']['run'][i]):
-                name, pkg_version = data['requirements']['run'][i].split('==')
-                name = name.strip()
-                if re.match('ska3-\S+$', name) and pkg_version == current_version:
-                    data['requirements']['run'][i] = f'{name} =={new_version}'
-        t = yaml.dump(data, indent=4)
-        with open(meta_file, 'w') as f:
-            f.write(t)
     else:
         print(f'  - NOT changing version on {pkg_path}')
+    for section in data['requirements']:
+        for i, requirement in enumerate(data['requirements'][section]):
+            if '==' in requirement:
+                name, pkg_version = requirement.split('==')
+                name = name.strip()
+                if re.match('ska3-\S+$', name) and pkg_version == current_version:
+                    data['requirements'][section][i] = f'{name} =={new_version}'
+    t = yaml.dump(data, indent=4)
+    with open(meta_file, 'w') as f:
+        f.write(t)
 
 
 def main():

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -216,13 +216,10 @@ def build_list_packages(pkg_names, args, src_dir, build_dir):
 def overwrite_skare3_version(current_version, new_version, pkg_path):
     meta_file = pkg_path / 'meta.yaml'
     with open(meta_file) as fh:
-        t = jinja2.Template(fh.read())
-    text = (t.render(SKA_PKG_VERSION='$SKA_PKG_VERSION',
-                     SKA_TOP_SRC_DIR='$SKA_TOP_SRC_DIR'))
-    if version.parse(yaml.__version__) < version.parse("5.1"):
-        data = yaml.load(text)
-    else:
-        data = yaml.load(text, Loader=yaml.BaseLoader)
+        if version.parse(yaml.__version__) < version.parse("5.1"):
+            data = yaml.load(fh)
+        else:
+            data = yaml.load(fh, Loader=yaml.BaseLoader)
     if str(data['package']['version']) == str(current_version):
         data['package']['version'] = new_version
         for i in range(len(data['requirements'])):
@@ -231,10 +228,7 @@ def overwrite_skare3_version(current_version, new_version, pkg_path):
                 name = name.strip()
                 if re.match('ska3-\S+$', name) and pkg_version == current_version:
                     data['requirements']['run'][i] = f'{name} =={new_version}'
-        t = string.Template(yaml.dump(data, indent=4)).substitute(
-            SKA_PKG_VERSION='{{ SKA_PKG_VERSION }}',
-            SKA_TOP_SRC_DIR='{{ SKA_TOP_SRC_DIR }}'
-        )
+        t = yaml.dump(data, indent=4)
         with open(meta_file, 'w') as f:
             f.write(t)
     else:

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -11,8 +11,6 @@ from pathlib import Path
 import tempfile
 from fnmatch import fnmatch
 import time
-from packaging import version
-import string
 
 import git
 import jinja2

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -63,7 +63,12 @@ def get_opt():
     parser.add_argument("--repo-url",
                         help="Use this URL instead of meta['about']['home']")
     parser.add_argument('--ska3-overwrite-version',
-                        help="The version of the ska3 conda meta-package to build (used by CI).")
+                        metavar='[<initial-version>:]<final-version>',
+                        help="This option is intended to overwrite ska3-* meta-package versions "
+                             "when building/testing pre-releases. If the initial version is not "
+                             "given, it is assumed to be the same as the final version with the "
+                             "pre-release portion of the version string removed. "
+                             "Versions are expected in PEP-0440 format.")
 
     args = parser.parse_args()
     return args
@@ -241,6 +246,15 @@ def main():
     args = get_opt()
 
     if args.ska3_overwrite_version:
+        """
+        the value of  args.ska3_overwrite_version can be of the forms:
+        - `<initial-version>:<final-version>`.
+        - `<final-version>`.
+        
+        In the first case, there is nothing to do. In the second case, we assume that the final
+        version is the same as the final version but removing the release candidate part
+        (i.e.: something that looks like "rcN" or "aN" or "bN").
+        """
         if ':' not in args.ska3_overwrite_version:
             rc = re.match(r'(?P<version>(?P<release>\S+)(a|b|rc)[0-9]+(\+(?P<label>\S+))?)$',
                           args.ska3_overwrite_version)

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -221,10 +221,7 @@ def build_list_packages(pkg_names, args, src_dir, build_dir):
 def overwrite_skare3_version(current_version, new_version, pkg_path):
     meta_file = pkg_path / 'meta.yaml'
     with open(meta_file) as fh:
-        if version.parse(yaml.__version__) < version.parse("5.1"):
-            data = yaml.load(fh)
-        else:
-            data = yaml.load(fh, Loader=yaml.BaseLoader)
+        data = yaml.load(fh, Loader=yaml.SafeLoader)
     if str(data['package']['version']) == str(current_version):
         data['package']['version'] = new_version
         # the intention of this function is for pre-releases.

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -62,7 +62,7 @@ def get_opt():
                         "except on Windows")
     parser.add_argument("--repo-url",
                         help="Use this URL instead of meta['about']['home']")
-    parser.add_argument('--skare3-overwrite-version',
+    parser.add_argument('--ska3-overwrite-version',
                         help="The version of the ska3 conda meta-package to build (used by CI).")
 
     args = parser.parse_args()
@@ -118,8 +118,8 @@ def build_package(name, args, src_dir, build_dir):
     pkg_path = Path(src_dir) / 'pkg_defs' / name
     shutil.copytree(PKG_DEFS_PATH / name, pkg_path)
 
-    if args.skare3_overwrite_version and re.match('ska3-\S+$', name):
-        skare3_old_version, skare3_new_version = args.skare3_overwrite_version.split(':')
+    if args.ska3_overwrite_version and re.match('ska3-\S+$', name):
+        skare3_old_version, skare3_new_version = args.ska3_overwrite_version.split(':')
         print(f'  - overwriting skare3 meta-package version {skare3_old_version} -> {skare3_new_version}')
         overwrite_skare3_version(skare3_old_version, skare3_new_version, pkg_path)
 
@@ -239,16 +239,16 @@ def overwrite_skare3_version(current_version, new_version, pkg_path):
 def main():
     args = get_opt()
 
-    if args.skare3_overwrite_version:
-        if ':' not in args.skare3_overwrite_version:
+    if args.ska3_overwrite_version:
+        if ':' not in args.ska3_overwrite_version:
             rc = re.match('(?P<version>(?P<release>\S+)(a|b|rc)[0-9]+(\+(?P<label>\S+))?)$',
-                          args.skare3_overwrite_version)
+                          args.ska3_overwrite_version)
             if not rc:
-                raise Exception(f'wrong format for skare3_overwrite_version: '
-                                f'{args.skare3_overwrite_version}')
+                raise Exception(f'wrong format for ska3_overwrite_version: '
+                                f'{args.ska3_overwrite_version}')
             version_info = rc.groupdict()
             version_info["label"] = f'+{version_info["label"]}' if version_info["label"] else ''
-            args.skare3_overwrite_version = \
+            args.ska3_overwrite_version = \
                 f'{version_info["release"]}{version_info["label"]}:{version_info["version"]}'
 
     if args.packages:

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -118,9 +118,10 @@ def build_package(name, args, src_dir, build_dir):
     pkg_path = Path(src_dir) / 'pkg_defs' / name
     shutil.copytree(PKG_DEFS_PATH / name, pkg_path)
 
-    if args.ska3_overwrite_version and re.match('ska3-\S+$', name):
+    if args.ska3_overwrite_version and re.match(r'ska3-\S+$', name):
         skare3_old_version, skare3_new_version = args.ska3_overwrite_version.split(':')
-        print(f'  - overwriting skare3 meta-package version {skare3_old_version} -> {skare3_new_version}')
+        print(f'  - overwriting skare3 meta-package version '
+              f'{skare3_old_version} -> {skare3_new_version}')
         overwrite_skare3_version(skare3_old_version, skare3_new_version, pkg_path)
 
     try:
@@ -229,7 +230,7 @@ def overwrite_skare3_version(current_version, new_version, pkg_path):
             if '==' in requirement:
                 name, pkg_version = requirement.split('==')
                 name = name.strip()
-                if re.match('ska3-\S+$', name) and pkg_version == current_version:
+                if re.match(r'ska3-\S+$', name) and pkg_version == current_version:
                     data['requirements'][section][i] = f'{name} =={new_version}'
     t = yaml.dump(data, indent=4)
     with open(meta_file, 'w') as f:
@@ -241,7 +242,7 @@ def main():
 
     if args.ska3_overwrite_version:
         if ':' not in args.ska3_overwrite_version:
-            rc = re.match('(?P<version>(?P<release>\S+)(a|b|rc)[0-9]+(\+(?P<label>\S+))?)$',
+            rc = re.match(r'(?P<version>(?P<release>\S+)(a|b|rc)[0-9]+(\+(?P<label>\S+))?)$',
                           args.ska3_overwrite_version)
             if not rc:
                 raise Exception(f'wrong format for ska3_overwrite_version: '

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -133,10 +133,10 @@ def build_package(name, args, src_dir, build_dir):
         version = subprocess.check_output(['python', 'setup.py', '--version'],
                                           cwd=os.path.join(src_dir, name))
         version = version.decode().split()[-1].strip()
+        print(f'  - SKA_PKG_VERSION={version}')
     except Exception:
         version = ''
     os.environ['SKA_PKG_VERSION'] = version
-    print(f'  - SKA_PKG_VERSION={version}')
 
     cmd_list = ["conda", "build", str(pkg_path),
                 "--croot", str(build_dir),

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -67,8 +67,7 @@ def get_opt():
                         help="This option is intended to overwrite ska3-* meta-package versions "
                              "when building/testing pre-releases. If the initial version is not "
                              "given, it is assumed to be the same as the final version with the "
-                             "pre-release portion of the version string removed. "
-                             "Versions are expected in PEP-0440 format.")
+                             "pre-release portion of the version string removed.")
 
     args = parser.parse_args()
     return args
@@ -260,8 +259,15 @@ def main():
         (i.e.: something that looks like "rcN" or "aN" or "bN").
         """
         if ':' not in args.ska3_overwrite_version:
-            rc = re.match(r'(?P<version>(?P<release>\S+)(a|b|rc)[0-9]+(\+(?P<label>\S+))?)$',
-                          args.ska3_overwrite_version)
+            rc = re.match(
+                r"""(?P<version>
+                    (?P<release>\S+)     # release segment (usually N!N.N.N but not enforced here)
+                    (a|b|rc)[0-9]+       # pre-release segment (rcN, aN or bN, required)
+                    (\+(?P<label>\S+))?  # label fragment (an optional string)
+                )$""",
+                args.ska3_overwrite_version,
+                re.VERBOSE
+            )
             if not rc:
                 raise Exception(f'wrong format for ska3_overwrite_version: '
                                 f'{args.ska3_overwrite_version}')


### PR DESCRIPTION
This PR adds a command argument `--skare3-overwrite-version` which is meant for continuous integration to create pre-release conda packages.

It does that by:
- adding the `--skare3-overwrite-version` argument
- parsing the value provided
  - the value can be of the form `<initial-version>:<final-version>`.
  - or just a single version, in which case it assumes that the the initial version is the same os the final version but removing the release candidate part (i.e.: something that looks like "rcN" or "aN" or "bN".
- the package definition directory is copied to the temp source directory
- meta.yaml is read, all occurrences of `<initial-version>` are replaced by `<final-version>`. This is in the package version and in its dependencies, whenever their name is of the form 'ska3-*'.

# Testing

built the following:
- Quaternion (should have no effect)
- ska3-template (pkg_def dir contains a subdir)
- ska3-flight-2020.10rcN (checks the proper parsing of version as string)
- ska3-flight-2020.13rc2+shiny