### PR TITLE
ska3-perl for shiny release candidate

### DIFF
--- a/pkg_defs/ska3-core/combine_arch.py
+++ b/pkg_defs/ska3-core/combine_arch.py
@@ -30,29 +30,29 @@ def main():
     ska_packages = [p['package'] for p in packages.get_package_list()
                     if p['package'] and p['package'] not in exceptions]
 
+    def get_env_packages(env_string):
+        """
+        Get platform label and dict of packages from json of supplied file.
+        """
+        try:
+            platform, filename = env_string.split('=')
+        except ValueError:
+            print(f' - skipped {env}')
+        print(f' + {platform}: {filename}')
+        with open(filename) as fh:
+            return platform, {p['name']: p for p in json.load(fh)}
+
     environments = {}
     print(f'Reading environments:')
     for env in args.env:
-        try:
-            platform, filename = env.split('=')
-        except ValueError:
-            print(f' - skipped {env}')
-            continue
-        print(f' + {platform}: {filename}')
-        with open(filename) as fh:
-            environments[platform] = {p['name']: p for p in json.load(fh)}
+        platform, env_packages = get_env_packages(env)
+        environments[platform] = env_packages
 
     subtract_environments = {}
     print(f'Reading environments to subtract:')
     for env in args.subtract_env:
-        try:
-            platform, filename = env.split('=')
-        except ValueError:
-            print(f' - skipped {env}')
-            continue
-        print(f' + {platform}: {filename}')
-        with open(filename) as fh:
-            subtract_environments[platform] = {p['name']: p for p in json.load(fh)}
+        platform, env_packages = get_env_packages(env)
+        subtract_environments[platform] = env_packages
 
     for platform in environments:
         remove_keys = []

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,24 +1,42 @@
 package:
   name: ska3-perl
-  version: 2020.01.24
+  version: 2020.13+shiny
+
+build:
+  skip: True  # [win]
 
 requirements:
   run:
-    - cfitsio ==3.450
-    - xtime ==1.2.2
-    - pgplot ==5.2.2 1 # [linux]
+    - _sysroot_linux-64_curr_repodata_hack ==3  # [linux]
+    - cfitsio ==3.470  # [linux]
+    - gsl ==2.4  # [linux]
+    - kernel-headers_linux-64 ==3.10.0  # [linux]
+    - krb5 ==1.18.2  # [linux]
+    - libcurl ==7.71.1  # [linux]
+    - libssh2 ==1.9.0  # [linux]
+    - libx11-common-cos7-x86_64 ==1.6.7  # [linux]
+    - libx11-cos7-x86_64 ==1.6.7  # [linux]
+    - libx11-devel-cos7-x86_64 ==1.6.7  # [linux]
     - perl ==5.26.2
-    - perl-extutils-f77 ==1.20
     - perl-app-cpanminus ==1.7044
-    - perl-core-deps ==0.1
-    - perl-pgplot ==2.19 # [linux]
-    - perl-dbd-sybase ==1.15 pl526_1 # [linux]
-    - perl-chandra-time ==0.9.2
-    - perl-app-env-ascds ==0.4
-    - perl-cxc-sysarch ==1.0
-    - perl-ska-agasc ==3.5.0
+    - perl-app-env-ascds ==0.04  # [linux]
+    - perl-chandra-time ==0.9.2  # [linux]
+    - perl-core-deps ==0.3
+    - perl-cxc-sysarch ==1.00  # [linux]
+    - perl-dbd-sybase ==1.15  # [linux]
+    - perl-extended-deps ==0.1  # [linux]
+    - perl-ska-agasc ==3.5.0  # [linux]
     - perl-ska-classic ==0.6
-    - perl-ska-convert ==4.3
-    - perl-ska-web ==4.0
-    - watch_cron_logs ==4.2
-    - task_schedule ==4.2.1
+    - perl-ska-convert ==4.3  # [linux]
+    - perl-ska-web ==4.0  # [linux]
+    - perl-tk ==804.035  # [linux]
+    - pkg-config ==0.29.2
+    - sysroot_linux-64 ==2.17  # [linux]
+    - xorg-kbproto ==1.0.7  # [linux]
+    - xorg-libx11 ==1.6.9  # [linux]
+    - xorg-libxft ==2.3.2  # [linux]
+    - xorg-libxrender ==0.9.10  # [linux]
+    - xorg-renderproto ==0.11.1  # [linux]
+    - xorg-xproto ==7.0.31  # [linux]
+    - xtime ==1.2.2  # [linux]
+    - zip ==3.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -7,6 +7,7 @@ build:
 
 requirements:
   run:
+    - ska3-core ==2020.13+shiny
     - _sysroot_linux-64_curr_repodata_hack ==3  # [linux]
     - cfitsio ==3.470  # [linux]
     - gsl ==2.4  # [linux]

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -8,6 +8,8 @@ build:
 requirements:
   run:
     - ska3-core ==2020.13+shiny
+    - task_schedule ==4.2.1
+    - watch_cron_logs ==4.2
     - _sysroot_linux-64_curr_repodata_hack ==3  # [linux]
     - cfitsio ==3.470  # [linux]
     - gsl ==2.4  # [linux]


### PR DESCRIPTION
Make a ska3-perl versioned metapackage for the shiny release candidate.  

Update combine_arch helper/utility script to with an option to subtract off the packages described by another platform-specific json file.  This new option was used to make the ska3-perl metapackage as the ska3-perl package should basically be the difference between the environment defined by (ska3-core ska3-flight ska3-perl-latest) and the one defined by (ska3-core ska3-flight).

