### PR TITLE
2021.3

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -8,43 +8,44 @@ build:
 
 requirements:
   run:
-    - aca_hi_bgd ==0.1.4
-    - aca_view ==0.4.1
-    - aca_weekly_report ==0.1.3
-    - acdc ==4.7.0
+    - aca_hi_bgd ==0.1.5
+    - aca_view ==0.6.0
+    - aca_weekly_report ==0.1.5
+    - acdc ==4.7.3
     - acis_taco ==4.2.0
-    - acis_thermal_check ==3.4.0
-    - acisfp_check ==3.2.0
+    - acis_thermal_check ==3.5.0
+    - acisfp_check ==3.5.0
     - acispy ==2.1.0
     - agasc ==4.11.0
     - annie ==0.11.0
-    - backstop_history ==1.3.0
-    - bep_pcb_check ==3.0.0
+    - backstop_history ==1.4.0
+    - bep_pcb_check ==3.3.0
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
-    - chandra_aca ==4.31.1
-    - cxotime ==3.2.3
-    - dea_check ==3.1.0
-    - dpa_check ==3.0.0
-    - fep1_actel_check ==3.0.0
-    - fep1_mong_check ==3.0.0
+    - chandra_aca ==4.32.0
+    - cxotime ==3.2.5
+    - dea_check ==3.4.0
+    - dpa_check ==3.3.0
+    - fep1_actel_check ==3.3.0
+    - fep1_mong_check ==3.3.0
     - find_attitude ==3.4.0
-    - hopper ==4.5.0
-    - kadi ==5.4.0
-    - maude ==3.4.0
-    - mica ==4.23.0
-    - parse_cm ==3.5.2
-    - perigee_health_plots ==0.1.2
+    - hopper ==4.5.1
+    - jobwatch ==0.2.0
+    - kadi ==5.5.1
+    - maude ==3.6.0
+    - mica ==4.25.0
+    - parse_cm ==3.6.0
+    - perigee_health_plots ==0.1.3
     - proseco ==4.12.0
-    - psmc_check ==3.0.0
+    - psmc_check ==3.3.0
     - pyyaks ==4.5.0
     - quaternion ==3.6.0
     - ska-sphinx-theme ==1.3.0
     - ska.arc5gl ==3.1.5
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.50.1
+    - ska.engarchive ==4.52.0
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.12.0
@@ -55,13 +56,13 @@ requirements:
     - ska.shell ==3.5.0
     - ska.sun ==3.6.0
     - ska.tdb ==3.6.0
-    - ska3-core ==2020.14
+    - ska3-core ==2021.2
     - ska3-template ==2019.09.03
-    - ska_helpers ==0.3.0
+    - ska_helpers ==0.5.0
     - ska_path ==3.1.2
     - ska_sync ==4.7.0
-    - skare3_tools ==1.0.1
+    - skare3_tools ==1.0.3
     - sparkles ==4.8.0
     - starcheck ==13.8.0
-    - testr ==4.5.0
+    - testr ==4.6.0
     - xija ==4.21.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2020.13+shiny
+  version: 2021.3
 
 build:
   noarch: generic
@@ -16,7 +16,7 @@ requirements:
     - acis_thermal_check ==3.4.0
     - acisfp_check ==3.2.0
     - acispy ==2.1.0
-    - agasc ==4.10.2
+    - agasc ==4.11.0
     - annie ==0.11.0
     - backstop_history ==1.3.0
     - bep_pcb_check ==3.0.0
@@ -36,7 +36,7 @@ requirements:
     - mica ==4.23.0
     - parse_cm ==3.5.2
     - perigee_health_plots ==0.1.2
-    - proseco ==4.10.0
+    - proseco ==4.12.0
     - psmc_check ==3.0.0
     - pyyaks ==4.5.0
     - quaternion ==3.6.0
@@ -61,7 +61,7 @@ requirements:
     - ska_path ==3.1.2
     - ska_sync ==4.7.0
     - skare3_tools ==1.0.1
-    - sparkles ==4.7.0
+    - sparkles ==4.8.0
     - starcheck ==13.8.0
     - testr ==4.5.0
     - xija ==4.21.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - mica ==4.25.0
     - parse_cm ==3.6.0
     - perigee_health_plots ==0.1.3
-    - proseco ==4.12.0
+    - proseco ==4.12.1
     - psmc_check ==3.3.0
     - pyyaks ==4.5.0
     - quaternion ==3.6.0


### PR DESCRIPTION
# ska3-matlab 2021.3

## Summary:

This is an incremental update of ska3-matlab with package changes to support the expanded AGASC supplement.

## Interface Impacts:

### AGASC access

Code that uses the `agasc` Python package to access star data will use updated magnitude information from the AGASC supplement by default.  This can be controlled by the AGASC_SUPPLEMENT_ENABLED environment variable, by use of the `agasc.set_supplement_enabled()` method, or by explicit use of the `use_supplement` argument in the methods.  See https://sot.github.io/agasc/api.html for the `agasc` documentation as needed.

## Testing:

- automated tests
  - [2021.3rc1](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.3rc1)
  - [2021.3rc2](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.3rc2)
 
Current release candidate is available for testing in the `test` conda channel:
```
conda create -n ska3-matlab-2021.3 \
    --override-channels -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
    -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
    ska3-matlab
```

The version of the agasc supplement file that will be promoted with ska3-matlab 2021.3 is:

https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/flight-promotion-2021.3/agasc_supplement.h5

(md5sum f676a119760405813c85823c96a0bc9e ).

## Review


## Deployment:
-

# Code changes

## ska3-matlab changes (2020.13+shiny -> 2021.3rc1)

### New Packages
- **jobwatch: 0.2.0**





### Updated Packages

- **aca_hi_bgd:** 0.1.4 -> 0.1.5 (0.1.4 -> 0.1.5)
  - [PR 9](https://github.com/sot/aca_hi_bgd/pull/9) (jeanconn): Rearrange processing at end to avoid reprocessing
- **aca_view:** 0.4.1 -> 0.6.0 (0.4.1 -> 0.5.0 -> 0.6.0)
  - [PR 64](https://github.com/sot/aca_view/pull/64) (javierggt): Data service
  - [PR 65](https://github.com/sot/aca_view/pull/65) (javierggt): Fix so aca_view can realistically be used in real-time mode.
- **aca_weekly_report:** 0.1.3 -> 0.1.5 (0.1.3 -> 0.1.4 -> 0.1.5)
  - [PR 7](https://github.com/sot/aca_weekly_report/pull/7) (jeanconn): Fix the type of the days-back option
  - [PR 9](https://github.com/sot/aca_weekly_report/pull/9) (jeanconn): Update task_schedule.cfg
- **acdc:** 4.7.0 -> 4.7.3 (4.7.0 -> 4.7.1 -> 4.7.2 -> 4.7.3)
  - [PR 59](https://github.com/sot/acdc/pull/59) (taldcroft): Catch another source of Telemetry Gap Error
  - [PR 60](https://github.com/sot/acdc/pull/60) (jeanconn): Update report link
  - [PR 61](https://github.com/sot/acdc/pull/61) (taldcroft): Adding a couple of logging messages
- **acis_thermal_check:** 3.2.1 -> 3.5.0 (3.2.1 -> 3.3.0 -> 3.4.0 -> 3.4.1 -> 3.5.0)
  - [PR 34](https://github.com/acisops/acis_thermal_check/pull/34) (jzuhone): Handles Maneuver-only loads, improve regression testing
  - [PR 35](https://github.com/acisops/acis_thermal_check/pull/35) (jzuhone): Re-issue Shiny PR
  - [PR 36](https://github.com/acisops/acis_thermal_check/pull/36) (jzuhone): Make regression testing work on standalone platforms
  - [PR 37](https://github.com/acisops/acis_thermal_check/pull/37) (jzuhone): Refactoring of limit handling, allowing for more customizations, use cxotime
- **acisfp_check:** 3.2.0 -> 3.5.0 (3.2.0 -> 3.3.0 -> 3.4.0 -> 3.5.0)
  - [PR 27](https://github.com/acisops/acisfp_check/pull/27) (jzuhone): Refactor tests to match new signature
  - [PR 28](https://github.com/acisops/acisfp_check/pull/28) (jzuhone): Update answers post-shiny
  - [PR 29](https://github.com/acisops/acisfp_check/pull/29) (jzuhone): Simplification of code, use cxotime, fixing bugs with violations reporting
- **acispy:** 2.0.1.dev12+gc5410da -> 2.1.0 (2.0.1.dev12+gc5410da -> v1.3.0 -> v1.5.0 -> v1.6.0 -> v1.8.0 -> v1.9.0 -> 2.0.0 -> 2.1.0)
  - [PR 3](https://github.com/acisops/acispy/pull/3) (jzuhone): Remove command-line scripts from ACISpy
  - [PR 5](https://github.com/acisops/acispy/pull/5) (jzuhone): Shiny workflow update
  - [PR 6](https://github.com/acisops/acispy/pull/6) (jzuhone): Shiny workflow update
  - [PR 4](https://github.com/acisops/acispy/pull/4) (jzuhone): Always propagate right-side y-axis
- **agasc:** 4.10.1 -> 4.11.0 (4.10.1 -> 4.10.2 -> 4.11.0)
  - [PR 54](https://github.com/sot/agasc/pull/54) (javierggt): Fixes in supplement update script (start/stop, input/output, docs)
  - [PR 72](https://github.com/sot/agasc/pull/72) (taldcroft): Add flake8 check to GitHub workflows
  - [PR 56](https://github.com/sot/agasc/pull/56) (taldcroft): Improved access to AGASC supplement
  - [PR 58](https://github.com/sot/agasc/pull/58) (taldcroft): Faster get_stars() function
  - [PR 55](https://github.com/sot/agasc/pull/55) (taldcroft): Handle bad-stars and obs status together
  - [PR 77](https://github.com/sot/agasc/pull/77) (javierggt): Flake8
  - [PR 76](https://github.com/sot/agasc/pull/76) (javierggt): Bugfixes
  - [PR 78](https://github.com/sot/agasc/pull/78) (javierggt): Improved logging
  - [PR 82](https://github.com/sot/agasc/pull/82) (javierggt): Obs status
  - [PR 85](https://github.com/sot/agasc/pull/85) (javierggt): Added supplement versions table
  - [PR 83](https://github.com/sot/agasc/pull/83) (javierggt): Auto yaml
  - [PR 86](https://github.com/sot/agasc/pull/86) (javierggt): Added a mechanism to set mag_aca and mag_aca_err manually in the supplement, and a unique star-observation ID
  - [PR 92](https://github.com/sot/agasc/pull/92) (javierggt): Added a mechanism to log command-line arguments to be able to re-run
  - [PR 100](https://github.com/sot/agasc/pull/100) (javierggt): Fix "telemetry mismatch" error
  - [PR 101](https://github.com/sot/agasc/pull/101) (javierggt): Rename observation_id
  - [PR 105](https://github.com/sot/agasc/pull/105) (javierggt): Fixture to monkeypatch builtin open function
- **backstop_history:** 1.2.0 -> 1.4.0 (1.2.0 -> 1.3.0 -> 1.4.0)
  - [PR 17](https://github.com/acisops/backstop_history/pull/17) (Gregg140): Modifications to Baskstop History to accommodate data structure change…
  - [PR 18](https://github.com/acisops/backstop_history/pull/18) (jzuhone): Replace Chandra.Time with cxotime
- **bep_pcb_check:** 3.0.0 -> 3.3.0 (3.0.0 -> 3.1.0 -> 3.2.0 -> 3.3.0)
  - [PR 2](https://github.com/acisops/bep_pcb_check/pull/2) (jzuhone): Shiny workflow update
  - [PR 3](https://github.com/acisops/bep_pcb_check/pull/3) (jzuhone): Shiny workflow update
  - [PR 4](https://github.com/acisops/bep_pcb_check/pull/4) (jzuhone): Refactor tests to match new signature
  - [PR 5](https://github.com/acisops/bep_pcb_check/pull/5) (jzuhone): Update answers for shiny
  - [PR 6](https://github.com/acisops/bep_pcb_check/pull/6) (jzuhone): Update regression testing
- **chandra_aca:** 4.31.1 -> 4.32.0 (4.31.1 -> 4.32.0)
  - [PR 113](https://github.com/sot/chandra_aca/pull/113) (javierggt): Fetch ACA telemetry from MAUDE using blobs
  - [PR 114](https://github.com/sot/chandra_aca/pull/114) (taldcroft): Add calc_target_offsets function
- **cxotime:** 3.2.3 -> 3.2.5 (3.2.3 -> 3.2.4 -> 3.2.5)
  - [PR 24](https://github.com/sot/cxotime/pull/24) (jeanconn): Astropy 4.2 compatibility: modified "import erfa" statement
  - [PR 25](https://github.com/sot/cxotime/pull/25) (taldcroft): Ignore ERFA dubious year warning
- **dea_check:** 3.1.0 -> 3.4.0 (3.1.0 -> 3.2.0 -> 3.3.0 -> 3.4.0)
  - [PR 24](https://github.com/acisops/dea_check/pull/24) (jzuhone): Shiny workflow update
  - [PR 25](https://github.com/acisops/dea_check/pull/25) (jzuhone): Shiny workflow update
  - [PR 28](https://github.com/acisops/dea_check/pull/28) (jzuhone): Refactor tests to match new signature
  - [PR 29](https://github.com/acisops/dea_check/pull/29) (jzuhone): Update answers for shiny
  - [PR 30](https://github.com/acisops/dea_check/pull/30) (jzuhone): Update regression testing
- **dpa_check:** 3.0.0 -> 3.3.0 (3.0.0 -> 3.1.0 -> 3.2.0 -> 3.3.0)
  - [PR 22](https://github.com/acisops/dpa_check/pull/22) (jzuhone): Shiny workflow update
  - [PR 23](https://github.com/acisops/dpa_check/pull/23) (jzuhone): Shiny workflow update
  - [PR 26](https://github.com/acisops/dpa_check/pull/26) (jzuhone): Refactor tests to match new signature
  - [PR 27](https://github.com/acisops/dpa_check/pull/27) (jzuhone): Update answers for shiny
  - [PR 28](https://github.com/acisops/dpa_check/pull/28) (jzuhone): Add customizations to support checking +12 degC/0 FEPs violations, other minor updates
- **fep1_actel_check:** 3.0.0 -> 3.3.0 (3.0.0 -> 3.1.0 -> 3.2.0 -> 3.3.0)
  - [PR 2](https://github.com/acisops/fep1_actel_check/pull/2) (jzuhone): Shiny workflow update
  - [PR 3](https://github.com/acisops/fep1_actel_check/pull/3) (jzuhone): Shiny workflow update
  - [PR 4](https://github.com/acisops/fep1_actel_check/pull/4) (jzuhone): Refactor tests to match new signature
  - [PR 5](https://github.com/acisops/fep1_actel_check/pull/5) (jzuhone): Update answers for shiny
  - [PR 6](https://github.com/acisops/fep1_actel_check/pull/6) (jzuhone): Update regression testing
- **fep1_mong_check:** 3.0.0 -> 3.3.0 (3.0.0 -> 3.1.0 -> 3.2.0 -> 3.3.0)
  - [PR 2](https://github.com/acisops/fep1_mong_check/pull/2) (jzuhone): Shiny workflow update
  - [PR 3](https://github.com/acisops/fep1_mong_check/pull/3) (jzuhone): Shiny workflow update
  - [PR 4](https://github.com/acisops/fep1_mong_check/pull/4) (jzuhone): Refactor tests to match new signature
  - [PR 5](https://github.com/acisops/fep1_mong_check/pull/5) (jzuhone): Update answers for shiny
  - [PR 6](https://github.com/acisops/fep1_mong_check/pull/6) (jzuhone): Update regression testing
- **hopper:** 4.5.0 -> 4.5.1 (4.5.0 -> 4.5.1)
  - [PR 20](https://github.com/sot/hopper/pull/20) (jeanconn): Package/install the tests
- **kadi:** 5.4.0 -> 5.5.1 (5.4.0 -> 5.5.0 -> 5.5.1)
  - [PR 196](https://github.com/sot/kadi/pull/196) (taldcroft): Handle cmds.h5 resource unavailable error
  - [PR 195](https://github.com/sot/kadi/pull/195) (taldcroft): Add Ska.ParseCM compatibility + read_backstop function
  - [PR 197](https://github.com/sot/kadi/pull/197) (taldcroft): Add test of creating cmds archive and retry opening cmds.h5
  - [PR 199](https://github.com/sot/kadi/pull/199) (taldcroft): Fix bug getting states starting between AOUPTARQ and AOMANUVR
- **maude:** 3.4.0 -> 3.6.0 (3.4.0 -> 3.5.0 -> 3.6.0)
  - [PR 30](https://github.com/sot/maude/pull/30) (taldcroft): Use LazyDict from ska_helpers.utils
  - [PR 29](https://github.com/sot/maude/pull/29) (taldcroft): Allow access without credentials when possible
  - [PR 31](https://github.com/sot/maude/pull/31) (javierggt): added blobs_to_table function
  - [PR 32](https://github.com/sot/maude/pull/32) (taldcroft): Do not assign defaults for start/stop times + exception handling
  - [PR 33](https://github.com/sot/maude/pull/33) (taldcroft): Fix chunks query when MAUDE returns no data in last chunk
- **mica:** 4.23.0 -> 4.25.0 (4.23.0 -> 4.24.0 -> 4.25.0)
  - [PR 249](https://github.com/sot/mica/pull/249) (jeanconn): More centroid_dashboard tweaks
  - [PR 250](https://github.com/sot/mica/pull/250) (jeanconn): Minor V&V fixes
  - [PR 251](https://github.com/sot/mica/pull/251) (taldcroft): Add list of available content types to asp_l1.get_files
  - [PR 253](https://github.com/sot/mica/pull/253) (jeanconn): Increase an ASOL quat vs OBC quat test tolerance by 4 arcsecs in roll
  - [PR 252](https://github.com/sot/mica/pull/252) (jeanconn): L0 ingest issues (both shiny and repro V)
  - [PR 254](https://github.com/sot/mica/pull/254) (taldcroft): A few small V&V and report updates
  - [PR 241](https://github.com/sot/mica/pull/241) (taldcroft): Use vectorized Quat
  - [PR 255](https://github.com/sot/mica/pull/255) (jeanconn): Fix script default to actually save plots
  - [PR 256](https://github.com/sot/mica/pull/256) (jeanconn): Skip report vv warn if no sybase passwd file for db
  - [PR 257](https://github.com/sot/mica/pull/257) (jeanconn): Avoid vv obspar race condition
- **parse_cm:** 3.5.2 -> 3.6.0 (3.5.2 -> 3.6.0)
  - [PR 23](https://github.com/sot/parse_cm/pull/23) (javierggt): Shiny workflow update
  - [PR 24](https://github.com/sot/parse_cm/pull/24) (javierggt): Shiny workflow update
  - [PR 29](https://github.com/sot/parse_cm/pull/29) (taldcroft): Add docs and modernize code
  - [PR 26](https://github.com/sot/parse_cm/pull/26) (taldcroft): fixed bug skipping the last line of an OBS block
  - [PR 28](https://github.com/sot/parse_cm/pull/28) (taldcroft): Support full parsing of obs request per OP19
  - [PR 30](https://github.com/sot/parse_cm/pull/30) (taldcroft): Add cmds property to return kadi.commands.CommandTable version
- **perigee_health_plots:** 0.1.2 -> 0.1.3 (0.1.2 -> 0.1.3)
  - [PR 18](https://github.com/sot/perigee_health_plots/pull/18) (jeanconn): Use config DAVCSDTEMP_PLOT xlim for dtemp default lims
- **proseco:** 4.10.0 -> 4.12.0 (4.10.0 -> 4.11.0 -> 4.12.0 -> 4.12.1)
  - [PR 349](https://github.com/sot/proseco/pull/349) (taldcroft): Built-in function for diffing ACA catalogs
  - [PR 345](https://github.com/sot/proseco/pull/345) (taldcroft): Use AGASC supplement in proseco
  - [PR 351](https://github.com/sot/proseco/pull/351) (taldcroft): Fix problem from table API change in astropy 4.2
- **psmc_check:** 3.0.0 -> 3.3.0 (3.0.0 -> 3.1.0 -> 3.2.0 -> 3.3.0)
  - [PR 21](https://github.com/acisops/psmc_check/pull/21) (jzuhone): Shiny workflow update
  - [PR 22](https://github.com/acisops/psmc_check/pull/22) (jzuhone): Shiny workflow update
  - [PR 23](https://github.com/acisops/psmc_check/pull/23) (jzuhone): Refactor tests to match new signature
  - [PR 24](https://github.com/acisops/psmc_check/pull/24) (jzuhone): Updating answers for shiny
  - [PR 25](https://github.com/acisops/psmc_check/pull/25) (jzuhone): Update regression testing
- **ska-sphinx-theme:** 1.2.dev0 -> 1.3.0 (1.2.dev0 -> 1.3.0)
  - [PR 2](https://github.com/sot/ska-sphinx-theme/pull/2) (astrofrog): Update sphinx URL that gets redirected
  - [PR 6](https://github.com/sot/ska-sphinx-theme/pull/6) (astrofrog): Remove deprecated use of script_files
  - [PR 4](https://github.com/sot/ska-sphinx-theme/pull/4) (astrofrog): Update layout.html file in sphinx to add top menubar to astropy docs
  - [PR 8](https://github.com/sot/ska-sphinx-theme/pull/8) (astrofrog): Change css styling to render dropdown menu horizontal instead of vertical
  - [PR 1](https://github.com/sot/ska-sphinx-theme/pull/1) (javierggt): Homepage menu
- **ska.engarchive:** 4.50.1 -> 4.52.0 (4.50.1 -> 4.51.0 -> 4.52.0)
  - [PR 209](https://github.com/sot/eng_archive/pull/209) (taldcroft): Better caching in fetch
  - [PR 210](https://github.com/sot/eng_archive/pull/210) (taldcroft): Update docs shiny
  - [PR 211](https://github.com/sot/eng_archive/pull/211) (taldcroft): Move sync archive update into normal task schedule
  - [PR 213](https://github.com/sot/eng_archive/pull/213) (taldcroft): Update flake8.yml to Python 3.8
  - [PR 217](https://github.com/sot/eng_archive/pull/217) (taldcroft): Fix file_defs.py for PEP8
  - [PR 215](https://github.com/sot/eng_archive/pull/215) (jeanconn): Fix sync index column order to match order from astropy 4.0
  - [PR 214](https://github.com/sot/eng_archive/pull/214) (taldcroft): Retry tables open file
- **ska3-core:** 2020.13+shiny -> 2021.2
- **ska_helpers:** 0.3.0 -> 0.5.0 (0.3.0 -> 0.4.0 -> 0.5.0)
  - [PR 17](https://github.com/sot/ska_helpers/pull/17) (taldcroft): Add retry decorator and function wrapper
  - [PR 18](https://github.com/sot/ska_helpers/pull/18) (taldcroft): Add retry and tests sub-packages
  - [PR 20](https://github.com/sot/ska_helpers/pull/20) (taldcroft): Add lru_cache_timed decorator
  - [PR 19](https://github.com/sot/ska_helpers/pull/19) (javierggt): add detail about all exceptions in ska_helpers.retry
  - [PR 21](https://github.com/sot/ska_helpers/pull/21) (taldcroft): Add tables_open_file func to retry opening
- **skare3_tools:** 1.0.1 -> 1.0.3 (1.0.1 -> 1.0.2 -> 1.0.3)
  - [PR 73](https://github.com/sot/skare3_tools/pull/73) (javierggt): deal with default branch
  - [PR 74](https://github.com/sot/skare3_tools/pull/74) (javierggt): Improve info provided by ska3_update_summary
  - [PR 76](https://github.com/sot/skare3_tools/pull/76) (javierggt): skare3_tools.packages fixes for when ska3-matlab or ska3-flight are not in the conda channel
  - [PR 75](https://github.com/sot/skare3_tools/pull/75) (javierggt): added skare3_promote
  - [PR 78](https://github.com/sot/skare3_tools/pull/78) (javierggt): Fix release description so PR links are full URIs
- **sparkles:** 4.7.0 -> 4.8.0 (4.7.0 -> 4.8.0)
  - [PR 149](https://github.com/sot/sparkles/pull/149) (taldcroft): Update tests for AGASC supplement disable as needed
- **testr:** 4.5.0 -> 4.6.0 (4.5.0 -> 4.6.0)
  - [PR 34](https://github.com/sot/testr/pull/34) (taldcroft): Add functionality to skip tests via skip.yml in package dir

## ska3-core changes (2020.13+shiny -> 2021.2)

### New Packages
- **commonmark: 0.9.1**
- **future: 0.18.2**
- **iniconfig: 1.1.1**
- **krb5: 1.18.2**
- **libcurl: 7.71.1**
- **libsolv: 0.7.14 (OSX) 0.7.16 (linux) 0.7.17 (windows)**
- **libssh2: 1.9.0**
- **mamba: 0.4.2 (OS X), 0.5.1 (linux, windows)**
- **plotly: 4.14.3**
- **pyerfa: 1.7.1.1**
- **python-kaleido: 0.0.3**
- **python_abi: 3.8**
- **retrying: 1.3.3**
- **sphinx-argparse: 0.2.5**

### Updated Packages

- **astropy:** 4.0.1.post1 -> 4.2
- **bleach:** 3.1.5 -> 3.3.0
- **ca-certificates:** 2020.6.24 -> 2021.1.19
- **certifi:** 2020.6.20 -> 2020.12.5
- **openssl:** 1.1.1g -> 1.1.1i
- **pytest:** 5.4.3 -> 6.2.0
- **sherpa:** 4.12.1 -> 4.12.2

# Related Issues

Fixes #609 
Fixes #612 
Fixes #613 
Fixes #614