### PR TITLE
2021.5

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.4
+  version: 2021.5
 
 build:
   noarch: generic
@@ -13,12 +13,12 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.7.3
     - acis_taco ==4.2.0
-    - acis_thermal_check ==3.5.0
+    - acis_thermal_check ==3.6.0
     - acisfp_check ==3.5.1
     - acispy ==2.1.0
     - agasc ==4.11.1
     - annie ==0.11.0
-    - backstop_history ==1.4.0
+    - backstop_history ==1.4.1
     - bep_pcb_check ==3.3.1
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0


### PR DESCRIPTION
# ska3-flight 2021.5

## Summary:

Several minor changes  to the ACIS packages acis_thermal_check and backstop_history.

## Interface Impacts:

From J. ZuHone's email:
* The limit for cold ECS measurements has been changed from -119.5 C to -118.2 C, to reflect the change in the MP guideline for the focal plane temperature recently approved at the FDB. 
* The --version command line argument was non-functional, this is now fixed.
* When running a thermal model for load review, we use glob to check for the existence of a backstop file. On case-insensitive filesystems, there is another file in our directories (cr_test.backstop) which was caught by this glob. We have changed the glob pattern to avoid this. 
* We now use the docutils python module directly to write the webpage from the RestructuredText file, previously this was handled by making a system call from Python to the rst2html command-line tool.

The side benefit of these latter two changes is that the ACIS thermal model checks now run on Windows and pass all regression tests, if that ever becomes useful. 

## Testing:

- [Automated testing](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.5-HEAD).
- Testing environments:
  - HEAD: `/proj/sot/ska3/test`
  - GRETA Linux: `/proj/sot/ska3/test`

To install:
```
conda install --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2021.5rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment:

ska3-flight 2021.5 will be promoted to flight conda channel and installed on HEAD and GRETA Linux after **MAY1021** loads are approved.

# Code changes

## ska3-flight changes (2021.4 -> 2021.5rc1)

### Updated Packages

- **acis_thermal_check:** 3.5.0 -> 3.6.0 (3.5.0 -> 3.6.0)
  - [PR 39](https://github.com/acisops/acis_thermal_check/pull/39) (jzuhone): Run on windows, change the cold ECS planning limit, fix bugs
- **backstop_history:** 1.4.0 -> 1.4.1 (1.4.0 -> 1.4.1)
  - [PR 19](https://github.com/acisops/backstop_history/pull/19) (jzuhone): Run on filesystems which are not case-sensitive

# Related Issues

Fixes #649
Fixes #648 
Fixes #647 