### PR TITLE
2021.13

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.12
+  version: 2021.13
 
 build:
   noarch: generic
@@ -14,7 +14,7 @@ requirements:
     - acdc ==4.8.0
     - acis_taco ==4.2.0
     - acis_thermal_check ==3.6.0
-    - acisfp_check ==3.7.0
+    - acisfp_check ==3.8.0
     - acispy ==2.2.0
     - agasc ==4.11.4
     - annie ==0.11.0


### PR DESCRIPTION
# ska3-flight 2021.13

This PR includes:
- 

## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.13/).

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2021.13rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2021.13rc#
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2021.13 will be promoted to flight conda channel and installed on HEAD and GRETA Linux after this week's loads are approved.

# Code changes

# Related Issues

Fixes #714
Fixes #715