### PR TITLE
2021.11

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.9
+  version: 2021.11
 
 build:
   noarch: generic
@@ -14,7 +14,7 @@ requirements:
     - acdc ==4.8.0
     - acis_taco ==4.2.0
     - acis_thermal_check ==3.6.0
-    - acisfp_check ==3.6.0
+    - acisfp_check ==3.7.0
     - acispy ==2.2.0
     - agasc ==4.11.4
     - annie ==0.11.0


### PR DESCRIPTION
# ska3-flight 2021.11

This PR includes:
- the latest release of acisfp_check with the correct file for the recent model recalibration update of the ACIS FP model.

## Interface Impacts:

None

## Testing:

- [Automated tests 2021.11rc1](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.11rc1).
- [Automated tests 2021.11](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.11).

The latest release candidate is installed in `/proj/sot/ska3/test` on HEAD, and is available for testing from the usual channels:
```
conda create -n ska3-flight-{version}rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2021.11rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2021.11 will be promoted to flight conda channel and installed on HEAD and GRETA Linux after the SEP2021A loads are approved.

# Code changes

- **acisfp_check:** 3.6.0 -> 3.7.0 (3.6.0 -> 3.7.0)
  - [PR 33](https://github.com/acisops/acisfp_check/pull/33) (jzuhone): 2021 ACIS FP recalibration (for real this time)
 
# Related Issues

Closes #707 
Closes #708 
