### PR TITLE
add ska-sphinx-theme

### DIFF
--- a/pkg_defs/ska-sphinx-theme/meta.yaml
+++ b/pkg_defs/ska-sphinx-theme/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: ska-sphinx-theme
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  noarch: python
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/ska-sphinx-theme
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - sphinx
+
+about:
+  home: https://github.com/sot/ska-sphinx-theme


### PR DESCRIPTION
Currently, if one wants to build the documentation, one installs the theme with 

```
pip install git+https://github.com/sot/ska-sphinx-theme.git
```

This PR adds a recipe for a conda package to skare3, in case people are interested.