### PR TITLE
Add plotly and tqdm to ska3-core-latest

### DIFF
--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -44,6 +44,7 @@ requirements:
    - pycrypto
    - prompt-toolkit<3.0.0a0 # [win]
    - pylint
+   - plotly
    - python-docx
    - pyyaml
    - qt
@@ -61,4 +62,5 @@ requirements:
    - sqlalchemy # [win]
    - sqlite
    - tk
+   - tqdm
    - yaml


### PR DESCRIPTION
These two packages should be capture as core dependencies.  `tqdm` is currently coming in as a derived dependency, so this makes it a primary one given direct use in Ska packages now.