### PR TITLE
2021.9

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.8
+  version: 2021.9
 
 build:
   noarch: generic
@@ -11,41 +11,41 @@ requirements:
     - aca_hi_bgd ==0.1.5
     - aca_view ==0.7.2
     - aca_weekly_report ==0.1.5
-    - acdc ==4.7.4
+    - acdc ==4.8.0
     - acis_taco ==4.2.0
     - acis_thermal_check ==3.6.0
-    - acisfp_check ==3.5.1
+    - acisfp_check ==3.6.0
     - acispy ==2.2.0
-    - agasc ==4.11.3
+    - agasc ==4.11.4
     - annie ==0.11.0
     - backstop_history ==1.4.1
     - bep_pcb_check ==3.3.1
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
-    - chandra_aca ==4.32.1
+    - chandra_aca ==4.33.0
     - cxotime ==3.2.5
     - dea_check ==3.4.1
     - dpa_check ==3.4.0
     - fep1_actel_check ==3.3.1
     - fep1_mong_check ==3.3.1
     - find_attitude ==3.4.0
-    - hopper ==4.5.1
+    - hopper ==4.5.2
     - jobwatch ==0.2.0
-    - kadi ==5.6.0
+    - kadi ==5.6.1
     - maude ==3.7.0
-    - mica ==4.26.1
+    - mica ==4.27.0
     - parse_cm ==3.7.1
-    - perigee_health_plots ==0.1.3
-    - proseco ==5.2.1
+    - perigee_health_plots ==0.2.1
+    - proseco ==5.3.0
     - psmc_check ==3.3.1
     - pyyaks ==4.5.0
-    - quaternion ==3.6.0
+    - quaternion ==4.0.1
     - ska-sphinx-theme ==1.3.0
     - ska.arc5gl ==3.1.5
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.53.0
+    - ska.engarchive ==4.53.1
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.12.0
@@ -54,7 +54,7 @@ requirements:
     - ska.quatutil ==3.4.0
     - ska.report_ranges ==0.4.0
     - ska.shell ==3.5.0
-    - ska.sun ==3.6.0
+    - ska.sun ==3.7.0
     - ska.tdb ==3.6.0
     - ska3-core ==2021.8
     - ska3-template ==2019.09.03
@@ -62,7 +62,7 @@ requirements:
     - ska_path ==3.1.2
     - ska_sync ==4.9.1
     - skare3_tools ==1.0.4
-    - sparkles ==4.12.0
-    - starcheck ==13.11.0
+    - sparkles ==4.12.2
+    - starcheck ==13.12.0
     - testr ==4.6.0
-    - xija ==4.23.0
+    - xija ==4.24.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - find_attitude ==3.4.0
     - hopper ==4.5.2
     - jobwatch ==0.2.0
-    - kadi ==5.6.1
+    - kadi ==5.6.0
     - maude ==3.7.0
     - mica ==4.27.0
     - parse_cm ==3.7.1


### PR DESCRIPTION
# ska3-flight 2021.9

This PR includes:
- acisfp_check changes already briefed in AUG3021A load review.
- attitude tool updates in Ska.Sun and Quaternion.
- updated planet plotting supported with changes in chandra_aca, proseco, and starcheck.
- starcheck also includes a change to read the ACA model from chandra_models via get_xija_model_spec (starcheck was set to read the *limits* from that but needed another tiny update to get the model from it).
- collection of tiny incremental changes.

## Interface Impacts:

None

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.9-HEAD/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.9-GRETA/).
- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.9/).
- [Automated tests (rc1)](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.9rc1/).
- [Automated tests (rc2)](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.9rc2/).

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2021.9rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2021.9rc#
```

The regression test loads were also run in starcheck and the only diff from the previous starcheck release is that the version of chandra models is now in the output:
```
********************* 2005/JUL1105/oflsc ********************
--- /home/jeanconn/git/starcheck/test_regress/release/2005/JUL1105/oflsc/starcheck.txt	2021-08-31 14:15:52.496202000 -0400
+++ /home/jeanconn/git/starcheck/test_regress/fido.cfa.harvard.edu_ff3ea1ffc759f1309b3bd68d97e7250cbb221f08/2005/JUL1105/oflsc/starcheck.txt	2021-08-31 14:12:07.312985000 -0
400
@@ -1,3 +1,4 @@
+ chandra_models version: 3.37
 
 Short Term Schedule: JUL1105C
```


## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment:

ska3-flight 2021.9 will be promoted to flight conda channel and installed on HEAD and GRETA Linux after the SEP0621 loads are approved.

# Code changes

## ska3-flight changes (2021.8 -> 2021.9rc2)

### Updated Packages

- **acdc:** 4.7.4 -> 4.8.0 (4.7.4 -> 4.8.0)
  - [PR 62](https://github.com/sot/acdc/pull/62) (jeanconn): Update warm pix notebook
  - [PR 64](https://github.com/sot/acdc/pull/64) (jeanconn): Scale the testing cal to the kwarg guide tccd for the observations
- **acisfp_check:** 3.5.1 -> 3.6.0 (3.5.1 -> 3.6.0)
  - [PR 32](https://github.com/acisops/acisfp_check/pull/32) (jzuhone): 2021 ACIS FP recalibration
- **agasc:** 4.11.3 -> 4.11.4 (4.11.3 -> 4.11.4)
  - [PR 123](https://github.com/sot/agasc/pull/123) (javierggt): add link to supplement diff in email notifications
  - [PR 126](https://github.com/sot/agasc/pull/126) (taldcroft): Make sure observations with status=0 are not flagged suspect
  - [PR 124](https://github.com/sot/agasc/pull/124) (javierggt): remove existing obs_status file if it is not going to be replaced
  - [PR 125](https://github.com/sot/agasc/pull/125) (javierggt): Enhanced output obs_status to include maxmag
- **chandra_aca:** 4.32.1 -> 4.33.0 (4.32.1 -> 4.33.0)
  - [PR 117](https://github.com/sot/chandra_aca/pull/117) (taldcroft): Add a few validation notebooks
  - [PR 118](https://github.com/sot/chandra_aca/pull/118) (taldcroft): Fix bug where centroid_fm was modifying input image
  - [PR 116](https://github.com/sot/chandra_aca/pull/116) (taldcroft): _Planet improvements_
- **hopper:** 4.5.1 -> 4.5.2 (4.5.1 -> 4.5.2)
  - [PR 22](https://github.com/sot/hopper/pull/22) (taldcroft): Fix get_backstop_cmds to work on Windows
- **mica:** 4.26.1 -> 4.27.0 (4.26.1 -> 4.27.0)
  - [PR 259](https://github.com/sot/mica/pull/259) (taldcroft): Add get_star_stats single-star method for acq/gui stats and remove Sybase from mica.web.star_hist
  - [PR 261](https://github.com/sot/mica/pull/261) (jeanconn): Add two new obsids to bad list
- **perigee_health_plots:** 0.1.3 -> 0.2.1 (0.1.3 -> 0.2.0 -> 0.2.1)
  - [PR 19](https://github.com/sot/perigee_health_plots/pull/19) (jeanconn): Update ccd temp warning limit for -6.5C planning limit
  - [PR 20](https://github.com/sot/perigee_health_plots/pull/20) (jeanconn): Get ACA model from chandra_models repo via xija code
- **proseco:** 5.2.1 -> 5.3.0 (5.2.1 -> 5.3.0)
  - [PR 361](https://github.com/sot/proseco/pull/361) (taldcroft): _Pass catalog date to plotting so planets are drawn_
  - [PR 366](https://github.com/sot/proseco/pull/366) (taldcroft): Improve handling for missing required args
  - [PR 367](https://github.com/sot/proseco/pull/367) (taldcroft): Add duration and target_name attributes to ACACatalog
- **quaternion:** 3.6.0 -> 4.0.1 (3.6.0 -> 4.0.0 -> 4.0.1)
  - [PR 34](https://github.com/sot/Quaternion/pull/34) (taldcroft): Add a link to the Matrix and Quaternions FAQ
  - [PR 36](https://github.com/sot/Quaternion/pull/36) (taldcroft): _Add rotate_about_vec method_
  - [PR 37](https://github.com/sot/Quaternion/pull/37) (taldcroft): _Make Quat behave more like ndarray (item access, iteration, reshaping etc)_
  - [PR 38](https://github.com/sot/Quaternion/pull/38) (taldcroft): Copy astropy shapes
- **ska.engarchive:** 4.53.0 -> 4.53.1 (4.53.0 -> 4.53.1)
  - [PR 220](https://github.com/sot/eng_archive/pull/220) (taldcroft): Add information about remote access and scripts
  - [PR 221](https://github.com/sot/eng_archive/pull/221) (taldcroft): New NOTES file for a bad ingest + gap process update
- **ska.sun:** 3.6.0 -> 3.7.0 (3.6.0 -> 3.7.0)
  - [PR 16](https://github.com/sot/Ska.Sun/pull/16) (taldcroft): _Add utility functions, add units tests and package properly_
  - [PR 17](https://github.com/sot/Ska.Sun/pull/17) (taldcroft): PEP8 compliance
- **sparkles:** 4.12.0 -> 4.12.2 (4.12.0 -> 4.12.1 -> 4.12.2)
  - [PR 158](https://github.com/sot/sparkles/pull/158) (jeanconn): Handle NoneType self.mons from a pickle
  - [PR 159](https://github.com/sot/sparkles/pull/159) (taldcroft): Fix checking guide count when monitors are present
  - [PR 160](https://github.com/sot/sparkles/pull/160) (taldcroft): Fix test failure from PR #159
- **starcheck:** 13.11.0 -> 13.12.0 (13.11.0 -> 13.12.0)
  - [PR 375](https://github.com/sot/starcheck/pull/375) (taldcroft): _Plot track of planets_
  - [PR 376](https://github.com/sot/starcheck/pull/376) (jeanconn): _Get the ACA thermal model with get_xija_model_spec_
- **xija:** 4.23.0 -> 4.24.0 (4.23.0 -> 4.23.1 -> 4.24.0)
  - [PR 109](https://github.com/sot/xija/pull/109) (taldcroft): This fixes a bug that was missed in the recent gui_fit PR
  - [PR 110](https://github.com/sot/xija/pull/110) (taldcroft): Set the default repo_path inside the get_model_spec function
  - [PR 111](https://github.com/sot/xija/pull/111) (taldcroft): Use the right repo path to get available model names
  - [PR 112](https://github.com/sot/xija/pull/112) (taldcroft): Two new functions to handle limit strings, minor viz fixes for xija_gui_fit
  - [PR 113](https://github.com/sot/xija/pull/113) (jzuhone): Fixing bugs in limits implementation and adding them to the model info window in xija_gui_fit


# Related Issues

Fixes #684
Fixes #685
Fixes #687
Fixes #688
Fixes #689
Fixes #690
Fixes #691
Fixes #692
Fixes #693
Fixes #694
Fixes #695
Fixes #696
Fixes #697
Fixes #698
Fixes #699
Fixes #700
Fixes #701
Fixes #702
