### PR TITLE
2021.4

### DIFF
--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -18,6 +18,7 @@ requirements:
    - git # [win]
    - gitpython
    - h5py
+   - ipympl
    - ipython
    - jinja2
    - jira
@@ -32,6 +33,7 @@ requirements:
    - nb_conda
    - nbconvert
    - networkx
+   - nodejs
    - notebook
    - numba
    - numexpr

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core-latest
-  version: 2021.2
+  version: 2021.4
 
 requirements:
   run:
@@ -48,6 +48,7 @@ requirements:
    - plotly
    - python-kaleido
    - python-docx
+   - pyqtgraph
    - pyyaml
    - qt
    - requests

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -74,6 +74,7 @@ requirements:
     - intel-openmp ==2019.4  # [osx]
     - intel-openmp ==2020.1  # [linux or win]
     - ipykernel ==5.3.3
+    - ipympl ==0.7.0
     - ipyparallel ==6.3.0
     - ipython ==7.16.1
     - ipython_genutils ==0.2.0
@@ -156,6 +157,7 @@ requirements:
     - nbformat ==5.0.7
     - ncurses ==6.2  # [linux or osx]
     - networkx ==2.4
+    - nodejs ==10.13.0
     - nose ==1.3.7
     - notebook ==6.0.3
     - numba ==0.50.1

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2021.2  # in a typical release, change the ska3-core version in ska3-flight requirements.
+  version: 2021.4  # in a typical release, change the ska3-core version in ska3-flight requirements.
 
 requirements:
   run:
@@ -204,6 +204,7 @@ requirements:
     - pyopenssl ==19.1.0
     - pyparsing ==2.4.7
     - pyqt ==5.9.2
+    - pyqtgraph ==0.11.0
     - pyreadline ==2.1  # [win]
     - pyrsistent ==0.16.0
     - pysocks ==1.7.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -9,14 +9,14 @@ build:
 requirements:
   run:
     - aca_hi_bgd ==0.1.5
-    - aca_view ==0.7.1
+    - aca_view ==0.7.2
     - aca_weekly_report ==0.1.5
     - acdc ==4.7.3
     - acis_taco ==4.2.0
     - acis_thermal_check ==3.5.0
     - acisfp_check ==3.5.1
     - acispy ==2.1.0
-    - agasc ==4.11.0
+    - agasc ==4.11.1
     - annie ==0.11.0
     - backstop_history ==1.4.0
     - bep_pcb_check ==3.3.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
-    - chandra_aca ==4.32.0
+    - chandra_aca ==4.32.1
     - cxotime ==3.2.5
     - dea_check ==3.4.1
     - dpa_check ==3.3.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -9,7 +9,7 @@ build:
 requirements:
   run:
     - aca_hi_bgd ==0.1.5
-    - aca_view ==0.6.0
+    - aca_view ==0.7.1
     - aca_weekly_report ==0.1.5
     - acdc ==4.7.3
     - acis_taco ==4.2.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.2
+  version: 2021.4
 
 build:
   noarch: generic
@@ -13,39 +13,39 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.7.3
     - acis_taco ==4.2.0
-    - acis_thermal_check ==3.5.0
+    - acis_thermal_check ==3.5.1
     - acisfp_check ==3.5.0
     - acispy ==2.1.0
-    - agasc ==4.10.2
+    - agasc ==4.11.0
     - annie ==0.11.0
     - backstop_history ==1.4.0
-    - bep_pcb_check ==3.3.0
+    - bep_pcb_check ==3.3.1
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
     - chandra_aca ==4.32.0
     - cxotime ==3.2.5
-    - dea_check ==3.4.0
-    - dpa_check ==3.3.0
-    - fep1_actel_check ==3.3.0
-    - fep1_mong_check ==3.3.0
+    - dea_check ==3.4.1
+    - dpa_check ==3.3.1
+    - fep1_actel_check ==3.3.1
+    - fep1_mong_check ==3.3.1
     - find_attitude ==3.4.0
     - hopper ==4.5.1
     - jobwatch ==0.2.0
-    - kadi ==5.5.1
-    - maude ==3.6.0
-    - mica ==4.25.0
-    - parse_cm ==3.6.0
+    - kadi ==5.6.0
+    - maude ==3.7.0
+    - mica ==4.26.0
+    - parse_cm ==3.7.0
     - perigee_health_plots ==0.1.3
-    - proseco ==4.11.1
-    - psmc_check ==3.3.0
+    - proseco ==4.12.1
+    - psmc_check ==3.3.1
     - pyyaks ==4.5.0
     - quaternion ==3.6.0
     - ska-sphinx-theme ==1.3.0
     - ska.arc5gl ==3.1.5
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.52.0
+    - ska.engarchive ==4.53.0
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.12.0
@@ -56,13 +56,13 @@ requirements:
     - ska.shell ==3.5.0
     - ska.sun ==3.6.0
     - ska.tdb ==3.6.0
-    - ska3-core ==2021.2
+    - ska3-core ==2021.4
     - ska3-template ==2019.09.03
     - ska_helpers ==0.5.0
     - ska_path ==3.1.2
-    - ska_sync ==4.7.0
+    - ska_sync ==4.8.0
     - skare3_tools ==1.0.3
-    - sparkles ==4.7.0
-    - starcheck ==13.8.0
+    - sparkles ==4.9.0
+    - starcheck ==13.9.0
     - testr ==4.6.0
-    - xija ==4.21.1
+    - xija ==4.23.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -13,8 +13,8 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.7.3
     - acis_taco ==4.2.0
-    - acis_thermal_check ==3.5.1
-    - acisfp_check ==3.5.0
+    - acis_thermal_check ==3.5.0
+    - acisfp_check ==3.5.1
     - acispy ==2.1.0
     - agasc ==4.11.0
     - annie ==0.11.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - kadi ==5.6.0
     - maude ==3.7.0
     - mica ==4.26.0
-    - parse_cm ==3.7.0
+    - parse_cm ==3.7.1
     - perigee_health_plots ==0.1.3
     - proseco ==4.12.1
     - psmc_check ==3.3.1
@@ -63,6 +63,6 @@ requirements:
     - ska_sync ==4.8.0
     - skare3_tools ==1.0.3
     - sparkles ==4.9.0
-    - starcheck ==13.9.0
+    - starcheck ==13.10.0
     - testr ==4.6.0
     - xija ==4.23.0


### PR DESCRIPTION
# ska3-flight 2021.4

## Summary:

The main changes in release 2021.4 are improvements to the AGASC supplement. It includes a new version of the AGASC supplement file, which includes a table of star magnitudes estimated by the ACA. The release includes the following:
- A [new version of the AGASC supplement file](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/flight-promotion-2021.3).
- Functionality to regularly update the AGASC supplement.
- Functionality to provide ACA-estimated magnitudes through the existing `agasc` module interface.

## Interface Impacts:

### AGASC access

Code that uses the `agasc` Python package to access star data will use updated magnitude information from the AGASC supplement by default.  This can be controlled by the AGASC_SUPPLEMENT_ENABLED environment variable, by use of the `agasc.set_supplement_enabled()` method, or by explicit use of the `use_supplement` argument in the methods.  See https://sot.github.io/agasc/api.html for the `agasc` documentation as needed.

### Starcheck
The deprecated `make_stars` output has been removed from starcheck.

#### ACA Load review checklist update to version 3.7

In parallel with this ska3-flight / starcheck promotion, we also bring a small ACA load review checklist update for approval.  The checklist item change has been reviewed and approved by SSAWG

[Remove ACA-044](https://github.com/sot/starcheck/compare/13.8.0...master#diff-3766be703952199f39ddf3e38784a23c4cda1f5f0bbefcbfcc98578e053a4da7)

(this is a link to the full diffs since last release, I haven't been able to find a git link just to the aca load review checklist, but to see just those changes, select "Files Changed" , select "6 changed files", and then select "starcheck/src/aca_load_review_cl.rst -Jean)


## Testing:

- [Automated testing](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.4rc3). Apparent failures are about warning messages caused by testing with current AGASC supplement file, as opposed to with the file to be promoted.

The following tests were done using [the supplement file to be promoted](https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement/flight-promotion-2021.3/agasc_supplement.h5):
- [Final test on Linux/HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.4-HEAD). All tests OK.
- [Linux on HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.4rc5-HEAD). All tests OK.
- [Mac OS 10.15](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.4rc5-Mac-OS-10.15). All tests OK.
- Windows 10. Tests OK except for a failure in `hopper` fixed by https://github.com/sot/hopper/pull/22. This
   package is only used operationally in `starcheck` which does not run on Windows.

Additional testing:
- The AGASC supplement update scripts have been running on a regular weekly schedule since November 2020 while improvements were still being made. The version of AGASC in this release has been running in the test environment since April 2nd 2021.
- The full starcheck regression test set has been run with the agasc supplement disabled via AGASC_SUPPLEMENT_ENABLED=False, as the loads in the regression test set were not built with the supplement.  Use of the agasc supplement for load review in starcheck has been functionally tested via use of the ska3-flight test environment against the APR0521T test products (built by the FOT with access to the supplement).

Test environment available on HEAD and GRETA Linux:
```
/proj/sot/ska3/test
```

To install the latest test version:
```
conda create -n ska3-flight-2021.4rc5 --override-channels -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test ska3-flight==2021.4rc5
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment:

- 2021.4 release will be promoted to the flight conda channel, and deployed on HEAD and GRETA ska3/flight after the release and products for the week are approved.
- AGASC supplement file will be copied to `/proj/sot/ska/data/agasc` on HEAD and GRETA.

# Code changes

## ska3-flight changes (2021.2 -> 2021.4rc5)

### Updated Packages

- **aca_view:** 0.6.0 -> 0.7.2 (0.6.0 -> 0.7.0 -> 0.7.1 -> 0.7.2)
  - [PR 80](https://github.com/sot/aca_view/pull/80) (javierggt): Small changes
  - [PR 81](https://github.com/sot/aca_view/pull/81) (javierggt): **_Added Plots_**
  - [PR 82](https://github.com/sot/aca_view/pull/82) (javierggt): Small fixes to work without QtAds and pyqtgraph 0.11.1
  - [PR 83](https://github.com/sot/aca_view/pull/83) (javierggt): Small bugfixes
- **acisfp_check:** 3.5.0 -> 3.5.1 (3.5.0 -> 3.5.1)
  - [PR 31](https://github.com/acisops/acisfp_check/pull/31) (jzuhone): Move conftest for tests
- **agasc:** 4.10.2 -> 4.11.1 (4.10.2 -> 4.11.0 -> 4.11.1)
  - [PR 72](https://github.com/sot/agasc/pull/72) (taldcroft): Add flake8 check to GitHub workflows
  - [PR 56](https://github.com/sot/agasc/pull/56) (taldcroft): Improved access to AGASC supplement
  - [PR 58](https://github.com/sot/agasc/pull/58) (taldcroft): **_Faster get_stars() function_**
  - [PR 55](https://github.com/sot/agasc/pull/55) (taldcroft): Handle bad-stars and obs status together
  - [PR 77](https://github.com/sot/agasc/pull/77) (javierggt): Flake8
  - [PR 76](https://github.com/sot/agasc/pull/76) (javierggt): Bugfixes
  - [PR 78](https://github.com/sot/agasc/pull/78) (javierggt): Improved logging
  - [PR 82](https://github.com/sot/agasc/pull/82) (javierggt): Obs status
  - [PR 85](https://github.com/sot/agasc/pull/85) (javierggt): Added supplement versions table
  - [PR 83](https://github.com/sot/agasc/pull/83) (javierggt): Auto yaml
  - [PR 86](https://github.com/sot/agasc/pull/86) (javierggt): Added a mechanism to set mag_aca and mag_aca_err manually in the supplement, and a unique star-observation ID
  - [PR 92](https://github.com/sot/agasc/pull/92) (javierggt): Added a mechanism to log command-line arguments to be able to re-run
  - [PR 100](https://github.com/sot/agasc/pull/100) (javierggt): Fix "telemetry mismatch" error
  - [PR 101](https://github.com/sot/agasc/pull/101) (javierggt): Rename observation_id
  - [PR 105](https://github.com/sot/agasc/pull/105) (javierggt): Fixture to monkeypatch builtin open function
  - [PR 107](https://github.com/sot/agasc/pull/107) (javierggt): Default dtype
  - [PR 103](https://github.com/sot/agasc/pull/103) (javierggt): Minor fixes
  - [PR 110](https://github.com/sot/agasc/pull/110) (javierggt): Implemented supplement update/promotion workflow
  - [PR 112](https://github.com/sot/agasc/pull/112) (javierggt): Tweaks to workflow and improvements to docs
- **bep_pcb_check:** 3.3.0 -> 3.3.1 (3.3.0 -> 3.3.1)
  - [PR 7](https://github.com/acisops/bep_pcb_check/pull/7) (jzuhone): Move conftest for tests
- **chandra_aca:** 4.32.0 -> 4.32.1 (4.32.0 -> 4.32.1)
  - [PR 115](https://github.com/sot/chandra_aca/pull/115) (javierggt): Update a tolerance in obc cen vs gnd sol test
- **dea_check:** 3.4.0 -> 3.4.1 (3.4.0 -> 3.4.1)
  - [PR 31](https://github.com/acisops/dea_check/pull/31) (jzuhone): Move conftest so tests can catch it
- **dpa_check:** 3.3.0 -> 3.3.1 (3.3.0 -> 3.3.1)
  - [PR 29](https://github.com/acisops/dpa_check/pull/29) (jzuhone): Move conftest so we can use testr
- **fep1_actel_check:** 3.3.0 -> 3.3.1 (3.3.0 -> 3.3.1)
  - [PR 7](https://github.com/acisops/fep1_actel_check/pull/7) (jzuhone): Move conftest for tests
- **fep1_mong_check:** 3.3.0 -> 3.3.1 (3.3.0 -> 3.3.1)
  - [PR 7](https://github.com/acisops/fep1_mong_check/pull/7) (jzuhone): Move conftest for tests
- **kadi:** 5.5.1 -> 5.6.0 (5.5.1 -> 5.6.0)
  - [PR 200](https://github.com/sot/kadi/pull/200) (taldcroft): _**Make kadi events complete from start of mission**_
- **maude:** 3.6.0 -> 3.7.0 (3.6.0 -> 3.7.0)
  - [PR 35](https://github.com/sot/maude/pull/35) (taldcroft): **_Improve chunked query to tolerate empty chunks_**
  - [PR 34](https://github.com/sot/maude/pull/34) (jeanconn): **_Update index and state code files for P015_**
- **mica:** 4.25.0 -> 4.26.0 (4.25.0 -> 4.26.0)
  - [PR 258](https://github.com/sot/mica/pull/258) (jeanconn): Disable use of agasc supplement for stats and a specific vv use case
- **parse_cm:** 3.6.0 -> 3.7.1 (3.6.0 -> 3.7.0 -> 3.7.1)
  - [PR 31](https://github.com/sot/parse_cm/pull/31) (taldcroft): **_Update maneuver regex to parse prelim neg obsids_**
  - [PR 34](https://github.com/sot/parse_cm/pull/34) (taldcroft): **_Ensure the last line of ObsReq is parsed_**
- **proseco:** 4.11.1 -> 4.12.1 (4.11.1 -> 4.12.1)
  - [PR 351](https://github.com/sot/proseco/pull/351) (javierggt): Fix problem from table API change in astropy 4.2
- **psmc_check:** 3.3.0 -> 3.3.1 (3.3.0 -> 3.3.1)
  - [PR 26](https://github.com/acisops/psmc_check/pull/26) (jzuhone): Move conftest for tests
- **ska.engarchive:** 4.52.0 -> 4.53.0 (4.52.0 -> 4.53.0)
  - [PR 218](https://github.com/sot/eng_archive/pull/218) (matthewdahmer): **_Use Telescope Bus 5 and Bus 6 state to calculate relevant derived thermal parameters_**
  - [PR 219](https://github.com/sot/eng_archive/pull/219) (taldcroft): **_Fix a problem adding MSIDs to existing content type_**
- **ska3-core:** 2021.2 -> 2021.4rc5
- **ska_sync:** 4.7.0 -> 4.8.0 (4.7.0 -> 4.8.0)
  - [PR 23](https://github.com/sot/ska_sync/pull/23) (taldcroft): **_Add --sync-mp option for ACA-related SOT mission planning files_**
  - [PR 24](https://github.com/sot/ska_sync/pull/24) (taldcroft): **_Update Ska.tdb to p015 and add cdb directory_**
- **sparkles:** 4.7.0 -> 4.9.0 (4.7.0 -> 4.8.0 -> 4.9.0)
  - [PR 149](https://github.com/sot/sparkles/pull/149) (taldcroft): Update tests for AGASC supplement disable as needed
  - [PR 151](https://github.com/sot/sparkles/pull/151) (taldcroft): Support slicing of ACAReviewTable
- **starcheck:** 13.8.0 -> 13.10.0 (13.8.0 -> 13.9.0 -> 13.10.0)
  - [PR 361](https://github.com/sot/starcheck/pull/361) (jeanconn): Remove all make_stars stuff
  - [PR 363](https://github.com/sot/starcheck/pull/363) (jeanconn): Remove multiple star filter stuff
  - [PR 364](https://github.com/sot/starcheck/pull/364) (jeanconn): Remove checks for flickering pixel mon windows
  - [PR 365](https://github.com/sot/starcheck/pull/365) (jeanconn): Recharacterize too few guide warning as yellow warn
  - [PR 366](https://github.com/sot/starcheck/pull/366) (jeanconn): Remove 'has magnitude been checked' for stealth mon star
  - [PR 367](https://github.com/sot/starcheck/pull/367) (jeanconn): Remove old ok-no-starcat stuff
  - [PR 362](https://github.com/sot/starcheck/pull/362) (jeanconn): Remove special case ER checks
  - [PR 368](https://github.com/sot/starcheck/pull/368) (jeanconn): Remove an orphaned bit of special_case_er code
  - [PR 371](https://github.com/sot/starcheck/pull/371) (jeanconn): **_Update ACA model for chandra_models 3.34.1_**
- **xija:** 4.21.1 -> 4.23.0 (4.21.1 -> 4.22.0 -> 4.23.0)
  - [PR 106](https://github.com/sot/xija/pull/106) (taldcroft): **_Add a Delay model component_**
  - [PR 107](https://github.com/sot/xija/pull/107) (taldcroft): **_Allow fewer dP pitches + add sensible keyword arg defaults_**
  - [PR 108](https://github.com/sot/xija/pull/108) (jzuhone): **_Fix random crashes using xija_gui_fit on Linux, change limit names for annotation, use CxoTime_**


## ska3-core changes (2021.2 -> 2021.4rc5)

### New Packages
- **ipympl: 0.7.0**  : **_Allow use of better interactive plots via `%matplotlib widgets`_**
- **nodejs: 10.13.0**
- **pyqtgraph: 0.11.0** : **_Make plots in Qt5_**

# Related Issues

Fixes #617
Fixes #618
Fixes #619
Fixes #620
Fixes #621
Fixes #623
Fixes #624
Fixes #625
Fixes #626
Fixes #627
Fixes #628
Fixes #629
Fixes #630
Fixes #631
Fixes #632
Fixes #633
Fixes #634
Fixes #635
Fixes #640
Fixes #641
Fixes #642
Fixes #643
Fixes #644
Fixes #645
Fixes #646
