### PR TITLE
2022.2

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,289 +1,401 @@
 ---
 package:
   name: ska3-core
-  version: 2021.8  # in a typical release, change the ska3-core version in ska3-flight requirements.
+  version: 2022.2
 
 requirements:
   run:
     - _libgcc_mutex ==0.1  # [linux]
+    - _openmp_mutex ==4.5  # [linux]
     - alabaster ==0.7.12
-    - appnope ==0.1.0  # [osx]
-    - asgiref ==3.2.10
-    - astroid ==2.4.2
-    - astropy ==4.2.1
-    - astropy-healpix ==0.5
+    - alsa-lib ==1.2.3  # [linux]
+    - anyio ==2.2.0
+    - appdirs ==1.4.4
+    - appnope ==0.1.2  # [osx]
+    - argon2-cffi ==20.1.0
+    - asgiref ==3.4.1
+    - astroid ==2.9.0
+    - astropy ==5.0
+    - astropy-healpix ==0.6
     - astropy-sphinx-theme ==1.1
+    - astroquery ==0.4.5
+    - async_generator ==1.10
     - atomicwrites ==1.4.0  # [win]
-    - attrs ==19.3.0
-    - autopep8 ==1.5.3
-    - babel ==2.8.0
+    - attrs ==21.4.0
+    - autopep8 ==1.6.0
+    - babel ==2.9.1
     - backcall ==0.2.0
-    - bcrypt ==3.1.7
-    - beautifulsoup4 ==4.9.1
-    - blas ==1.0
-    - bleach ==3.3.0
+    - backports ==1.0
+    - backports.zoneinfo ==0.2.1
+    - bcrypt ==3.2.0
+    - beautifulsoup4 ==4.10.0
+    - black ==19.10b0
+    - blas ==1.0  # [win]
+    - blas ==1.1  # [linux or osx]
+    - bleach ==4.1.0
     - blinker ==1.4
-    - blosc ==1.19.0
-    - bokeh ==2.1.1
+    - blosc ==1.21.0
+    - bokeh ==2.4.2
+    - bottleneck ==1.3.2
+    - brotli ==1.0.9
     - brotlipy ==0.7.0
     - bzip2 ==1.0.8
-    - ca-certificates ==2021.1.19
-    - certifi ==2020.12.5
-    - cffi ==1.14.0
-    - chardet ==3.0.4
-    - cloudpickle ==1.5.0  # [win]
-    - colorama ==0.4.3  # [win]
+    - c-ares ==1.18.1  # [linux or osx]
+    - ca-certificates ==2021.10.26
+    - certifi ==2021.10.8
+    - cffi ==1.14.6  # [linux or osx]
+    - cffi ==1.15.0  # [win]
+    - chardet ==4.0.0
+    - charset-normalizer ==2.0.4
+    - click ==8.0.3
+    - cloudpickle ==2.0.0  # [win]
+    - colorama ==0.4.4
     - commonmark ==0.9.1
-    - conda ==4.8.3
-    - conda-build ==3.18.11
-    - conda-package-handling ==1.6.1
+    - conda ==4.11.0
+    - conda-build ==3.21.7
+    - conda-package-handling ==1.7.3
     - configobj ==5.0.6
-    - cryptography ==2.9.2
-    - cycler ==0.10.0
-    - cython ==0.29.21
-    - dbus ==1.13.16  # [linux or osx]
-    - decorator ==4.4.2
-    - defusedxml ==0.6.0
-    - django ==3.0.3
-    - docutils ==0.16
-    - docxtpl ==0.10.0
+    - coverage ==5.5  # [win]
+    - coverage ==6.2  # [linux or osx]
+    - cryptography ==36.0.0
+    - cycler ==0.11.0
+    - cython ==0.29.25
+    - dbus ==1.13.18  # [linux or osx]
+    - debugpy ==1.5.1
+    - decorator ==5.1.0
+    - defusedxml ==0.7.1
+    - django ==3.1.7
+    - docutils ==0.17.1
+    - docxtpl ==0.11.5
     - entrypoints ==0.3
-    - expat ==2.2.9  # [linux or osx]
-    - filelock ==3.0.12
-    - flake8 ==3.8.3
-    - fontconfig ==2.13.0  # [linux]
-    - freetype ==2.10.2
+    - expat ==2.4.3  # [linux or osx]
+    - filelock ==3.4.2
+    - flake8 ==3.9.2
+    - font-ttf-dejavu-sans-mono ==2.37  # [linux]
+    - font-ttf-inconsolata ==2.001  # [linux]
+    - font-ttf-source-code-pro ==2.030  # [linux]
+    - font-ttf-ubuntu ==0.83  # [linux]
+    - fontconfig ==2.13.1  # [linux]
+    - fonts-conda-forge ==1  # [linux]
+    - fonttools ==4.28.5
+    - freetype ==2.10.4  # [win]
+    - freetype ==2.11.0  # [linux or osx]
     - future ==0.18.2
-    - gettext ==0.19.8.1  # [osx]
-    - git ==2.23.0  # [win]
-    - gitdb ==4.0.5
-    - gitpython ==3.1.3
-    - glib ==2.65.0  # [linux or osx]
+    - gettext ==0.21.0  # [linux or osx]
+    - giflib ==5.2.1  # [linux or osx]
+    - git ==2.34.1  # [win]
+    - gitdb ==4.0.7
+    - gitpython ==3.1.18
+    - glib ==2.68.4  # [linux]
+    - glib ==2.69.1  # [osx]
+    - glib-tools ==2.68.4  # [linux]
     - glob2 ==0.7
-    - gst-plugins-base ==1.14.0  # [linux]
-    - gstreamer ==1.14.0  # [linux]
-    - h5py ==2.10.0
-    - hdf5 ==1.10.4
+    - greenlet ==1.1.1  # [win]
+    - gst-plugins-base ==1.18.5  # [linux]
+    - gstreamer ==1.18.5  # [linux]
+    - h5py ==3.6.0
+    - hdf5 ==1.10.6
+    - html5lib ==1.1
+    - hypothesis ==6.29.3
     - icc_rt ==2019.0.0  # [win]
-    - icu ==58.2
-    - idna ==2.10
-    - imagesize ==1.2.0
-    - importlib-metadata ==1.7.0
-    - importlib_metadata ==1.7.0
+    - icu ==68.2
+    - idna ==3.3
+    - imagesize ==1.3.0
+    - importlib-metadata ==4.10.1
+    - importlib_metadata ==4.10.1
     - iniconfig ==1.1.1
-    - intel-openmp ==2019.4  # [osx]
-    - intel-openmp ==2020.1  # [linux or win]
-    - ipykernel ==5.3.3
+    - intel-openmp ==2022.0.0  # [win]
+    - ipykernel ==6.4.1
     - ipympl ==0.7.0
     - ipyparallel ==6.3.0
-    - ipython ==7.16.1
+    - ipython ==7.29.0
     - ipython_genutils ==0.2.0
-    - ipywidgets ==7.5.1
-    - isort ==4.3.21
-    - jedi ==0.17.1
-    - jinja2 ==2.11.2
-    - jira ==2.0.0
-    - joblib ==0.16.0
-    - jpeg ==9b
-    - jplephem ==2.14
-    - json5 ==0.9.5
+    - ipywidgets ==7.6.5
+    - isort ==5.9.3
+    - jbig ==2.1
+    - jedi ==0.18.0
+    - jeepney ==0.7.1  # [linux]
+    - jinja2 ==2.11.3
+    - jira ==3.0.1
+    - joblib ==1.1.0
+    - jpeg ==9d
+    - jplephem ==2.17
+    - json5 ==0.9.6
     - jsonschema ==3.2.0
     - jupyter ==1.0.0
-    - jupyter_client ==6.1.6
-    - jupyter_console ==6.1.0
-    - jupyter_core ==4.6.3
-    - jupyterlab ==2.1.5
-    - jupyterlab_server ==1.2.0
-    - kiwisolver ==1.2.0
-    - krb5 ==1.18.2
-    - lazy-object-proxy ==1.4.3
-    - lcms2 ==2.11  # [linux or osx]
-    - ld_impl_linux-64 ==2.33.1  # [linux]
-    - libarchive ==3.4.2
-    - libcurl ==7.71.1
-    - libcxx ==10.0.0  # [osx]
-    - libedit ==3.1.20191231  # [linux or osx]
+    - jupyter_client ==7.1.0
+    - jupyter_console ==6.4.0
+    - jupyter_core ==4.9.1
+    - jupyter_server ==1.4.1
+    - jupyterlab ==3.2.1
+    - jupyterlab_pygments ==0.1.2
+    - jupyterlab_server ==2.10.2
+    - jupyterlab_widgets ==1.0.0
+    - kaleido-core ==0.2.1
+    - keyring ==23.4.0
+    - kiwisolver ==1.3.2
+    - krb5 ==1.19.2
+    - lazy-object-proxy ==1.6.0
+    - lcms2 ==2.12  # [linux or osx]
+    - ld_impl_linux-64 ==2.35.1  # [linux]
+    - lerc ==2.2.1
+    - libarchive ==3.5.2
+    - libblas ==3.8.0  # [osx]
+    - libblas ==3.9.0  # [linux or win]
+    - libcblas ==3.8.0  # [osx]
+    - libcblas ==3.9.0  # [linux or win]
+    - libclang ==11.1.0
+    - libcurl ==7.80.0
+    - libcxx ==12.0.0  # [osx]
+    - libdeflate ==1.7
+    - libedit ==3.1.20210910  # [linux or osx]
+    - libev ==4.33  # [linux or osx]
+    - libevent ==2.1.10  # [linux]
     - libffi ==3.3  # [linux or osx]
-    - libgcc-ng ==9.1.0  # [linux]
+    - libgcc-ng ==11.2.0  # [linux]
     - libgfortran ==3.0.1  # [osx]
-    - libgfortran-ng ==7.3.0  # [linux]
-    - libiconv ==1.15  # [linux or win]
-    - libiconv ==1.16  # [osx]
-    - liblief ==0.10.1
-    - libllvm9 ==9.0.1
+    - libgfortran-ng ==7.5.0  # [linux]
+    - libgfortran4 ==7.5.0  # [linux]
+    - libglib ==2.68.4  # [linux]
+    - libiconv ==1.15  # [win]
+    - libiconv ==1.16  # [linux or osx]
+    - liblapack ==3.8.0  # [osx]
+    - liblapack ==3.9.0  # [linux or win]
+    - liblief ==0.11.5
+    - libllvm11 ==11.1.0  # [linux or osx]
+    - libmamba ==0.19.1
+    - libmambapy ==0.19.1
+    - libnghttp2 ==1.46.0  # [linux or osx]
+    - libogg ==1.3.5  # [linux]
+    - libopenblas ==0.3.10  # [osx]
+    - libopenblas ==0.3.12  # [linux]
+    - libopus ==1.3.1  # [linux]
     - libpng ==1.6.37
-    - libsodium ==1.0.18
-    - libsolv ==0.7.14  # [osx]
-    - libsolv ==0.7.16  # [linux]
-    - libsolv ==0.7.17  # [win]
+    - libpq ==12.9  # [win]
+    - libpq ==13.3  # [linux or osx]
+    - libsodium ==1.0.18  # [linux or osx]
+    - libsolv ==0.7.19
     - libssh2 ==1.9.0
-    - libstdcxx-ng ==9.1.0  # [linux]
-    - libtiff ==4.1.0
+    - libstdcxx-ng ==11.2.0  # [linux]
+    - libtiff ==4.3.0
     - libuuid ==1.0.3  # [linux]
+    - libuv ==1.40.0  # [linux or osx]
+    - libvorbis ==1.3.7  # [linux]
+    - libwebp ==1.2.1
+    - libwebp-base ==1.2.1
     - libxcb ==1.14  # [linux]
-    - libxml2 ==2.9.10
-    - libxslt ==1.1.34
-    - line_profiler ==2.1.2
-    - llvm-openmp ==10.0.0  # [osx]
-    - llvmlite ==0.33.0
-    - lxml ==4.5.2
-    - lz4-c ==1.9.2
+    - libxkbcommon ==1.0.3  # [linux]
+    - libxml2 ==2.9.12
+    - libxslt ==1.1.33  # [linux or osx]
+    - libxslt ==1.1.34  # [win]
+    - line_profiler ==3.3.1
+    - llvm-openmp ==12.0.1  # [linux or osx]
+    - llvmlite ==0.37.0
+    - lxml ==4.5.1  # [linux or osx]
+    - lxml ==4.7.1  # [win]
+    - lz4-c ==1.9.3
     - lzo ==2.10
     - m2w64-gcc-libgfortran ==5.3.0  # [win]
     - m2w64-gcc-libs ==5.3.0  # [win]
     - m2w64-gcc-libs-core ==5.3.0  # [win]
     - m2w64-gmp ==6.1.0  # [win]
     - m2w64-libwinpthread-git ==5.0.0.4634.697f757  # [win]
-    - mamba ==0.4.2  # [osx]
-    - mamba ==0.5.1  # [linux or win]
-    - markupsafe ==1.1.1
-    - matplotlib ==3.2.2
-    - matplotlib-base ==3.2.2
+    - mamba ==0.19.1
+    - markupsafe ==2.0.1
+    - mathjax ==2.7.7
+    - matplotlib ==3.5.1
+    - matplotlib-base ==3.5.1
+    - matplotlib-inline ==0.1.2
     - mccabe ==0.6.1
-    - menuinst ==1.4.16  # [win]
+    - menuinst ==1.4.18  # [win]
     - mistune ==0.8.4
-    - mkl ==2019.4  # [osx]
-    - mkl ==2020.1  # [linux or win]
-    - mkl-service ==2.3.0
-    - mkl_fft ==1.1.0
-    - mkl_random ==1.1.1
-    - mock ==4.0.2
-    - more-itertools ==8.4.0
-    - mpld3 ==0.3
+    - mkl ==2021.4.0  # [win]
+    - mkl-service ==2.4.0  # [win]
+    - mkl_fft ==1.3.1  # [win]
+    - mkl_random ==1.2.2  # [win]
+    - mock ==4.0.3
+    - more-itertools ==8.12.0  # [win]
+    - mpld3 ==0.5.7
     - msys2-conda-epoch ==20160418  # [win]
+    - munkres ==1.1.4
+    - mypy_extensions ==0.4.3
+    - mysql-common ==8.0.25  # [linux or osx]
+    - mysql-libs ==8.0.25  # [linux or osx]
     - nb_conda ==2.2.1
-    - nb_conda_kernels ==2.2.3
-    - nbconvert ==5.6.1
-    - nbformat ==5.0.7
-    - ncurses ==6.2  # [linux or osx]
-    - networkx ==2.4
-    - nodejs ==10.13.0
+    - nb_conda_kernels ==2.3.1
+    - nbclassic ==0.2.6
+    - nbclient ==0.5.3
+    - nbconvert ==6.1.0  # [win]
+    - nbconvert ==6.3.0  # [linux or osx]
+    - nbformat ==5.1.3
+    - ncurses ==6.3  # [linux or osx]
+    - nest-asyncio ==1.5.1
+    - networkx ==2.6.3
+    - nodejs ==16.13.1
     - nose ==1.3.7
-    - notebook ==6.0.3
-    - numba ==0.50.1
-    - numexpr ==2.7.1
-    - numpy ==1.18.5
-    - numpy-base ==1.18.5
+    - notebook ==6.4.6
+    - nspr ==4.32  # [linux or osx]
+    - nss ==3.69  # [linux or osx]
+    - numba ==0.54.1
+    - numexpr ==2.8.1
+    - numpy ==1.20.3
+    - numpy-base ==1.20.3
     - numpydoc ==1.1.0
     - oauthlib ==3.1.0
     - olefile ==0.46
-    - openssl ==1.1.1i
-    - packaging ==20.4
-    - pandas ==1.0.5
-    - pandoc ==2.10
-    - pandocfilters ==1.4.2
-    - paramiko ==2.7.1
-    - parso ==0.7.0
-    - patchelf ==0.11  # [linux]
-    - pbr ==5.4.5
-    - pcre ==8.44  # [linux or osx]
+    - openblas ==0.3.12  # [linux]
+    - openblas ==0.3.4  # [osx]
+    - openssl ==1.1.1m
+    - packaging ==21.3
+    - pandas ==1.3.5
+    - pandocfilters ==1.4.3
+    - paramiko ==2.8.1
+    - parso ==0.8.3
+    - patchelf ==0.14.3  # [linux]
+    - pathspec ==0.7.0
+    - pcre ==8.45  # [linux or osx]
     - pexpect ==4.8.0
     - pickleshare ==0.7.5
-    - pillow ==7.2.0
-    - pip ==20.1.1
-    - pkginfo ==1.5.0.1
-    - plotly ==4.14.3
-    - pluggy ==0.13.1
-    - prometheus_client ==0.8.0
+    - pillow ==8.4.0
+    - pip ==21.2.2  # [win]
+    - pip ==21.2.4  # [linux or osx]
+    - pkginfo ==1.8.2
+    - platformdirs ==2.4.0
+    - plotly ==5.1.0
+    - pluggy ==0.13.1  # [win]
+    - pluggy ==1.0.0  # [linux or osx]
+    - prometheus_client ==0.12.0
     - prompt-toolkit ==2.0.10  # [win]
-    - prompt-toolkit ==3.0.5  # [linux or osx]
-    - prompt_toolkit ==2.0.10  # [win]
-    - prompt_toolkit ==3.0.5  # [linux or osx]
-    - psutil ==5.7.0
-    - ptyprocess ==0.6.0  # [linux or osx]
-    - py ==1.9.0
-    - py-lief ==0.10.1
-    - pycodestyle ==2.6.0
+    - prompt-toolkit ==3.0.20  # [linux or osx]
+    - prompt_toolkit ==3.0.20  # [linux or osx]
+    - prompt_toolkit ==3.0.3  # [win]
+    - psutil ==5.9.0
+    - psycopg2 ==2.8.6  # [win]
+    - psycopg2 ==2.9.2  # [linux or osx]
+    - ptyprocess ==0.7.0
+    - py ==1.10.0
+    - py-lief ==0.11.5
+    - pybind11-abi ==4
+    - pycodestyle ==2.7.0
     - pycosat ==0.6.3
-    - pycparser ==2.20
+    - pycparser ==2.21
     - pycrypto ==2.6.1
-    - pyerfa ==1.7.1.1
-    - pyflakes ==2.2.0
-    - pygments ==2.6.1
+    - pyerfa ==2.0.0.1
+    - pyflakes ==2.3.1
+    - pygments ==2.10.0
     - pyjwt ==1.7.1
-    - pylint ==2.5.3
+    - pylint ==2.12.2
     - pynacl ==1.4.0
-    - pyopenssl ==19.1.0
-    - pyparsing ==2.4.7
-    - pyqt ==5.9.2
+    - pyopenssl ==21.0.0
+    - pyparsing ==3.0.6
+    - pyqt ==5.12.3
+    - pyqt-impl ==5.12.3
+    - pyqt5-sip ==4.19.18
+    - pyqtchart ==5.12
     - pyqtgraph ==0.11.0
+    - pyqtwebengine ==5.12.1
     - pyreadline ==2.1  # [win]
-    - pyrsistent ==0.16.0
+    - pyrsistent ==0.18.0
     - pysocks ==1.7.1
     - pytables ==3.6.1
-    - pytest ==6.2.0
-    - python ==3.8.3
-    - python-dateutil ==2.8.1
-    - python-docx ==0.8.10
-    - python-kaleido ==0.0.3
-    - python-libarchive-c ==2.9
+    - pytest ==6.2.4  # [win]
+    - pytest ==6.2.5  # [linux or osx]
+    - pytest-arraydiff ==0.3
+    - pytest-astropy ==0.9.0
+    - pytest-astropy-header ==0.1.2
+    - pytest-cov ==3.0.0
+    - pytest-doctestplus ==0.11.2
+    - pytest-filter-subpackage ==0.1.1
+    - pytest-mock ==3.6.1
+    - pytest-openfiles ==0.5.0
+    - pytest-remotedata ==0.3.3
+    - python ==3.8.12
+    - python-dateutil ==2.8.2
+    - python-docx ==0.8.11
+    - python-kaleido ==0.2.1
+    - python-libarchive-c ==3.2
+    - python-mimeparse ==1.6.0
     - python_abi ==3.8
-    - pytz ==2020.1
-    - pywin32 ==227  # [win]
+    - pytz ==2021.3
+    - pyvo ==1.2.1
+    - pywin32 ==302  # [win]
+    - pywin32-ctypes ==0.2.0  # [win]
     - pywinpty ==0.5.7  # [win]
-    - pyyaml ==5.3.1
-    - pyzmq ==19.0.1
-    - qt ==5.9.7
-    - qtconsole ==4.7.5
-    - qtpy ==1.9.0
-    - readline ==8.0  # [linux or osx]
-    - requests ==2.24.0
+    - pyyaml ==6.0
+    - pyzmq ==22.3.0
+    - qt ==5.12.9
+    - qtconsole ==5.1.1
+    - qtpy ==1.10.0
+    - readline ==8.1.2  # [linux or osx]
+    - regex ==2021.11.2  # [linux or osx]
+    - regex ==2021.8.3  # [win]
+    - regions ==0.5
+    - reproc ==14.2.3
+    - reproc-cpp ==14.2.3
+    - requests ==2.27.1
     - requests-oauthlib ==1.3.0
     - requests-toolbelt ==0.9.1
-    - retrying ==1.3.3
-    - ripgrep ==11.0.2  # [linux or osx]
-    - rope ==0.17.0
-    - ruamel_yaml ==0.15.87
+    - ripgrep ==13.0.0  # [linux or osx]
+    - rope ==0.21.1
+    - ruamel_yaml ==0.15.100
     - runipy ==0.1.5  # [win]
-    - scikit-learn ==0.23.1
-    - scipy ==1.5.0
-    - send2trash ==1.5.0
-    - setuptools ==49.2.0
-    - setuptools-scm ==4.1.2
-    - setuptools_scm ==4.1.2
+    - scikit-learn ==1.0.2
+    - scipy ==1.7.3
+    - secretstorage ==3.3.1  # [linux]
+    - send2trash ==1.8.0
+    - setuptools ==58.0.4
+    - setuptools-scm ==6.3.2
+    - setuptools_scm ==6.3.2
     - sherpa ==4.12.2  # [linux or osx]
-    - sip ==4.19.13  # [linux or win]
-    - sip ==4.19.8  # [osx]
     - six ==1.15.0
-    - smmap ==3.0.2
-    - snappy ==1.1.8
-    - snowballstemmer ==2.0.0
-    - soupsieve ==2.0.1
-    - sphinx ==3.1.2
-    - sphinx-argparse ==0.2.5
+    - smmap ==4.0.0
+    - sniffio ==1.2.0
+    - snowballstemmer ==2.2.0
+    - sortedcontainers ==2.4.0
+    - soupsieve ==2.3.1
+    - sphinx ==4.2.0
+    - sphinx-argparse ==0.3.1
     - sphinxcontrib-applehelp ==1.0.2
     - sphinxcontrib-devhelp ==1.0.2
-    - sphinxcontrib-htmlhelp ==1.0.3
+    - sphinxcontrib-htmlhelp ==2.0.0
     - sphinxcontrib-jsmath ==1.0.1
     - sphinxcontrib-qthelp ==1.0.3
-    - sphinxcontrib-serializinghtml ==1.1.4
-    - sqlalchemy ==1.3.18  # [win]
-    - sqlite ==3.32.3
-    - sqlparse ==0.3.1
-    - tbb ==2020.0
-    - terminado ==0.8.3
-    - testpath ==0.4.4
-    - threadpoolctl ==2.1.0
-    - tk ==8.6.10
-    - toml ==0.10.1
-    - tornado ==6.0.4
-    - tqdm ==4.47.0
-    - traitlets ==4.3.3
-    - typing_extensions ==3.7.4.2
-    - urllib3 ==1.25.9
-    - vc ==14.1  # [win]
-    - vs2015_runtime ==14.16.27012  # [win]
+    - sphinxcontrib-serializinghtml ==1.1.5
+    - sqlalchemy ==1.4.27  # [win]
+    - sqlite ==3.37.0
+    - sqlparse ==0.4.1
+    - tbb ==2021.4.0  # [osx]
+    - tbb ==2021.5.0  # [linux or win]
+    - tenacity ==8.0.1
+    - terminado ==0.9.4
+    - testpath ==0.5.0
+    - threadpoolctl ==2.2.0
+    - tk ==8.6.11
+    - toml ==0.10.2
+    - tomli ==1.2.2
+    - tornado ==6.1
+    - tqdm ==4.62.3
+    - traitlets ==5.1.1
+    - typed-ast ==1.4.3
+    - typing-extensions ==3.10.0.2
+    - typing_extensions ==3.10.0.2
+    - tzdata ==2021e
+    - unicodedata2 ==14.0.0
+    - urllib3 ==1.26.7
+    - vc ==14.2  # [win]
+    - vs2015_runtime ==14.27.29016  # [win]
     - wcwidth ==0.2.5
     - webencodings ==0.5.1
-    - wheel ==0.34.2
+    - wheel ==0.37.1
     - widgetsnbextension ==3.5.1
     - win_inet_pton ==1.1.0  # [win]
     - wincertstore ==0.2  # [win]
     - winpty ==0.4.3  # [win]
-    - wrapt ==1.11.2
+    - wrapt ==1.13.3
     - xz ==5.2.5
     - yaml ==0.2.5
-    - zeromq ==4.3.2
-    - zipp ==3.1.0
+    - yaml-cpp ==0.6.3
+    - zeromq ==4.3.4  # [linux or osx]
+    - zipp ==3.7.0
     - zlib ==1.2.11
-    - zstd ==1.4.5
+    - zstd ==1.5.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2021.15
+  version: 2022.2
 
 build:
   noarch: generic
@@ -12,50 +12,50 @@ requirements:
     - aca_view ==0.9.0
     - aca_weekly_report ==0.1.5
     - acdc ==4.8.0
-    - acis_taco ==4.2.0
+    - acis_taco ==4.2.1
     - acis_thermal_check ==4.1.0
     - acispy ==2.3.0
     - agasc ==4.11.4
-    - annie ==0.11.0
+    - annie ==0.11.1
     - backstop_history ==1.5.1
     - chandra.cmd_states ==3.17.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.0
-    - chandra_aca ==4.34.0
+    - chandra_aca ==4.34.1
     - cxotime ==3.2.5
     - find_attitude ==3.4.0
     - hopper ==4.5.2
     - jobwatch ==0.6.0
-    - kadi ==5.8.0
+    - kadi ==5.8.1
     - maude ==3.7.0
     - mica ==4.28.0
     - parse_cm ==3.7.1
     - perigee_health_plots ==0.2.1
-    - proseco ==5.4.0
+    - proseco ==5.5.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.0
     - ska-sphinx-theme ==1.3.0
     - ska.arc5gl ==3.2.0
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.54.0
+    - ska.engarchive ==4.54.1
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
-    - ska.matplotlib ==3.13.0
-    - ska.numpy ==3.9.0
+    - ska.matplotlib ==3.14.0
+    - ska.numpy ==3.9.1
     - ska.parsecm ==3.4.0
     - ska.quatutil ==3.4.0
     - ska.report_ranges ==0.4.0
     - ska.shell ==3.5.0
     - ska.sun ==3.7.0
     - ska.tdb ==3.6.0
-    - ska3-core ==2021.8
+    - ska3-core ==2022.1
     - ska3-template ==2019.09.03
     - ska_helpers ==0.5.0
     - ska_path ==3.1.2
     - ska_sync ==4.9.1
     - skare3_tools ==1.0.5
     - sparkles ==4.13.1
-    - starcheck ==13.14.0
-    - testr ==4.6.0
-    - xija ==4.24.0
+    - starcheck ==13.15.0
+    - testr ==4.7.0
+    - xija ==4.24.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.8.0
     - acis_taco ==4.2.0
-    - acis_thermal_check ==4.0.0
+    - acis_thermal_check ==4.1.0
     - acispy ==2.3.0
     - agasc ==4.11.4
     - annie ==0.11.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-perl
-  version: 2020.14
+  version: 2022.2
 
 build:
   skip: True  # [win]
@@ -10,14 +10,16 @@ requirements:
   run:
     - _sysroot_linux-64_curr_repodata_hack ==3  # [linux]
     - cfitsio ==3.470  # [linux]
+    - fonts-anaconda ==1  # [linux]
+    - fonts-conda-ecosystem ==1  # [linux]
     - gsl ==2.4  # [linux]
+    - intel-openmp ==2021.4.0  # [linux]
     - kernel-headers_linux-64 ==3.10.0  # [linux]
-    - krb5 ==1.18.2  # [linux]
-    - libcurl ==7.71.1  # [linux]
-    - libssh2 ==1.9.0  # [linux]
     - libx11-common-cos7-x86_64 ==1.6.7  # [linux]
     - libx11-cos7-x86_64 ==1.6.7  # [linux]
     - libx11-devel-cos7-x86_64 ==1.6.7  # [linux]
+    - mkl ==2021.4.0  # [linux]
+    - mkl_fft ==1.3.1  # [linux]
     - perl ==5.26.2
     - perl-app-cpanminus ==1.7044
     - perl-app-env-ascds ==0.04  # [linux]
@@ -36,8 +38,8 @@ requirements:
     - task_schedule ==4.2.1
     - watch_cron_logs ==4.2.1
     - xorg-kbproto ==1.0.7  # [linux]
-    - xorg-libx11 ==1.6.9  # [linux]
-    - xorg-libxft ==2.3.2  # [linux]
+    - xorg-libx11 ==1.6.12  # [linux]
+    - xorg-libxft ==2.3.4  # [linux]
     - xorg-libxrender ==0.9.10  # [linux]
     - xorg-renderproto ==0.11.1  # [linux]
     - xorg-xproto ==7.0.31  # [linux]


### PR DESCRIPTION
# ska3-flight 2022.2

This PR includes:
- 

## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.2/).

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2022.2rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2022.2rc#
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2022.2 will be promoted to flight conda channel and installed on HEAD and GRETA Linux after this week's loads are approved.

# Code changes

# Related Issues