### PR TITLE
Xija linux build

### DIFF
--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -14,9 +14,10 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - gxx_linux-64 # [linux]
+    - gcc_linux-64==8.4.0 # [linux]
+    - libgcc-ng==9.1.0  # [linux]
     - clangxx_osx-64 # [osx]
-    - python
+    - python==3.8.10
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive

--- a/pkg_defs/Ska.Numpy/meta.yaml
+++ b/pkg_defs/Ska.Numpy/meta.yaml
@@ -15,9 +15,10 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - gcc_linux-64 # [linux]
+    - gcc_linux-64==8.4.0 # [linux]
+    - libgcc-ng==9.1.0  # [linux]
     - clang_osx-64 # [osx]
-    - python
+    - python==3.8.10
     - numpy
     - setuptools
     - setuptools_scm

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  number: 1
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/xija

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -4,10 +4,10 @@ package:
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/xija
-  build: 2
 
 
 # the build and runtime requirements. Dependencies of these requirements

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - gcc_linux-64==8.4.0 # [linux]
     - libgcc-ng==9.1.0  # [linux]
     - clang_osx-64 # [osx]
-    - python
+    - python==3.8.10
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -7,6 +7,7 @@ build:
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/xija
+  build: 2
 
 
 # the build and runtime requirements. Dependencies of these requirements
@@ -15,7 +16,8 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - gcc_linux-64 # [linux]
+    - gcc_linux-64==8.4.0 # [linux]
+    - libgcc-ng==9.1.0  # [linux]
     - clang_osx-64 # [osx]
     - python
     - setuptools


### PR DESCRIPTION
This PR changes the recipe for the xija package. It fixes the current build issue by building the package in python 3.8.10 and also fixing the versions of other build dependencies.

I verified that this:
- [x] builds in the upcoming version of the docker builder
- [x] builds in the current version of the docker builder
- [x] installs in our current installation without adding/updating packages to ska3-core
- [x] passes unit tests on HEAD

To build from this branch using the current docker builder image:
```
docker run --rm  --name builder -v $GITHUB_WORKSPACE:/github/workspace -w /github/workspace \
>     -e CONDA_PASSWORD -e GIT_USERNAME -e GIT_PASSWORD \
>     docker.pkg.github.com/sot/skare3/centos7-builder:latest \
>     sot/xija --skare3-branch linux-build --force --tag 4.23.0
```

Fixes #674 