### PR TITLE
2021.6

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.5
+  version: 2021.6
 
 build:
   noarch: generic
@@ -26,7 +26,7 @@ requirements:
     - chandra_aca ==4.32.1
     - cxotime ==3.2.5
     - dea_check ==3.4.1
-    - dpa_check ==3.3.1
+    - dpa_check ==3.4.0
     - fep1_actel_check ==3.3.1
     - fep1_mong_check ==3.3.1
     - find_attitude ==3.4.0


### PR DESCRIPTION
# ska3-flight 2021.6

## Summary:

This release only includes changes to dpa_check briefed and approved in load review:
- Re-calibration of the 1DPAMZT thermal model. This eliminates an over-estimation of the
temperatures at the hot end.
- In addition, the value for the 2xx0 parameter was set by hand to a more reasonable value [slides 28, 29, 30 and 31 of the TWG presentation](https://github.com/acisops/dpa_check/blob/master/dpa_check/2021_1DPAMZT_Calibration_TWG.pdf)
- General re-calibration.

## Interface Impacts:

None
    
## Testing:

From G. Germain's email: The changes were tested with the full regression test set for the 1DPAMZT model.

Test runs:
- [Automated testing](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.6).
- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.6_HEAD).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.6_GRETA).

In these runs:
   - mica test_get_rms_data fails because the data used as reference changed. This test was fixed in the most current version of mica (which is not included in this release) and does not affect any functionality.
   - mica post_check_logs test appears to fail. This happens because the automated test runner does not have sybase access. This is not an issue.

## Review

Changes in this PR and test results were reviewed and approved by T. Aldcroft as flight director.

## Deployment:

ska3-flight 2021.6 will be promoted to flight conda channel and installed on HEAD and GRETA Linux after JUN1421A loads are approved.

# Code changes

## ska3-flight changes (2021.5 -> 2021.6rc1)

### Updated Packages

- **dpa_check:** 3.3.1 -> 3.4.0 (3.3.1 -> 3.4.0)
  - [PR 30](https://github.com/acisops/dpa_check/pull/30) (Gregg140): May 2021 Re-Calibration of the 1DPAMZT model
  - [PR 31](https://github.com/acisops/dpa_check/pull/31) (Gregg140): Added Release Notes and TWG presentation to the 2021 1DPAMZT re-calibration PR


# Related Issues

Fixes #655 
Fixes #653 