### PR TITLE
2021.14

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -19,13 +19,13 @@ requirements:
     - agasc ==4.11.4
     - annie ==0.11.0
     - backstop_history ==1.5.1
-    - bep_pcb_check ==3.3.1
+    - bep_pcb_check ==3.3.2
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
     - chandra_aca ==4.34.0
     - cxotime ==3.2.5
-    - dea_check ==3.4.1
+    - dea_check ==3.4.2
     - dpa_check ==3.4.0
     - fep1_actel_check ==3.3.1
     - fep1_mong_check ==3.3.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -9,7 +9,7 @@ build:
 requirements:
   run:
     - aca_hi_bgd ==0.1.5
-    - aca_view ==0.7.2
+    - aca_view ==0.8.0
     - aca_weekly_report ==0.1.5
     - acdc ==4.8.0
     - acis_taco ==4.2.0
@@ -45,7 +45,7 @@ requirements:
     - ska.arc5gl ==3.1.5
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.53.1
+    - ska.engarchive ==4.54.0
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.13.0
@@ -61,8 +61,8 @@ requirements:
     - ska_helpers ==0.5.0
     - ska_path ==3.1.2
     - ska_sync ==4.9.1
-    - skare3_tools ==1.0.4
-    - sparkles ==4.12.2
+    - skare3_tools ==1.0.5
+    - sparkles ==4.13.0
     - starcheck ==13.12.0
     - testr ==4.6.0
     - xija ==4.24.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.8.0
     - acis_taco ==4.2.0
-    - acis_thermal_check ==3.7.1
+    - acis_thermal_check ==3.7.2
     - acisfp_check ==3.8.1
     - acispy ==2.2.0
     - agasc ==4.11.4
@@ -23,7 +23,7 @@ requirements:
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
-    - chandra_aca ==4.33.0
+    - chandra_aca ==4.34.0
     - cxotime ==3.2.5
     - dea_check ==3.4.1
     - dpa_check ==3.4.0
@@ -31,16 +31,16 @@ requirements:
     - fep1_mong_check ==3.3.1
     - find_attitude ==3.4.0
     - hopper ==4.5.2
-    - jobwatch ==0.4.0
-    - kadi ==5.7.1
+    - jobwatch ==0.5.0
+    - kadi ==5.8.0
     - maude ==3.7.0
     - mica ==4.27.2
     - parse_cm ==3.7.1
     - perigee_health_plots ==0.2.1
-    - proseco ==5.3.0
+    - proseco ==5.4.0
     - psmc_check ==3.3.1
     - pyyaks ==4.5.0
-    - quaternion ==4.0.1
+    - quaternion ==4.1.0
     - ska-sphinx-theme ==1.3.0
     - ska.arc5gl ==3.1.5
     - ska.astro ==3.3.0
@@ -48,7 +48,7 @@ requirements:
     - ska.engarchive ==4.53.1
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
-    - ska.matplotlib ==3.12.0
+    - ska.matplotlib ==3.13.0
     - ska.numpy ==3.9.0
     - ska.parsecm ==3.4.0
     - ska.quatutil ==3.4.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -62,7 +62,7 @@ requirements:
     - ska_path ==3.1.2
     - ska_sync ==4.9.1
     - skare3_tools ==1.0.5
-    - sparkles ==4.13.0
+    - sparkles ==4.13.1
     - starcheck ==13.12.0
     - testr ==4.6.0
     - xija ==4.24.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -13,12 +13,12 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.8.0
     - acis_taco ==4.2.0
-    - acis_thermal_check ==3.7.0
+    - acis_thermal_check ==3.7.1
     - acisfp_check ==3.8.1
     - acispy ==2.2.0
     - agasc ==4.11.4
     - annie ==0.11.0
-    - backstop_history ==1.5.0
+    - backstop_history ==1.5.1
     - bep_pcb_check ==3.3.1
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0
@@ -31,7 +31,7 @@ requirements:
     - fep1_mong_check ==3.3.1
     - find_attitude ==3.4.0
     - hopper ==4.5.2
-    - jobwatch ==0.2.0
+    - jobwatch ==0.4.0
     - kadi ==5.7.1
     - maude ==3.7.0
     - mica ==4.27.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -63,6 +63,6 @@ requirements:
     - ska_sync ==4.9.1
     - skare3_tools ==1.0.5
     - sparkles ==4.13.1
-    - starcheck ==13.12.0
+    - starcheck ==13.13.0
     - testr ==4.6.0
     - xija ==4.24.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.13
+  version: 2021.14
 
 build:
   noarch: generic
@@ -13,12 +13,12 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.8.0
     - acis_taco ==4.2.0
-    - acis_thermal_check ==3.6.0
+    - acis_thermal_check ==3.7.0
     - acisfp_check ==3.8.1
     - acispy ==2.2.0
     - agasc ==4.11.4
     - annie ==0.11.0
-    - backstop_history ==1.4.1
+    - backstop_history ==1.5.0
     - bep_pcb_check ==3.3.1
     - chandra.cmd_states ==3.16.0
     - chandra.maneuver ==3.8.0


### PR DESCRIPTION
# ska3-flight 2021.14

This PR includes:
- Update to starcheck load review tool to change the bright star limit to 5.2 mag.
   - The starcheck update includes an update to the [ACA load review](https://github.com/sot/starcheck/pull/377/files#diff-3766be703952199f39ddf3e38784a23c4cda1f5f0bbefcbfcc98578e053a4da7) checklist consistent with the change in the bright limit for guide and acq stars.  This was approved by SSAWG.
- Changes in proseco, chandra_aca, and sparkles in relation to the 5.2 mag bright star limit.
- Changes in kadi to handle the LETG move duration.

## Interface Impacts:

- **kadi**: add a new intermediate state to the grating states to indicate the movement time between INSR and RETR. This behavior can be disabled using `kadi.command.states.disable_grating_move_duration `

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2021.14rc15/).

Functional and full regression test suite run on starcheck; only expected diffs (warnings removed on a few stars in the regression test set brighter than 6.0 mag).

The latest release candidate is installed in `/proj/sot/ska3/test` on HEAD, and all release candidates are available for testing from the usual channels:
```
conda create -n ska3-flight-2021.14rc15 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2021.14rc15
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight {version} will be promoted to flight conda channel and installed on HEAD and GRETA Linux after this week's loads are approved.

# Code changes

## ska3-flight changes (2021.13 -> 2021.14rc15)


### Updated Packages

- **aca_view:** 0.7.2 -> 0.8.0 (0.7.2 -> 0.8.0)
  - [PR 84](https://github.com/sot/aca_view/pull/84) (javierggt): Commands in time slider and other small changes
  - [PR 85](https://github.com/sot/aca_view/pull/85) (javierggt): Refactored config to play nice with QSettings.
  - [PR 86](https://github.com/sot/aca_view/pull/86) (javierggt): Add MAUDE channel as an option
  - [PR 91](https://github.com/sot/aca_view/pull/91) (javierggt): Use first kadi maneuver to set obsid start, not last
  - [PR 93](https://github.com/sot/aca_view/pull/93) (javierggt): fixed wrong logging message
  - [PR 92](https://github.com/sot/aca_view/pull/92) (javierggt): Fix the way the image view slides as dither pushes the image against the edge
  - [PR 90](https://github.com/sot/aca_view/pull/90) (javierggt): Fix issue sot/aca_view/issues/88.
- **acis_thermal_check:** 3.6.0 -> 3.7.2 (3.6.0 -> 3.7.0 -> 3.7.1 -> 3.7.2)
  - [PR 41](https://github.com/acisops/acis_thermal_check/pull/41) (Gregg140): Update for SCS-106 change and new power commands
  - [PR 42](https://github.com/acisops/acis_thermal_check/pull/42) (Gregg140): Write .hist files to --outdir directory
  - [PR 43](https://github.com/acisops/acis_thermal_check/pull/43) (jzuhone): Temporarily disable the inclusion of gratings moves states
- **backstop_history:** 1.4.1 -> 1.5.1 (1.4.1 -> 1.5.0 -> 1.5.1)
  - [PR 20](https://github.com/acisops/backstop_history/pull/20) (Gregg140): Update for SCS-106 change and new power commands
  - [PR 21](https://github.com/acisops/backstop_history/pull/21) (Gregg140): Use cr backstop files
- **bep_pcb_check:** 3.3.1 -> 3.3.2 (3.3.1 -> 3.3.2)
  - [PR 8](https://github.com/acisops/bep_pcb_check/pull/8) (jzuhone): Violation time off by a fraction of a second
- **chandra_aca:** 4.33.0 -> 4.34.0 (4.33.0 -> 4.34.0)
  - [PR 119](https://github.com/sot/chandra_aca/pull/119) (jeanconn): Update guide_count for 5.2mag bright limit
- **dea_check:** 3.4.1 -> 3.4.2 (3.4.1 -> 3.4.2)
  - [PR 32](https://github.com/acisops/dea_check/pull/32) (jzuhone): Violation time is off by a fraction of a second
- **jobwatch:** 0.2.0 -> 0.5.0 (0.2.0 -> 0.3.0 -> 0.4.0 -> 0.5.0)
  - [PR 48](https://github.com/sot/jobwatch/pull/48) (taldcroft): Check that the last kadi dwell < 3 days old
  - [PR 49](https://github.com/sot/jobwatch/pull/49) (jeanconn): Exclude some mica errors from log warnings
  - [PR 50](https://github.com/sot/jobwatch/pull/50) (taldcroft): Split hourly watch into Ska and MTA jobs
- **kadi:** 5.7.1 -> 5.8.0 (5.7.1 -> 5.8.0)
  - [PR 210](https://github.com/sot/kadi/pull/210) (taldcroft): Make changes for grating move duration (again)
- **proseco:** 5.3.0 -> 5.4.0 (5.3.0 -> 5.4.0)
  - [PR 368](https://github.com/sot/proseco/pull/368) (jeanconn): Move bright limits to approach or hit the new 5.2 mag onboard limit
- **quaternion:** 4.0.1 -> 4.1.0 (4.0.1 -> 4.1.0)
  - [PR 39](https://github.com/sot/Quaternion/pull/39) (taldcroft): Add from_attitude class method for more permissive init
- **ska.engarchive:** 4.53.1 -> 4.54.0 (4.53.1 -> 4.54.0)
  - [PR 223](https://github.com/sot/eng_archive/pull/223) (taldcroft): Improve MSID representation
  - [PR 224](https://github.com/sot/eng_archive/pull/224) (taldcroft): Try preventing square overflow and give debug info otherwise
- **ska.matplotlib:** 3.12.0 -> 3.13.0 (3.12.0 -> 3.13.0)
  - [PR 19](https://github.com/sot/Ska.Matplotlib/pull/19) (taldcroft): Handle shaped and zero-length input data in cxctime2plotdate
- **skare3_tools:** 1.0.4 -> 1.0.5 (1.0.4 -> 1.0.5)
  - [PR 83](https://github.com/sot/skare3_tools/pull/83) (javierggt): Fix version overwrite when building
- **sparkles:** 4.12.2 -> 4.13.1 (4.12.2 -> 4.13.0 -> 4.13.1)
  - [PR 162](https://github.com/sot/sparkles/pull/162) (jeanconn): Update bright limit check to use 5.2 mag
  - [PR 163](https://github.com/sot/sparkles/pull/163) (jeanconn): Update roll review test for up to 5.2 mag stars
  - [PR 164](https://github.com/sot/sparkles/pull/164) (taldcroft): Allow specifying all roll options from command line
  - [PR 161](https://github.com/sot/sparkles/pull/161) (taldcroft): Add module to find ER catalog
  - [PR 165](https://github.com/sot/sparkles/pull/165) (taldcroft): Fix ER attitude finder test fails due to 5.2 mag limit change
- **starcheck:** 13.12.0 -> 13.13.0 (13.12.0 -> 13.13.0)
  - [PR 377](https://github.com/sot/starcheck/pull/377) (jeanconn): Move the bright limit to 5.2 in code and checklist

# Related Issues

Fixes #721
Fixes #722
Fixes #726
Fixes #727
Fixes #728
Fixes #729
Fixes #730
Fixes #731
Fixes #732
Fixes #733
Fixes #734
Fixes #735
Fixes #736
Fixes #737
Fixes #738
Fixes #739
Fixes #740
