### PR TITLE
2020.14

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2020.13+shiny
+  version: 2020.14
 
 requirements:
   run:

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - ska.shell ==3.5.0
     - ska.sun ==3.6.0
     - ska.tdb ==3.6.0
-    - ska3-core ==2020.13+shiny
+    - ska3-core ==2020.14
     - ska3-template ==2019.09.03
     - ska_helpers ==0.3.0
     - ska_path ==3.1.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -13,12 +13,12 @@ requirements:
     - aca_weekly_report ==0.1.3
     - acdc ==4.7.0
     - acis_taco ==4.2.0
-    - acis_thermal_check ==3.2.1
+    - acis_thermal_check ==3.4.0
     - acisfp_check ==3.2.0
-    - acispy ==2.0.1.dev12+gc5410da
-    - agasc ==4.10.1
+    - acispy ==2.1.0
+    - agasc ==4.10.2
     - annie ==0.11.0
-    - backstop_history ==1.2.0
+    - backstop_history ==1.3.0
     - bep_pcb_check ==3.0.0
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
@@ -40,7 +40,7 @@ requirements:
     - psmc_check ==3.0.0
     - pyyaks ==4.5.0
     - quaternion ==3.6.0
-    - ska-sphinx-theme ==1.2.dev0
+    - ska-sphinx-theme ==1.3.0
     - ska.arc5gl ==3.1.5
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2020.13+shiny
+  version: 2020.14
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - ska.shell ==3.5.0
     - ska.sun ==3.6.0
     - ska.tdb ==3.6.0
-    - ska3-core ==2020.13+shiny
+    - ska3-core ==2020.14
     - ska3-template ==2019.09.03
     - ska_helpers ==0.3.0
     - ska_path ==3.1.2

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -13,12 +13,12 @@ requirements:
     - aca_weekly_report ==0.1.3
     - acdc ==4.7.0
     - acis_taco ==4.2.0
-    - acis_thermal_check ==3.2.1
+    - acis_thermal_check ==3.4.0
     - acisfp_check ==3.2.0
-    - acispy ==2.0.1.dev12+gc5410da
-    - agasc ==4.10.1
+    - acispy ==2.1.0
+    - agasc ==4.10.2
     - annie ==0.11.0
-    - backstop_history ==1.2.0
+    - backstop_history ==1.3.0
     - bep_pcb_check ==3.0.0
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
@@ -40,7 +40,7 @@ requirements:
     - psmc_check ==3.0.0
     - pyyaks ==4.5.0
     - quaternion ==3.6.0
-    - ska-sphinx-theme ==1.2.dev0
+    - ska-sphinx-theme ==1.3.0
     - ska.arc5gl ==3.1.5
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-perl
-  version: 2020.13+shiny
+  version: 2020.14
 
 build:
   skip: True  # [win]


### PR DESCRIPTION
# ska3-flight 2020.14

## Summary:

The Ska3 runtime environment consists of an integrated suite of Python-3 packages and
associated applications. The `shiny` distribution is a major update to Ska3 that includes:

- Python 3.6 => 3.8: many very useful new features ([What's New 3.7](https://docs.python.org/3/whatsnew/3.7.html), [What's New 3.8](https://docs.python.org/3/whatsnew/3.8.html)).  Highlights:
  - `dict` is now ordered by insertion order
  - [dataclasses](https://docs.python.org/3/library/dataclasses.html#module-dataclasses)
     - [A gentler way of classes in Python](https://realpython.com/python-data-classes/)
  - ["walrus" operator](https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions)
  - [very handy debug print format](https://docs.python.org/3/whatsnew/3.8.html#f-strings-support-for-self-documenting-expressions-and-debugging)
   
- Recent release of every core dependency, often including several years of new development / bug fixes
  - `Numpy` 1.12 (Jan-2017) => 1.18: stricter in many ways for more reliable code but may cause breakage.
  - `Matplotlib` 2.0 (Jan-2017) => 3.2
     - we've noticed minor changes in required keyword args in some plotting ('normed' no longer a kwarg of plt.hist)
     - pylab.find is no longer supported (see np.flatnonzero as a replacement for most applications)
  - `Scipy` 0.19 (Mar-2017) => 1.5
  - `Astropy` 4.0.1 (hopefully 4.1 to be released soon)
    - https://docs.astropy.org/en/v4.0.1/whatsnew/4.0.html#whatsnew-4-0-time-ymdhms
    - https://docs.astropy.org/en/v4.0.1/whatsnew/4.0.html#whatsnew-4-0-table-new
    - https://docs.astropy.org/en/v4.0.1/whatsnew/4.0.html#improvements-to-performance-for-tables
    - https://docs.astropy.org/en/v3.1.2/whatsnew/3.1.html#whatsnew-3-1-table
    - https://docs.astropy.org/en/v3.1.2/whatsnew/3.1.html#improvements-and-new-features-in-time
- Adds [Jupyterlab](https://jupyterlab.readthedocs.io/en/stable/): next generation Jupyter notebook environment
  - See https://towardsdatascience.com/jupyter-lab-evolution-of-the-jupyter-notebook-5297cacde6b
- Includes `CxoTime` which is now ready for production use and recommended instead of `Chandra.Time.DateTime`
- Other new packages of note:
  - `acispy`: Enhanced Ska data collection and plotting
  - `python-docx` and `docxtpl`: Python library for creating and updating Microsoft Word (.docx) files [local guru: John S].
  - `filelock`: Platform independent file lock that supports the with-statement.
  - `jira`: Python library to work with Jira APIs
  - `libarchive`: One-stop compressed archive creation and extraction (zip, tar, bz2, bstd) (https://github.com/dsoprea/PyEasyArchive)
  - `mpld3`: Make live browser or notebook plots using matplotlib (https://mpld3.github.io/)
  - `pandoc`: Universal document converter (https://pandoc.org/)
  - `pycosat`: SAT solver for computer geeks.
  - `ruamel_yaml`: Newer YAML interface with support for YAML 1.2 (https://yaml.readthedocs.io/en/latest/overview.html).
  - `snappy`: Fast compression library from Google.

- Other updated packages of note:
  - `conda` 4.8.3: not compatible with previous Ska3 conda (4.3) or any conda < 4.7
  - `pytest` 5.4.3: much improved and stricter than previous pytest 3.2.1; shows warnings by default.

- New documentation pages
  - https://sot.github.io/

- Under the hood
  - Many infrastructure updates that make managing Ska3 feasible.
  - Mostly captured in [Skare3 tools](https://sot.github.io/skare3_tools/)
  - Hourly updates of [Ska3 package dashboard](https://cxc.cfa.harvard.edu/mta/ASPECT/skare3/dashboard/)
  - Daily run of full integration tests on linux using the latest development version of all Ska3 packages, with
     detailed inspection of test failures supported.
  - Integration tests can run (and pass) on Mac and Windows now.
  - Auto-generated and deployed documentation for each package release.
  - Use of GitHub actions for CI and code linting
  - Bulk GitHub PR's and updating of all Ska3 packages at once.

In addition to distributions built for linux (CentOS-7+) and MacOSX (Catalina), `shiny` adds a fully-functional
and tested binary conda distribution for Windows 10. This will be the basis for FOT MATLAB tools with the 2020_015 release.

## Detailed package changes

See below.

## Interface Impacts:

In general the core packages numpy, scipy, and matplotlib (and many others) have changed so much that functional testing is the only way to determine the interface impacts.

- `Chandra.cmd_states` deprecated in favor of `kadi.commands.states`
- `Ska.ParseCM` deprecated in favor of `parse_cm`.
```
FutureWarning: Ska.ParseCM is deprecated, use parse_cm instead
```
- Update `Chandra.Time` 3.20 =>  4.0 with change that `2020:001` => `2020:001:00:00:00` instead of `2020:001:12:00:00`. This
  can break code (especially tests) that use the shorthand YYYY:DDD notation for dates.

- Cheta remote data access from chimchim
  - Python 3.8 code requires using python 3.8 remote server, and likewise for Python 3.6.
  - For MATLAB tools users everything should just work.
  - Standalone users need to ensure they have the correct new remote key file.
  - Remote servers for both versions are up and will remain running following deployment. Contact Mark Baski for questions.
 
## Testing:

See https://github.com/sot/skare3/wiki/Ska3-shiny-testing

## Review:

Community review of content and testing.

## Deployment:

See https://github.com/sot/skare3/wiki/Shiny-promotion-plan

## Outstanding actions

- Update [user instructions for Ska3](https://github.com/sot/skare3/wiki/Ska3-runtime-environment-for-users) to reflect the shiny update. This will include instructions for standalone users to reinstall (doing an in-place update does not work) and updates to the maintenance process.

## Updated package requiring separate approval by FD

- **arc / a.k.a Replan Central** 4.3.0 -> 4.4.0
  - [PR 55](https://github.com/sot/arc/pull/55)(jeanconn): Update for Shiny

Description: Version 4.4.0 includes a set of small changes for the new Python 3.8 "shiny" environment.

Rationale:Small changes to the plotting commands were required to work in the new environment. While making those changes, several other small improvements were effected.

Code changes:
https://github.com/sot/arc/pull/55 - Update for shiny

This:Includes minor changes to a couple of Matplotlib commands that have changed for version 3.2.
Sets the timeline code to use kadi for commanded states instead of cmd_states.

Testing:This has been run in a shiny testing area and we have confirmed the processing and plots are reasonable.

Interface Impacts:None

Review:Ska team review.

Deployment Plan:This version will be installed as part of the shiny deployment.

# Code Changes

## ska3-flight changes (2020.12 -> 2020.14rc1)

### New Packages
- **aca_hi_bgd: 0.1.4**
- **aca_weekly_report: 0.1.3**
- **acispy: 2.1.0**
- **perigee_health_plots: 0.1.2**
- **ska-sphinx-theme: 1.3.0**
- **ska.report_ranges: 0.4.0**
- **skare3_tools: 1.0.1**

### Removed Packages

- **jplephem** # now included as a ska3-core package not a ska3-flight package
- **tables3_api**

### Updated Packages

- **aca_view:** 0.3.0 -> 0.4.1 (0.3.0 -> 0.4.0 -> 0.4.1): *Incremental improvements working toward replacing ACA EGSE*
  - [PR 45](https://github.com/sot/aca_view/pull/45) (javierggt): Add documentation directory
  - [PR 46](https://github.com/sot/aca_view/pull/46) (javierggt): Moved docs sources to another directory
  - [PR 55](https://github.com/sot/aca_view/pull/55) (javierggt): Unified documentation style
  - [PR 56](https://github.com/sot/aca_view/pull/56) (javierggt): Shiny-related changes and other small things
  - [PR 61](https://github.com/sot/aca_view/pull/61) (javierggt): Fix time-matching between images and centroids.
  - [PR 62](https://github.com/sot/aca_view/pull/62) (javierggt): Configurable main-window size
  - [PR 63](https://github.com/sot/aca_view/pull/63) (javierggt): Tweaks: date format, temperature units, image titles, magnitudes
- **acdc:** 4.5.0 -> 4.7.0 (4.5.0 -> 4.6.0 -> 4.7.0): *Improved plots and usability*
  - [PR 51](https://github.com/sot/acdc/pull/51) (taldcroft): *Add 5-year plots of relevant quantities*
  - [PR 50](https://github.com/sot/acdc/pull/50) (taldcroft): Rearrange README and add docs on excluding SRDC's
  - [PR 52](https://github.com/sot/acdc/pull/52) (taldcroft): Remove flake8 checking on f-string with no values
  - [PR 53](https://github.com/sot/acdc/pull/53) (taldcroft): Add 2020:145 safe mode to annotated plot
  - [PR 57](https://github.com/sot/acdc/pull/57) (jconnelly): Update flake8 check to use py38
  - [PR 58](https://github.com/sot/acdc/pull/58) (taldcroft): Fixes for shiny
  - [PR 56](https://github.com/sot/acdc/pull/56) (jconnelly): *Add a summary page and relocate to public web*
- **acis_taco:** 4.1.0 -> 4.2.0 (4.1.0 -> 4.2.0)
  - [PR 15](https://github.com/sot/taco/pull/15) (javierggt): Setting up automated builds
  - [PR 16](https://github.com/sot/taco/pull/16) (taldcroft): SHINY: Use legacy np printoptions for regression consistency
  - [PR 19](https://github.com/sot/taco/pull/19) (taldcroft): Changes for Python 3 and matplotlib deprecations
  - [PR 20](https://github.com/sot/taco/pull/20) (taldcroft): Updates for matplotlib 3.2
- **acis_thermal_check:** 3.3.0 -> 3.4.0 (3.3.0 -> 3.4.0): *Use kadi.commands not Chandra.cmds_states, Ska.ParseCM*
  - [PR 35](https://github.com/acisops/acis_thermal_check/pull/35) (jzuhone): Re-issue Shiny PR
- **acisfp_check:** 3.3.0 -> 3.2.0 (3.3.0)
- **agasc:** 4.8.1 -> 4.10.2 (4.8.1 -> 4.9.0 -> 4.10.0 -> 4.10.1 -> 4.10.2): *Add magnitude estimation infrastructure*
  - [PR 46](https://github.com/sot/agasc/pull/46) (javierggt): Unified documentation style
  - [PR 48](https://github.com/sot/agasc/pull/48) (javierggt): *added magnitude estimation (formerly known as mag-stats)*
  - [PR 50](https://github.com/sot/agasc/pull/50) (taldcroft): Nicer documentation including AGASC catalog description
  - [PR 51](https://github.com/sot/agasc/pull/51) (jconnelly): Skip the mag supplement tests when no mags in supplement
  - [PR 53](https://github.com/sot/agasc/pull/53) (jconnelly): Remove UserWarning on no mag table in supplement
  - [PR 52](https://github.com/sot/agasc/pull/52) (jconnelly): Update supplement MAG_ACA_ERR test
  - [PR 54](https://github.com/sot/agasc/pull/54) (javierggt): Fixes in supplement update script (start/stop, input/output, docs)
- **annie:** 0.10.1 -> 0.11.0 (0.10.1 -> 0.11.0) 
  - [PR 101](https://github.com/sot/annie/pull/101) (taldcroft): SHINY: Pass tests
  - [PR 105](https://github.com/sot/annie/pull/105) (javierggt): Unified documentation style
  - [PR 106](https://github.com/sot/annie/pull/106) (taldcroft): Doc fixes
- **backstop_history:** 1.2.0 -> 1.3.0 (1.2.0 -> 1.3.0) : *Use kadi.commands not Chandra.cmds_states, Ska.ParseCM*
  - [PR 17](https://github.com/acisops/backstop_history/pull/17) (ggermain): *Modifications to Baskstop History to accommodate data structure change…*
- **bep_pcb_check:** 3.1.0 -> 3.0.0 (3.1.0)
- **chandra.cmd_states:** 3.15.2 -> 3.16.0 (3.15.2 -> 3.16.0) : *Shiny compatibility, minor bug fix*
  - [PR 52](https://github.com/sot/cmd_states/pull/52) (taldcroft): Version for shiny
  - [PR 54](https://github.com/sot/cmd_states/pull/54) (taldcroft): Ignore warnings
  - [PR 55](https://github.com/sot/cmd_states/pull/55) (taldcroft): Updates for shiny
  - [PR 56](https://github.com/sot/cmd_states/pull/56) (taldcroft): Ignore Ska.ParseCM warning in testing
  - [PR 59](https://github.com/sot/cmd_states/pull/59) (jconnelly): *Warn on use of sybase to get cmd_states*
  - [PR 61](https://github.com/sot/cmd_states/pull/61) (jconnelly): Set interrupt_loads to shorten timelines only as short as zero length
  - [PR 62](https://github.com/sot/cmd_states/pull/62) (javierggt): Unified documentation style
- **chandra.maneuver:** 3.7.3 -> 3.8.0 (3.7.3 -> 3.8.0)
  - [PR 18](https://github.com/sot/Chandra.Maneuver/pull/18) (taldcroft): Version for shiny
  - [PR 19](https://github.com/sot/Chandra.Maneuver/pull/19) (taldcroft): Ignore expected warnings in pytest
  - [PR 23](https://github.com/sot/Chandra.Maneuver/pull/23) (javierggt): Unified documentation style
- **chandra.time:** 3.20.6 -> 4.0.0 (3.20.6 -> 4.0.0) : *Support CxoTime and change in handling of 2020:001*
  - [PR 40](https://github.com/sot/Chandra.Time/pull/40) (taldcroft): Allow setup.py --version to work without Cython
  - [PR 44](https://github.com/sot/Chandra.Time/pull/44) (taldcroft): Version for shiny
  - [PR 43](https://github.com/sot/Chandra.Time/pull/43) (taldcroft): Migrate pydocs sphinx docs to project
  - [PR 42](https://github.com/sot/Chandra.Time/pull/42) (taldcroft): Support CxoTime in DateTime and modernize
  - [PR 45](https://github.com/sot/Chandra.Time/pull/45) (taldcroft): Flake8
  - [PR 46](https://github.com/sot/Chandra.Time/pull/46) (taldcroft): Change so date like 2020:001 is midnight not noon
  - [PR 47](https://github.com/sot/Chandra.Time/pull/47) (taldcroft): Disable automatic astropy.iers downloads
  - [PR 48](https://github.com/sot/Chandra.Time/pull/48) (taldcroft): Shiny
  - [PR 52](https://github.com/sot/Chandra.Time/pull/52) (javierggt): Unified documentation style
- **chandra_aca:** 4.29.1 -> 4.31.1 (4.29.1 -> 4.30.0 -> 4.31.0 -> 4.31.1)
  - [PR 95](https://github.com/sot/chandra_aca/pull/95) (javierggt): Fixed bug in decom of imgstat. It must be an unsigned int.
  - [PR 99](https://github.com/sot/chandra_aca/pull/99) (taldcroft): Shiny tests
  - [PR 90](https://github.com/sot/chandra_aca/pull/90) (taldcroft): Add PIXTLM and BGDTYP
  - [PR 104](https://github.com/sot/chandra_aca/pull/104) (taldcroft): Migrate transforms here and make them work for N-d inputs
  - [PR 105](https://github.com/sot/chandra_aca/pull/105) (javierggt): Unified documentation style
  - [PR 107](https://github.com/sot/chandra_aca/pull/107) (jconnelly): Remove check that interval is just one obsid (for obc sol)
  - [PR 106](https://github.com/sot/chandra_aca/pull/106) (jconnelly): Use modern vectorized Quaternion
  - [PR 108](https://github.com/sot/chandra_aca/pull/108) (taldcroft): *Support calculating and plotting planet positions*
  - [PR 109](https://github.com/sot/chandra_aca/pull/109) (javierggt): Improve setup.py for ephemeris data download
  - [PR 110](https://github.com/sot/chandra_aca/pull/110) (taldcroft): Improve _aca_packets_to_table speed by factor of 20
  - [PR 111](https://github.com/sot/chandra_aca/pull/111) (javierggt): Fix aca_view issue 57, need masked=True in Table creation
  - [PR 112](https://github.com/sot/chandra_aca/pull/112) (taldcroft): Calculate row/col of planet even if off CCD
- **cxotime:** 3.1.1 -> 3.2.3 (3.1.1 -> 3.2.0 -> 3.2.1 -> 3.2.2 -> 3.2.3) : *Now production-ready*
  - [PR 4](https://github.com/sot/cxotime/pull/4) (javierggt): Setting up automated builds
  - [PR 6](https://github.com/sot/cxotime/pull/6) (taldcroft): SHINY: always use UTC scale for DateTime formats + other improvements
  - [PR 7](https://github.com/sot/cxotime/pull/7) (taldcroft): Shiny
  - [PR 8](https://github.com/sot/cxotime/pull/8) (taldcroft): Improve the documentation
  - [PR 9](https://github.com/sot/cxotime/pull/9) (taldcroft): Allow for CxoTime() to get current time in date format
  - [PR 13](https://github.com/sot/cxotime/pull/13) (taldcroft): Faster guessing of CxoTime-specific formats
  - [PR 17](https://github.com/sot/cxotime/pull/17) (taldcroft): Add flake8 checking workflow
  - [PR 14](https://github.com/sot/cxotime/pull/14) (javierggt): Unified documentation style
  - [PR 15](https://github.com/sot/cxotime/pull/15) (taldcroft): *Much faster parsing in CxoTime and add maude format*
  - [PR 21](https://github.com/sot/cxotime/pull/21) (javierggt): Copy changes from astropy. Fixes issue #20 (C99 mode)
  - [PR 16](https://github.com/sot/cxotime/pull/16) (taldcroft): export astropy units and TimeDelta within cxotime
  - [PR 22](https://github.com/sot/cxotime/pull/22) (taldcroft): Remove an extra underscore in PyInit declaration
  - [PR 23](https://github.com/sot/cxotime/pull/23) (taldcroft): Fix incompatibility with DateTime init with None
- **find_attitude:** 3.3.2 -> 3.4.0 (3.3.2 -> 3.4.0)
  - [PR 11](https://github.com/sot/find_attitude/pull/11) (javierggt): Setting up automated builds
  - [PR 15](https://github.com/sot/find_attitude/pull/15) (javierggt): Unified documentation style
- **hopper:** 4.4.1 -> 4.5.0 (4.4.1 -> 4.5.0)
  - [PR 17](https://github.com/sot/hopper/pull/17) (javierggt): Setting up automated builds
- **kadi:** 5.2.0 -> 5.4.0 (5.2.0 -> 5.3.0 -> 5.4.0)
  - [PR 165](https://github.com/sot/kadi/pull/165) (taldcroft): Fix flake8 issues
  - [PR 166](https://github.com/sot/kadi/pull/166) (taldcroft): SHINY: update dates for Chandra.Time 4.0+
  - [PR 167](https://github.com/sot/kadi/pull/167) (taldcroft): SHINY: remove all dependencies on Chandra.cmd_states and Ska.ParseCM
  - [PR 169](https://github.com/sot/kadi/pull/169) (taldcroft): Change default remove_starcat to False
  - [PR 168](https://github.com/sot/kadi/pull/168) (taldcroft): SHINY: add times to states and commands outputs
  - [PR 170](https://github.com/sot/kadi/pull/170) (taldcroft): *Add helpers for compatibility with legacy commands / states code*
  - [PR 173](https://github.com/sot/kadi/pull/173) (taldcroft): Fix async problem of event query within Jupyter notebook
  - [PR 175](https://github.com/sot/kadi/pull/175) (taldcroft): Shiny
  - [PR 176](https://github.com/sot/kadi/pull/176) (taldcroft): *Fix continuity and states for start within maneuver*
  - [PR 190](https://github.com/sot/kadi/pull/190) (taldcroft): Migrate cmds.h5 idx column from 16 to 32 bits
  - [PR 193](https://github.com/sot/kadi/pull/193) (javierggt): Unified documentation style
  - [PR 194](https://github.com/sot/kadi/pull/194) (taldcroft): Use $SKA/data/mpcrit1 not /data/mpcrit1
- **maude:** 3.3.2 -> 3.4.0 (3.3.2 -> 3.4.0)
  - [PR 22](https://github.com/sot/maude/pull/22) (javierggt): setting token for authentication
  - [PR 23](https://github.com/sot/maude/pull/23) (taldcroft): SHINY: update test times for Chandra.Time 4.0+
  - [PR 27](https://github.com/sot/maude/pull/27) (javierggt): Unified documentation style
- **mica:** 4.21.2 -> 4.23.0 (4.21.2 -> 4.22.0 -> 4.23.0)
  - [PR 225](https://github.com/sot/mica/pull/225) (taldcroft): Remove tables3_api imports
  - [PR 226](https://github.com/sot/mica/pull/226) (taldcroft): Updates for passing tests on shiny
  - [PR 224](https://github.com/sot/mica/pull/224) (taldcroft): test_get_l0_images ends up trying to load mica/archive/asp1/archfiles…
  - [PR 227](https://github.com/sot/mica/pull/227) (taldcroft): Remove use of Chandra.cmd_states
  - [PR 230](https://github.com/sot/mica/pull/230) (taldcroft): Shiny 
  - [PR 231](https://github.com/sot/mica/pull/231) (taldcroft): More shiny fixes
  - [PR 233](https://github.com/sot/mica/pull/233) (taldcroft): Use q_att_raw for ASPSOL quaternions if available
  - [PR 240](https://github.com/sot/mica/pull/240) (taldcroft): Unified documentation style
  - [PR 244](https://github.com/sot/mica/pull/244) (jconnelly): Don't throw error if there is more than one log (more than one aspect interval)
  - [PR 245](https://github.com/sot/mica/pull/245) (javierggt): removed outdated documentation section
  - [PR 80](https://github.com/sot/mica/pull/80) (jconnelly): Add the list of obsids that are bad for trending to the project
  - [PR 242](https://github.com/sot/mica/pull/242) (taldcroft): Remove warning when account doesn't have axafvv access
  - [PR 236](https://github.com/sot/mica/pull/236) (jconnelly): Toss the centroid dashboard code into mica
  - [PR 248](https://github.com/sot/mica/pull/248) (jconnelly): Fixes for asp1 processing
  - [PR 247](https://github.com/sot/mica/pull/247) (taldcroft): Add mod to be able to get 8x8 images in aca_l0.get_slot_data
- **proseco:** 4.8.1 -> 4.10.0 (4.8.1 -> 4.9.0 -> 4.10.0)
  - [PR 326](https://github.com/sot/proseco/pull/326) (taldcroft): Fix a documentation link
  - [PR 327](https://github.com/sot/proseco/pull/327) (taldcroft): Update flake8 checking for recent version of flake8
  - [PR 317](https://github.com/sot/proseco/pull/317) (taldcroft): Fixes for shiny Ska3
  - [PR 328](https://github.com/sot/proseco/pull/328) (taldcroft): *Add monitors and target_offset attributes to ACACatalogTable*
  - [PR 332](https://github.com/sot/proseco/pull/332) (taldcroft): Fix inadvertent re-use of base class `allowed_kwargs`
  - [PR 333](https://github.com/sot/proseco/pull/333) (taldcroft): *Remove defunct thumbs_up property*
  - [PR 334](https://github.com/sot/proseco/pull/334) (taldcroft): Set to use 3.8 in flake8 check
  - [PR 331](https://github.com/sot/proseco/pull/331) (taldcroft): *Add include/exclude of fids by index/id*
  - [PR 343](https://github.com/sot/proseco/pull/343) (taldcroft): Fix allowed_kwargs test after #331
  - [PR 341](https://github.com/sot/proseco/pull/341) (taldcroft): Update to use chandra_aca versions of radec_to_yagzag, and yagzag_to_radec
  - [PR 344](https://github.com/sot/proseco/pull/344) (taldcroft): *Add img_size guide parameter to control guide star image readout size*
  - [PR 339](https://github.com/sot/proseco/pull/339) (javierggt): Unified documentation style
  - [PR 348](https://github.com/sot/proseco/pull/348) (jconnelly): *Update penalty limit from -8.1 to -7.5C*
- **psmc_check:** 3.1.0 -> 3.0.0 (3.1.0)
- **pyyaks:** 4.4.2 -> 4.5.0 (4.4.2 -> 4.5.0)
  - [PR 12](https://github.com/sot/pyyaks/pull/12) (taldcroft): SHINY: fix test to pass with modern pytest
- **quaternion:** 3.5.2 -> 3.6.0 (3.5.2 -> 3.6.0)
  - [PR 32](https://github.com/sot/Quaternion/pull/32) (taldcroft): Add rotate_x_to_vec class method (from Ska.quatutil)
  - [PR 33](https://github.com/sot/Quaternion/pull/33) (javierggt): Unified documentation style
- **ska.arc5gl:** 3.1.4 -> 3.1.5 (3.1.4 -> 3.1.5)
  - [PR 12](https://github.com/sot/Ska.arc5gl/pull/12) (javierggt): Unified documentation style
- **ska.astro:** 3.2.4 -> 3.3.0 (3.2.4 -> 3.3.0)
  - [PR 12](https://github.com/sot/Ska.astro/pull/12) (javierggt): Unified documentation style
- **ska.dbi:** 4.0.2 -> 4.1.0 (4.0.2 -> 4.1.0)
  - [PR 17](https://github.com/sot/Ska.DBI/pull/17) (taldcroft): Version for shiny
  - [PR 21](https://github.com/sot/Ska.DBI/pull/21) (javierggt): Unified documentation style
- **ska.engarchive:** 4.48.0 -> 4.50.1 (4.48.0 -> 4.49.0 -> 4.50.0 -> 4.50.1)
  - [PR 194](https://github.com/sot/eng_archive/pull/194) (taldcroft): Better warnings
  - [PR 195](https://github.com/sot/eng_archive/pull/195) (taldcroft): Fix problem with sync stats update for rarely sampled content
  - [PR 196](https://github.com/sot/eng_archive/pull/196) (taldcroft): *Allow model version in MUPS clean computed MSID and fix tests*
  - [PR 197](https://github.com/sot/eng_archive/pull/197) (taldcroft): Shiny tests
  - [PR 198](https://github.com/sot/eng_archive/pull/198) (taldcroft): Allow multiple paths in ENG_ARCHIVE
  - [PR 203](https://github.com/sot/eng_archive/pull/203) (javierggt): Unified documentation style
  - [PR 202](https://github.com/sot/eng_archive/pull/202) (taldcroft): Remove use of axes.axesPatch. This is a shiny change. Fixes #201
  - [PR 204](https://github.com/sot/eng_archive/pull/204) (taldcroft): Fix a problem with remote access on Windows in Py3.8
  - [PR 205](https://github.com/sot/eng_archive/pull/205) (taldcroft): Shiny remote followup
  - [PR 206](https://github.com/sot/eng_archive/pull/206) (taldcroft): Lazy-load inital content and remote access setup
  - [PR 208](https://github.com/sot/eng_archive/pull/208) (taldcroft): *Use get_xija_model_spec instead of GitHub for pftank2t model*
- **ska.file:** 3.4.4 -> 3.4.5 (3.4.4 -> 3.4.5)
  - [PR 13](https://github.com/sot/Ska.File/pull/13) (javierggt): Unified documentation style
- **ska.ftp:** 3.5.3 -> 3.6.0 (3.5.3 -> 3.6.0)
  - [PR 21](https://github.com/sot/Ska.ftp/pull/21) (taldcroft): Improve input validation, make tests more consistent
  - [PR 22](https://github.com/sot/Ska.ftp/pull/22) (taldcroft): Version for shiny
  - [PR 26](https://github.com/sot/Ska.ftp/pull/26) (javierggt): Unified documentation style
- **ska.matplotlib:** 3.11.4 -> 3.12.0 (3.11.4 -> 3.12.0)
  - [PR 9](https://github.com/sot/Ska.Matplotlib/pull/9) (taldcroft): *Avoid top-level import of pyplot for benefit of upstream packages*
  - [PR 13](https://github.com/sot/Ska.Matplotlib/pull/13) (taldcroft): Version for shiny
  - [PR 14](https://github.com/sot/Ska.Matplotlib/pull/14) (taldcroft): Accept any validate DateTime or CxoTime initializer
  - [PR 18](https://github.com/sot/Ska.Matplotlib/pull/18) (javierggt): Unified documentation style
- **ska.numpy:** 3.8.4 -> 3.9.0 (3.8.4 -> 3.9.0)
  - [PR 7](https://github.com/sot/Ska.Numpy/pull/7) (taldcroft): Allow setup.py --version to run without Cython, numpy
  - [PR 8](https://github.com/sot/Ska.Numpy/pull/8) (taldcroft): Version for shiny
  - [PR 9](https://github.com/sot/Ska.Numpy/pull/9) (taldcroft): Shiny tests
  - [PR 13](https://github.com/sot/Ska.Numpy/pull/13) (javierggt): Unified documentation style
- **ska.parsecm:** 3.3.4 -> 3.4.0 (3.3.4 -> 3.4.0)
  - [PR 8](https://github.com/sot/Ska.ParseCM/pull/8) (taldcroft): *Deprecate use of Ska.ParseCM* : Note that this deprecation propagates to Chandra.cmd_states 
  - [PR 12](https://github.com/sot/Ska.ParseCM/pull/12) (javierggt): Unified documentation style
- **ska.quatutil:** 3.3.3 -> 3.4.0 (3.3.3 -> 3.4.0)
  - [PR 10](https://github.com/sot/Ska.quatutil/pull/10) (taldcroft): Version for shiny
  - [PR 15](https://github.com/sot/Ska.quatutil/pull/15) (javierggt): Unified documentation style
- **ska.shell:** 3.4.1 -> 3.5.0 (3.4.1 -> 3.5.0)
  - [PR 19](https://github.com/sot/Ska.Shell/pull/19) (taldcroft): Use explicit package name in call to get_version
  - [PR 23](https://github.com/sot/Ska.Shell/pull/23) (javierggt): Unified documentation style
- **ska.sun:** 3.5.3 -> 3.6.0 (3.5.3 -> 3.6.0)
  - [PR 15](https://github.com/sot/Ska.Sun/pull/15) (javierggt): Unified documentation style
- **ska.tdb:** 3.5.3 -> 3.6.0 (3.5.3 -> 3.6.0)
  - [PR 12](https://github.com/sot/Ska.tdb/pull/12) (taldcroft): Version for shiny
  - [PR 16](https://github.com/sot/Ska.tdb/pull/16) (javierggt): Unified documentation style
- **ska3-core:** 2020.5 -> 2020.14rc1
- **ska_helpers:** 0.1.2 -> 0.3.0 (0.1.2 -> 0.2.0 -> 0.3.0)
  - [PR 13](https://github.com/sot/ska_helpers/pull/13) (taldcroft): Ignore useless warning about Ska being already imported
  - [PR 16](https://github.com/sot/ska_helpers/pull/16) (taldcroft): Add ska_helpers.utils module with LazyDict
- **ska_path:** 3.1.1 -> 3.1.2 (3.1.1 -> 3.1.2)
  - [PR 6](https://github.com/sot/ska_path/pull/6) (javierggt): Setting up automated builds
- **ska_sync:** 4.6.0 -> 4.7.0 (4.6.0 -> 4.7.0)
  - [PR 17](https://github.com/sot/ska_sync/pull/17) (javierggt): Setting up automated builds
  - [PR 16](https://github.com/sot/ska_sync/pull/16) (jconnelly): Add old config as ska_sync/limited_config
  - [PR 22](https://github.com/sot/ska_sync/pull/22) (taldcroft): Use getpass.getuser() instead of USER env var
  - [PR 21](https://github.com/sot/ska_sync/pull/21) (taldcroft): Add chandra_models for sync
- **sparkles:** 4.6.0 -> 4.7.0 (4.6.0 -> 4.7.0)
  - [PR 142](https://github.com/sot/sparkles/pull/142) (taldcroft): Fix date in test for Chandra.Time 4.0+
  - [PR 143](https://github.com/sot/sparkles/pull/143) (taldcroft): formatted callargs HTML id to be consistent between JavaScript and HTML
  - [PR 106](https://github.com/sot/sparkles/pull/106) (taldcroft): *Improve roll options including uniform sampling of roll range*
- **starcheck:** 13.7.0 -> 13.8.0 (13.7.0 -> 13.7.1 -> 13.8.0)
  - [PR 356](https://github.com/sot/starcheck/pull/356) (taldcroft): Remove orphaned scripts / makefile
  - [PR 357](https://github.com/sot/starcheck/pull/357) (jconnelly): change yaml loading to avoid warning
  - [PR 358](https://github.com/sot/starcheck/pull/358) (jconnelly): Fix info statement regarding being off padded CCD
  - [PR 360](https://github.com/sot/starcheck/pull/360) (jconnelly): *Planning limit increase -7.1 C to -6.5 C, penalty limit -8.1 C to -7.5 C*
- **testr:** 4.3.1 -> 4.5.0 (4.3.1 -> 4.4.0 -> 4.5.0)
  - [PR 20](https://github.com/sot/testr/pull/20) (javierggt): Setting up automated builds
  - [PR 22](https://github.com/sot/testr/pull/22) (taldcroft): Ignore certain warnings and supply pytest args as list not string
  - [PR 21](https://github.com/sot/testr/pull/21) (javierggt): Skare3 ci
  - [PR 23](https://github.com/sot/testr/pull/23) (taldcroft): Disable caching of test results
  - [PR 24](https://github.com/sot/testr/pull/24) (taldcroft): Support running with no --test-spec
  - [PR 25](https://github.com/sot/testr/pull/25) (taldcroft): Ignore bleach warning
  - [PR 29](https://github.com/sot/testr/pull/29) (javierggt): Unified documentation style
  - [PR 30](https://github.com/sot/testr/pull/30) (javierggt): rename log files and use pathlib.Path
  - [PR 32](https://github.com/sot/testr/pull/32) (taldcroft): Support Windows for package testing
- **xija:** 4.19.0 -> 4.21.1 (4.19.0 -> 4.20.0 -> 4.20.1 -> 4.21.0 -> 4.21.1)
  - [PR 91](https://github.com/sot/xija/pull/91) (taldcroft): Shiny
  - [PR 95](https://github.com/sot/xija/pull/95) (javierggt): Unified documentation style
  - [PR 97](https://github.com/sot/xija/pull/97) (taldcroft): Migrate all doc strings to use numpydoc
  - [PR 99](https://github.com/sot/xija/pull/99) (taldcroft): Allow model_spec to be provided as Path
  - [PR 96](https://github.com/sot/xija/pull/96) (taldcroft): *Add module to allow getting model spec files from Ska data*
  - [PR 100](https://github.com/sot/xija/pull/100) (taldcroft): Add timeout error catch that occurs on linux
  - [PR 102](https://github.com/sot/xija/pull/102) (taldcroft): Fix get_model_spec to work on Windows
  - [PR 103](https://github.com/sot/xija/pull/103) (taldcroft): *Add MSIDStatePower component*
  - [PR 104](https://github.com/sot/xija/pull/104) (taldcroft): Use github's 'latest' release link for latest version

## ska3-core changes (2020.5 -> 2020.14rc1)

### New Packages
- **astropy-sphinx-theme: 1.1**
- **attrs: 19.3.0**
- **autopep8: 1.5.3**
- **backcall: 0.2.0**
- **bcrypt: 3.1.7**
- **blosc: 1.19.0**
- **brotlipy: 0.7.0**
- **bzip2: 1.0.8**
- **ca-certificates: 2020.6.24**
- **commonmark: 0.9.1**
- **conda: 4.8.3**
- **conda-build: 3.18.11**
- **conda-package-handling: 1.6.1**
- **dbus: 1.13.16**
- **filelock: 3.0.12**
- **flake8: 3.8.3**
- **future: 0.18.2**
- **gettext: 0.19.8.1**
- **gitdb: 4.0.5**
- **glib: 2.65.0**
- **glob2: 0.7**
- **importlib-metadata: 1.7.0**
- **importlib_metadata: 1.7.0**
- **intel-openmp: 2019.4**
- **joblib: 0.16.0**
- **jplephem: 2.14**
- **json5: 0.9.5**
- **jupyterlab: 2.1.5**
- **jupyterlab_server: 1.2.0**
- **kiwisolver: 1.2.0**
- **lcms2: 2.11**
- **libarchive: 3.4.2**
- **libedit: 3.1.20191231**
- **libffi: 3.3**
- **libiconv: 1.16**
- **liblief: 0.10.1**
- **libllvm9: 9.0.1**
- **libsodium: 1.0.18**
- **libxml2: 2.9.10**
- **llvm-openmp: 10.0.0**
- **lz4-c: 1.9.2**
- **lzo: 2.10**
- **matplotlib-base: 3.2.2**
- **mccabe: 0.6.1**
- **mkl-service: 2.3.0**
- **mkl_fft: 1.1.0**
- **mkl_random: 1.1.1**
- **mock: 4.0.2**
- **more-itertools: 8.4.0**
- **ncurses: 6.2**
- **numpy-base: 1.18.5**
- **pandoc: 2.10**
- **parso: 0.7.0**
- **pcre: 8.44**
- **pkginfo: 1.5.0.1**
- **pluggy: 0.13.1**
- **prometheus_client: 0.8.0**
- **prompt-toolkit: 3.0.5**
- **py-lief: 0.10.1**
- **pycosat: 0.6.3**
- **pynacl: 1.4.0**
- **pyopenssl: 19.1.0**
- **pyrsistent: 0.16.0**
- **pysocks: 1.7.1**
- **python-libarchive-c: 2.9**
- **ripgrep: 11.0.2**
- **ruamel_yaml: 0.15.87**
- **send2trash: 1.5.0**
- **setuptools-scm: 4.1.2**
- **smmap: 3.0.2**
- **snappy: 1.1.8**
- **soupsieve: 2.0.1**
- **sphinx-argparse: 0.2.5**
- **sphinxcontrib-applehelp: 1.0.2**
- **sphinxcontrib-devhelp: 1.0.2**
- **sphinxcontrib-htmlhelp: 1.0.3**
- **sphinxcontrib-jsmath: 1.0.1**
- **sphinxcontrib-qthelp: 1.0.3**
- **sphinxcontrib-serializinghtml: 1.1.4**
- **tbb: 2020.0**
- **threadpoolctl: 2.1.0**
- **toml: 0.10.1**
- **tqdm: 4.47.0**
- **typing_extensions: 3.7.4.2**
- **urllib3: 1.25.9**
- **webencodings: 0.5.1**
- **zipp: 3.1.0**
- **zstd: 1.4.5**


### Removed Packages

- **_nb_ext_conf**
- **anaconda-client**
- **asn1crypto**
- **bkcharts**
- **clyent**
- **curl**
- **git**
- **gitdb2**
- **html5lib**
- **jbig**
- **krb5**
- **libgcc**
- **libssh2**
- **nb_anacondacloud**
- **nbpresent**
- **path.py**
- **pep8**
- **pyasn1**
- **pytest-arraydiff**
- **pytest-astropy**
- **pytest-doctestplus**
- **pytest-openfiles**
- **pytest-remotedata**
- **python.app**
- **qtawesome**
- **runipy**
- **simplegeneric**
- **singledispatch**
- **smmap2**
- **sphinxcontrib**
- **sphinxcontrib-websupport**

### Updated Packages

- **alabaster:** 0.7.10 -> 0.7.12
- **asgiref:** 3.2.3 -> 3.2.10
- **astroid:** 1.5.3 -> 2.4.2
- **astropy:** 3.0.3 -> 4.0.1.post1
- **astropy-healpix:** 0.4 -> 0.5
- **babel:** 2.5.0 -> 2.8.0
- **beautifulsoup4:** 4.6.0 -> 4.9.1
- **bleach:** 1.5.0 -> 3.1.5
- **bokeh:** 0.12.7 -> 2.1.1
- **certifi:** 2016.2.28 -> 2020.6.20
- **cffi:** 1.10.0 -> 1.14.0
- **cryptography:** 1.8.1 -> 2.9.2
- **cython:** 0.26 -> 0.29.21
- **decorator:** 4.1.2 -> 4.4.2
- **django:** 3.0.1 -> 3.0.3
- **docutils:** 0.14 -> 0.16
- **docxtpl:** 0.6.3 -> 0.10.0
- **entrypoints:** 0.2.3 -> 0.3
- **expat:** 2.1.0 -> 2.2.9
- **freetype:** 2.5.5 -> 2.10.2
- **gitpython:** 2.1.3 -> 3.1.3
- **h5py:** 2.7.0 -> 2.10.0
- **hdf5:** 1.8.17 -> 1.10.4
- **icu:** 54.1 -> 58.2
- **idna:** 2.6 -> 2.10
- **imagesize:** 0.7.1 -> 1.2.0
- **ipykernel:** 4.6.1 -> 5.3.3
- **ipyparallel:** 6.0.2 -> 6.3.0
- **ipython:** 6.1.0 -> 7.16.1
- **ipywidgets:** 7.3.0 -> 7.5.1
- **isort:** 4.2.15 -> 4.3.21
- **jedi:** 0.10.2 -> 0.17.1
- **jinja2:** 2.9.6 -> 2.11.2
- **jsonschema:** 2.6.0 -> 3.2.0
- **jupyter_client:** 5.1.0 -> 6.1.6
- **jupyter_console:** 5.2.0 -> 6.1.0
- **jupyter_core:** 4.3.0 -> 4.6.3
- **lazy-object-proxy:** 1.3.1 -> 1.4.3
- **libcxx:** 9.0.1 -> 10.0.0
- **libgfortran:** 3.0.0 -> 3.0.1
- **libpng:** 1.6.30 -> 1.6.37
- **libtiff:** 4.0.6 -> 4.1.0
- **libxslt:** 1.1.29 -> 1.1.34
- **line_profiler:** 2.0 -> 2.1.2
- **llvmlite:** 0.18.0 -> 0.33.0
- **lxml:** 3.8.0 -> 4.5.2
- **markupsafe:** 1.0 -> 1.1.1
- **matplotlib:** 2.0.2 -> 3.2.2
- **mistune:** 0.7.4 -> 0.8.4
- **mkl:** 2017.0.3 -> 2019.4
- **nb_conda:** 2.2.0 -> 2.2.1
- **nb_conda_kernels:** 2.1.0 -> 2.2.3
- **nbconvert:** 5.2.1 -> 5.6.1
- **nbformat:** 4.4.0 -> 5.0.7
- **networkx:** 1.11 -> 2.4
- **notebook:** 5.0.0 -> 6.0.3
- **numba:** 0.33.0 -> 0.50.1
- **numexpr:** 2.6.2 -> 2.7.1
- **numpy:** 1.12.1 -> 1.18.5
- **numpydoc:** 0.7.0 -> 1.1.0
- **olefile:** 0.44 -> 0.46
- **openssl:** 1.0.2l -> 1.1.1g
- **packaging:** 16.8 -> 20.4
- **pandas:** 0.20.3 -> 1.0.5
- **paramiko:** 2.1.2 -> 2.7.1
- **pbr:** 5.4.4 -> 5.4.5
- **pexpect:** 4.2.1 -> 4.8.0
- **pickleshare:** 0.7.4 -> 0.7.5
- **pillow:** 4.2.1 -> 7.2.0
- **pip:** 9.0.1 -> 20.1.1
- **prompt_toolkit:** 1.0.15 -> 3.0.5
- **psutil:** 5.2.2 -> 5.7.0
- **ptyprocess:** 0.5.2 -> 0.6.0
- **py:** 1.4.34 -> 1.9.0
- **pycodestyle:** 2.3.1 -> 2.6.0
- **pycparser:** 2.18 -> 2.20
- **pyflakes:** 1.6.0 -> 2.2.0
- **pygments:** 2.2.0 -> 2.6.1
- **pylint:** 1.7.2 -> 2.5.3
- **pyparsing:** 2.2.0 -> 2.4.7
- **pyqt:** 5.6.0 -> 5.9.2
- **pytables:** 3.4.2 -> 3.6.1
- **pytest:** 3.2.1 -> 5.4.3
- **python:** 3.6.2 -> 3.8.3
- **python-dateutil:** 2.6.1 -> 2.8.1
- **python-docx:** 0.8.7 -> 0.8.10
- **pytz:** 2017.2 -> 2020.1
- **pyyaml:** 3.12 -> 5.3.1
- **pyzmq:** 16.0.2 -> 19.0.1
- **qt:** 5.6.2 -> 5.9.7
- **qtconsole:** 4.3.1 -> 4.7.5
- **qtpy:** 1.3.1 -> 1.9.0
- **readline:** 6.2 -> 8.0
- **requests:** 2.14.2 -> 2.24.0
- **rope:** 0.9.4 -> 0.17.0
- **scikit-learn:** 0.19.0 -> 0.23.1
- **scipy:** 0.19.1 -> 1.5.0
- **setuptools:** 36.4.0 -> 49.2.0
- **setuptools_scm:** 3.3.3 -> 4.1.2
- **sherpa:** 4.11.1 -> 4.12.2
- **sip:** 4.18 -> 4.19.8
- **six:** 1.10.0 -> 1.15.0
- **snowballstemmer:** 1.2.1 -> 2.0.0
- **sphinx:** 1.6.3 -> 3.1.2
- **sqlite:** 3.13.0 -> 3.32.3
- **sqlparse:** 0.3.0 -> 0.3.1
- **terminado:** 0.6 -> 0.8.3
- **testpath:** 0.3.1 -> 0.4.4
- **tk:** 8.5.18 -> 8.6.10
- **tornado:** 4.5.2 -> 6.0.4
- **traitlets:** 4.3.2 -> 4.3.3
- **wcwidth:** 0.1.7 -> 0.2.5
- **wheel:** 0.29.0 -> 0.34.2
- **widgetsnbextension:** 3.3.0 -> 3.5.1
- **wrapt:** 1.10.11 -> 1.11.2
- **xz:** 5.2.3 -> 5.2.5
- **yaml:** 0.1.6 -> 0.2.5
- **zeromq:** 4.1.3 -> 4.3.2

# Related Issues

Fixes #540
Fixes #543
Fixes #541
Fixes #544
