### PR TITLE
2022.1

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - acispy ==2.4.0
     - agasc ==4.11.4
     - annie ==0.11.0
-    - backstop_history ==1.5.1
+    - backstop_history ==1.5.2
     - chandra.cmd_states ==3.17.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.15
+  version: 2022.1
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.8.0
     - acis_taco ==4.2.0
-    - acis_thermal_check ==4.0.0
+    - acis_thermal_check ==4.1.0
     - acispy ==2.3.0
     - agasc ==4.11.4
     - annie ==0.11.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - acdc ==4.8.0
     - acis_taco ==4.2.0
     - acis_thermal_check ==4.1.0
-    - acispy ==2.3.0
+    - acispy ==2.4.0
     - agasc ==4.11.4
     - annie ==0.11.0
     - backstop_history ==1.5.1


### PR DESCRIPTION
# ska3-flight 2022.1

This PR includes the ACIS OPS improvements in FSDS-11 and FSDS-13.

## Interface Impacts:

No impacts.

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.1rc3/).

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2022.1rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2022.1rc#
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2022.1 will be promoted to flight conda channel and installed on HEAD and GRETA Linux on Feb 07 2022 evening, after FSDS ticket is approved.

# Code changes

## ska3-flight changes (2021.15 -> 2022.1rc3)

### Updated Packages

- **acis_thermal_check:** 4.0.0 -> 4.1.0 (4.0.0 -> 4.1.0)
  - [PR 45](https://github.com/acisops/acis_thermal_check/pull/45) (jzuhone): Use limits from the JSON file, refactor prediction plots
  - [PR 46](https://github.com/acisops/acis_thermal_check/pull/46) (jzuhone): Prevent matplotlib warning
- **acispy:** 2.3.0 -> 2.4.0 (2.3.0 -> 2.4.0)
  - [PR 10](https://github.com/acisops/acispy/pull/10) (jzuhone): Use thermal limits from JSON files, support ACIS FP in SimulateECSRun, new "attitude" argument 
- **backstop_history:** 1.5.1 -> 1.5.2 (1.5.1 -> 1.5.2)
  - [PR 22](https://github.com/acisops/backstop_history/pull/22) (Gregg140): Now processes a full continuity (science + vehicle commands) load as …

# Related Issues

Fixes #766
Fixes #767 
Fixes #775 
Fixes #777 
