### PR TITLE
cxotime is not noarch anymore

### DIFF
--- a/pkg_defs/cxotime/meta.yaml
+++ b/pkg_defs/cxotime/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  noarch: python
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/cxotime


### PR DESCRIPTION
I tested that this produces an arch-dependent package on mac os.