### PR TITLE
2021.2

### DIFF
--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core-latest
-  version: 2020.13+shiny
+  version: 2021.2
 
 requirements:
   run:

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -26,6 +26,7 @@ requirements:
    - jupyterlab
    - line_profiler
    - lxml
+   - mamba
    - matplotlib
    - mpld3
    - nb_conda

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -46,6 +46,7 @@ requirements:
    - prompt-toolkit<3.0.0a0 # [win]
    - pylint
    - plotly
+   - python-kaleido
    - python-docx
    - pyyaml
    - qt

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2021.1  # in a typical release, change the ska3-core version in sk3-flight requirements.
+  version: 2021.2  # in a typical release, change the ska3-core version in ska3-flight requirements.
 
 requirements:
   run:
@@ -10,7 +10,7 @@ requirements:
     - appnope ==0.1.0  # [osx]
     - asgiref ==3.2.10
     - astroid ==2.4.2
-    - astropy ==4.0.1.post1
+    - astropy ==4.2
     - astropy-healpix ==0.5
     - astropy-sphinx-theme ==1.1
     - atomicwrites ==1.4.0  # [win]
@@ -21,14 +21,14 @@ requirements:
     - bcrypt ==3.1.7
     - beautifulsoup4 ==4.9.1
     - blas ==1.0
-    - bleach ==3.1.5
+    - bleach ==3.3.0
     - blinker ==1.4
     - blosc ==1.19.0
     - bokeh ==2.1.1
     - brotlipy ==0.7.0
     - bzip2 ==1.0.8
-    - ca-certificates ==2020.6.24
-    - certifi ==2020.6.20
+    - ca-certificates ==2021.1.19
+    - certifi ==2020.12.5
     - cffi ==1.14.0
     - chardet ==3.0.4
     - cloudpickle ==1.5.0  # [win]
@@ -67,6 +67,7 @@ requirements:
     - icc_rt ==2019.0.0  # [win]
     - icu ==58.2
     - idna ==2.10
+    - iniconfig ==1.1.1
     - imagesize ==1.2.0
     - importlib-metadata ==1.7.0
     - importlib_metadata ==1.7.0
@@ -156,7 +157,7 @@ requirements:
     - numpydoc ==1.1.0
     - oauthlib ==3.1.0
     - olefile ==0.46
-    - openssl ==1.1.1g
+    - openssl ==1.1.1i
     - packaging ==20.4
     - pandas ==1.0.5
     - pandoc ==2.10
@@ -171,6 +172,7 @@ requirements:
     - pillow ==7.2.0
     - pip ==20.1.1
     - pkginfo ==1.5.0.1
+    - plotly ==4.14.3
     - pluggy ==0.13.1
     - prometheus_client ==0.8.0
     - prompt-toolkit ==2.0.10  # [win]
@@ -185,6 +187,7 @@ requirements:
     - pycosat ==0.6.3
     - pycparser ==2.20
     - pycrypto ==2.6.1
+    - pyerfa ==1.7.1.1
     - pyflakes ==2.2.0
     - pygments ==2.6.1
     - pyjwt ==1.7.1
@@ -214,6 +217,7 @@ requirements:
     - requests ==2.24.0
     - requests-oauthlib ==1.3.0
     - requests-toolbelt ==0.9.1
+    - retrying ==1.3.3
     - ripgrep ==11.0.2  # [linux or osx]
     - rope ==0.17.0
     - ruamel_yaml ==0.15.87

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -67,10 +67,10 @@ requirements:
     - icc_rt ==2019.0.0  # [win]
     - icu ==58.2
     - idna ==2.10
-    - iniconfig ==1.1.1
     - imagesize ==1.2.0
     - importlib-metadata ==1.7.0
     - importlib_metadata ==1.7.0
+    - iniconfig ==1.1.1
     - intel-openmp ==2019.4  # [osx]
     - intel-openmp ==2020.1  # [linux or win]
     - ipykernel ==5.3.3
@@ -200,7 +200,7 @@ requirements:
     - pyrsistent ==0.16.0
     - pysocks ==1.7.1
     - pytables ==3.6.1
-    - pytest ==6.2
+    - pytest ==6.2.0
     - python ==3.8.3
     - python-dateutil ==2.8.1
     - python-docx ==0.8.10

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -212,6 +212,7 @@ requirements:
     - python ==3.8.3
     - python-dateutil ==2.8.1
     - python-docx ==0.8.10
+    - python-kaleido ==0.0.3
     - python-libarchive-c ==2.9
     - python_abi ==3.8
     - pytz ==2020.1

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -94,22 +94,28 @@ requirements:
     - jupyterlab ==2.1.5
     - jupyterlab_server ==1.2.0
     - kiwisolver ==1.2.0
+    - krb5 ==1.18.2
     - lazy-object-proxy ==1.4.3
     - lcms2 ==2.11  # [linux or osx]
     - ld_impl_linux-64 ==2.33.1  # [linux]
     - libarchive ==3.4.2
+    - libcurl ==7.71.1
     - libcxx ==10.0.0  # [osx]
     - libedit ==3.1.20191231  # [linux or osx]
     - libffi ==3.3  # [linux or osx]
     - libgcc-ng ==9.1.0  # [linux]
     - libgfortran ==3.0.1  # [osx]
     - libgfortran-ng ==7.3.0  # [linux]
-    - libiconv ==1.15  # [win]
+    - libiconv ==1.15  # [linux or win]
     - libiconv ==1.16  # [osx]
     - liblief ==0.10.1
     - libllvm9 ==9.0.1
     - libpng ==1.6.37
     - libsodium ==1.0.18
+    - libsolv ==0.7.14  # [osx]
+    - libsolv ==0.7.16  # [linux]
+    - libsolv ==0.7.17  # [win]
+    - libssh2 ==1.9.0
     - libstdcxx-ng ==9.1.0  # [linux]
     - libtiff ==4.1.0
     - libuuid ==1.0.3  # [linux]
@@ -127,6 +133,8 @@ requirements:
     - m2w64-gcc-libs-core ==5.3.0  # [win]
     - m2w64-gmp ==6.1.0  # [win]
     - m2w64-libwinpthread-git ==5.0.0.4634.697f757  # [win]
+    - mamba ==0.4.2  # [osx]
+    - mamba ==0.5.1  # [linux or win]
     - markupsafe ==1.1.1
     - matplotlib ==3.2.2
     - matplotlib-base ==3.2.2
@@ -205,6 +213,7 @@ requirements:
     - python-dateutil ==2.8.1
     - python-docx ==0.8.10
     - python-libarchive-c ==2.9
+    - python_abi ==3.8
     - pytz ==2020.1
     - pywin32 ==227  # [win]
     - pywinpty ==0.5.7  # [win]

--- a/pkg_defs/ska3-flight-latest/meta.yaml
+++ b/pkg_defs/ska3-flight-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight-latest
-  version: 2020.13+shiny
+  version: 2021.2
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight-latest/meta.yaml
+++ b/pkg_defs/ska3-flight-latest/meta.yaml
@@ -12,26 +12,24 @@ requirements:
     - aca_hi_bgd
     - aca_view
     - aca_weekly_report
-    - acispy
-    - acisfp_check
-    - acis_thermal_check
-    - backstop_history
-    - dea_check
-    - dpa_check
-    - psmc_check
-    - bep_pcb_check
-    - fep1_mong_check
-    - fep1_actel_check
-    - ska3-template
     - acdc
-    - agasc
     - acis_taco
+    - acis_thermal_check
+    - acisfp_check
+    - acispy
+    - agasc
     - annie
+    - backstop_history
+    - bep_pcb_check
     - chandra_aca
     - chandra.cmd_states
     - chandra.maneuver
     - chandra.time
     - cxotime
+    - dea_check
+    - dpa_check
+    - fep1_mong_check
+    - fep1_actel_check
     - find_attitude
     - hopper
     - jobwatch
@@ -41,8 +39,10 @@ requirements:
     - parse_cm
     - perigee_health_plots
     - proseco
+    - psmc_check
     - pyyaks
     - quaternion
+    - ska-sphinx-theme
     - ska.arc5gl
     - ska.astro
     - ska.dbi
@@ -55,13 +55,13 @@ requirements:
     - ska.quatutil
     - ska.report_ranges
     - ska.shell
-    - ska-sphinx-theme
-    - ska_path
-    - ska_helpers
-    - ska_sync
-    - skare3_tools
     - ska.sun
     - ska.tdb
+    - ska3-template
+    - ska_helpers
+    - ska_path
+    - ska_sync
+    - skare3_tools
     - sparkles
     - starcheck
     - testr

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.1
+  version: 2021.2
 
 build:
   noarch: generic
@@ -9,9 +9,9 @@ build:
 requirements:
   run:
     - aca_hi_bgd ==0.1.5
-    - aca_view ==0.5.0
-    - aca_weekly_report ==0.1.4
-    - acdc ==4.7.1
+    - aca_view ==0.6.0
+    - aca_weekly_report ==0.1.5
+    - acdc ==4.7.2
     - acis_taco ==4.2.0
     - acis_thermal_check ==3.5.0
     - acisfp_check ==3.5.0
@@ -23,7 +23,7 @@ requirements:
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
-    - chandra_aca ==4.31.1
+    - chandra_aca ==4.32.0
     - cxotime ==3.2.3
     - dea_check ==3.4.0
     - dpa_check ==3.3.0
@@ -31,11 +31,12 @@ requirements:
     - fep1_mong_check ==3.3.0
     - find_attitude ==3.4.0
     - hopper ==4.5.1
-    - kadi ==5.5.0
-    - maude ==3.5.0
-    - mica ==4.24.0
+    - jobwatch ==0.2.0
+    - kadi ==5.5.1
+    - maude ==3.6.0
+    - mica ==4.25.0
     - parse_cm ==3.6.0
-    - perigee_health_plots ==0.1.2
+    - perigee_health_plots ==0.1.3
     - proseco ==4.11.0
     - psmc_check ==3.3.0
     - pyyaks ==4.5.0
@@ -55,12 +56,12 @@ requirements:
     - ska.shell ==3.5.0
     - ska.sun ==3.6.0
     - ska.tdb ==3.6.0
-    - ska3-core ==2021.1
+    - ska3-core ==2021.2
     - ska3-template ==2019.09.03
     - ska_helpers ==0.4.0
     - ska_path ==3.1.2
     - ska_sync ==4.7.0
-    - skare3_tools ==1.0.2
+    - skare3_tools ==1.0.3
     - sparkles ==4.7.0
     - starcheck ==13.8.0
     - testr ==4.6.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -11,7 +11,7 @@ requirements:
     - aca_hi_bgd ==0.1.5
     - aca_view ==0.6.0
     - aca_weekly_report ==0.1.5
-    - acdc ==4.7.2
+    - acdc ==4.7.3
     - acis_taco ==4.2.0
     - acis_thermal_check ==3.5.0
     - acisfp_check ==3.5.0
@@ -24,7 +24,7 @@ requirements:
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
     - chandra_aca ==4.32.0
-    - cxotime ==3.2.4
+    - cxotime ==3.2.5
     - dea_check ==3.4.0
     - dpa_check ==3.3.0
     - fep1_actel_check ==3.3.0
@@ -45,7 +45,7 @@ requirements:
     - ska.arc5gl ==3.1.5
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.51.0
+    - ska.engarchive ==4.52.0
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.12.0
@@ -58,7 +58,7 @@ requirements:
     - ska.tdb ==3.6.0
     - ska3-core ==2021.2
     - ska3-template ==2019.09.03
-    - ska_helpers ==0.4.0
+    - ska_helpers ==0.5.0
     - ska_path ==3.1.2
     - ska_sync ==4.7.0
     - skare3_tools ==1.0.3

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
     - chandra_aca ==4.32.0
-    - cxotime ==3.2.3
+    - cxotime ==3.2.4
     - dea_check ==3.4.0
     - dpa_check ==3.3.0
     - fep1_actel_check ==3.3.0
@@ -37,7 +37,7 @@ requirements:
     - mica ==4.25.0
     - parse_cm ==3.6.0
     - perigee_health_plots ==0.1.3
-    - proseco ==4.11.0
+    - proseco ==4.11.1
     - psmc_check ==3.3.0
     - pyyaks ==4.5.0
     - quaternion ==3.6.0


### PR DESCRIPTION
# ska3-flight 2021.2

## Summary:

This is an update of ska3-core and ska3-flight. The most notable change is the update of astropy to version 4.2. A test installation is available for testing at `/proj/sot/ska3/test-2021.2rc5` on HEAD and GRETA linux, as announced on February 19 2021 on the chandracode distribution list.

Fixes/changes to maude, kadi and chandra_aca will be briefed by Tom (shown in bold in the Code Changes section below).

This release also includes some minor fixes and changes to several packages. Two packages that can be of general use were added to ska3-core: mamba and plotly.

## Interface Impacts:

### astropy 4.2

astropy 4.2 introduces some API changes that ended up impacting our code in regression testing (https://docs.astropy.org/en/latest/changelog.html#id91):

- Change Table.columns.keys() and Table.columns.values() to both return generators instead of a list. This matches the behavior for Python dict objects. [#10543]
- The order of columns when creating a table from a list of dict may be changed. Previously, the order was alphabetical because the dict keys were assumed to be in random order. Since Python 3.7, the keys are always in order of insertion, so Table now uses the order of keys in the first row to set the column order. To alphabetize the columns to match the previous behavior, use t = t[sorted(t.colnames)]. [#10900]

## Testing:

Automated regression testing: https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.2rc5/

The one apparent failure is actually a warning due to insufficient access permissions. This test does pass if it is run with the right permissions.

Testing in `/proj/sot/ska3/test-2021.2rc5`:
- [kady](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.2rc5-kady)
- [chimchim](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.2rc5-chimchim)

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment:
-  The 2021.2 release will be promoted to the flight conda channel, and deployed on HEAD and GRETA ska3/flight after the release and products for the week are approved.

# Code changes

## ska3-flight changes (2021.1 -> 2021.2)

### New Packages
- **jobwatch: 0.2.0**

### Updated Packages

- **ska3-core:** 2021.1 -> 2021.2

- **aca_view:** 0.5.0 -> 0.6.0 (0.5.0 -> 0.6.0)
  - [PR 65](https://github.com/sot/aca_view/pull/65) (javierggt): Fix so aca_view can realistically be used in real-time mode.
- **aca_weekly_report:** 0.1.4 -> 0.1.5 (0.1.4 -> 0.1.5)
  - [PR 9](https://github.com/sot/aca_weekly_report/pull/9) (jeanconn): Update task_schedule.cfg
- **acdc:** 4.7.1 -> 4.7.3 (4.7.1 -> 4.7.2 -> 4.7.3)
  - [PR 60](https://github.com/sot/acdc/pull/60) (jeanconn): Update report link
  - [PR 61](https://github.com/sot/acdc/pull/61) (jeanconn): Adding a couple of logging messages
- **chandra_aca:** 4.31.1 -> 4.32.0 (4.31.1 -> 4.32.0)
  - [PR 113](https://github.com/sot/chandra_aca/pull/113) (javierggt): Fetch ACA telemetry from MAUDE using blobs
  - **[PR 114](https://github.com/sot/chandra_aca/pull/114) (taldcroft): Add calc_target_offsets function**
- **cxotime:** 3.2.3 -> 3.2.5 (3.2.3 ->  3.2.4 -> 3.2.5)
  - [PR 24](https://github.com/sot/cxotime/pull/24) (taldcroft): Astropy 4.2 compatibility: modified "import erfa" statement
  - [PR 25](https://github.com/sot/cxotime/pull/25) (javierggt): Ignore ERFA dubious year warning
- **kadi:** 5.5.0 -> 5.5.1 (5.5.0 -> 5.5.1)
  - **[PR 199](https://github.com/sot/kadi/pull/199) (taldcroft): Fix bug getting states starting between AOUPTARQ and AOMANUVR**
- **maude:** 3.5.0 -> 3.6.0 (3.5.0 -> 3.6.0)
  - **[PR 32](https://github.com/sot/maude/pull/32) (taldcroft): Do not assign defaults for start/stop times + exception handling**
  - [PR 33](https://github.com/sot/maude/pull/33) (taldcroft): Fix chunks query when MAUDE returns no data in last chunk
- **mica:** 4.24.0 -> 4.25.0 (4.24.0 -> 4.25.0)
  - [PR 255](https://github.com/sot/mica/pull/255) (jeanconn): Fix script default to actually save plots
  - [PR 256](https://github.com/sot/mica/pull/256) (jeanconn): Skip report vv warn if no sybase passwd file for db
  - [PR 257](https://github.com/sot/mica/pull/257) (jeanconn): Avoid vv obspar race condition
- **perigee_health_plots:** 0.1.2 -> 0.1.3 (0.1.2 -> 0.1.3)
  - [PR 18](https://github.com/sot/perigee_health_plots/pull/18) (jeanconn): Use config DAVCSDTEMP_PLOT xlim for dtemp default lims
- **proseco:** 4.11.0 -> 4.11.1 (4.11.0 -> 4.11.1)
  -  [PR 350](https://github.com/sot/proseco/pull/350) (taldcroft): Fix problem from table API change in astropy 4.2
- **ska.engarchive:** 4.51.0 -> 4.52.0 (4.51.0 -> 4.52.0)
  - [PR 213](https://github.com/sot/eng_archive/pull/213) (taldcroft): Update flake8.yml to Python 3.8
  - [PR 217](https://github.com/sot/eng_archive/pull/217) (taldcroft): Fix file_defs.py for PEP8
  - [PR 215](https://github.com/sot/eng_archive/pull/215) (jeanconn): Fix sync index column order to match order from astropy 4.0
  - [PR 214](https://github.com/sot/eng_archive/pull/214) (taldcroft): Retry tables open file
- **ska_helpers:** 0.4.0 -> 0.5.0 (0.4.0 -> 0.5.0)
  - [PR 21](https://github.com/sot/ska_helpers/pull/21) (taldcroft): Add tables_open_file func to retry opening
- **skare3_tools:** 1.0.2 -> 1.0.3 (1.0.2 -> 1.0.3)
  - [PR 78](https://github.com/sot/skare3_tools/pull/78) (javierggt): Fix release description so PR links are full URIs

## ska3-core changes (2021.1 -> 2021.2)

### New Packages
- **iniconfig: 1.1.1**
- **krb5: 1.18.2**
- **libcurl: 7.71.1**
- **libsolv: 0.7.14**
- **libssh2: 1.9.0**
- **mamba: 0.4.2**
- **plotly: 4.14.3**
- **pyerfa: 1.7.1.1**
- **python-kaleido: 0.0.3**
- **python_abi: 3.8**
- **retrying: 1.3.3**

### Updated Packages

- **astropy:** 4.0.1.post1 -> 4.2
- **bleach:** 3.1.5 -> 3.3.0
- **ca-certificates:** 2020.6.24 -> 2021.1.19
- **certifi:** 2020.6.20 -> 2020.12.5
- **openssl:** 1.1.1g -> 1.1.1i
- **pytest:** 6.2 -> 6.2.0

# Related Issues

Fixes #555
Fixes #568
Fixes #583
Fixes #585
Fixes #587
Fixes #588
Fixes #589
Fixes #590
Fixes #591
Fixes #592
Fixes #593
Fixes #594
Fixes #595
Fixes #596
Fixes #597
Fixes #601
Fixes #602
Fixes #605
Fixes #606
Fixes #607
Fixes #608

