### PR TITLE
Ska3 next scripts

### DIFF
--- a/combine_arch_meta.py
+++ b/combine_arch_meta.py
@@ -67,7 +67,11 @@ def include_list(env, args):
 
     # add explicit includes
     # (otherwise ska3-flight-latest env minus ska3-flight-latest meta does not include ska3-core)
-    include = sorted(include + args.include)
+    for pkg in args.include:
+        if pkg in env:
+            include.append(pkg)
+
+    include = sorted(include)
 
     return include
 

--- a/patch_instructions.py
+++ b/patch_instructions.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+
+"""
+This script takes care of fetching patch instructions from upstream repositories. See
+https://docs.conda.io/projects/conda-build/en/latest/concepts/generating-index.html#repodata-patching
+to learn more about this.
+
+While both Anaconda and conda-forge maintain a set of python scripts to generate these patch
+instructions (which are stored in JSON format), we just get their patch instructions and try to
+merge them. Hopefully this will work... famous last words.
+"""
+
+
+import json
+import re
+import logging
+import subprocess
+import requests
+import collections
+import argparse
+from pathlib import Path
+
+
+def match(package, spec_string):
+    """
+    Check if a package info matches a spec string.
+
+    If present, the version must be an exact match.
+
+    Parameters
+    ----------
+    package : dict
+        Usually the output of `conda list --json`
+    spec_string : str
+        a string of the form <name>[==<version>]
+
+    Returns
+    -------
+    bool
+    """
+    m = re.match(r'(?P<name>[-_a-zA-Z0-9]+)(==)?(?P<version>\S+)?', spec_string)
+    if m:
+        parts = m.groupdict()
+        return (
+            parts['name'] == package['name']
+            and ((parts['version'] is None) or (parts['version'] == package['version']))
+        )
+    return False
+
+
+def get_patch_instructions(packages=()):
+    """
+    Fetch patch instructions from upstream repositories.
+
+    Parameters
+    ----------
+    packages : list
+        A list of dictionaries. Usually the output of `conda list --json`
+
+    Returns
+    -------
+    dict
+    """
+    # get all installed packages
+    p = subprocess.Popen(['conda', 'list', '--json'], stdout=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    package_info = json.loads(stdout.decode())
+    if packages:
+        # only consider the ones requested
+        tmp = []
+        for pkg_string in packages:
+            for pkg in package_info:
+                if match(pkg, pkg_string):
+                    tmp.append(pkg)
+                    break
+            else:
+                logging.warning(f'Package spec {pkg_string} not found')
+        package_info = tmp
+    # get patch instruction from all upstream repositories
+    urls = set(['{base_url}/{platform}'.format(**p) for p in package_info])
+    rc = {url: requests.get(f'{url}/patch_instructions.json') for url in urls}
+    upstream_patches = {url: json.loads(r.content.decode()) for url, r in rc.items() if r.ok}
+    # put those instructions in our on dictionary
+    patches = collections.defaultdict(lambda: {'packages': {}, 'remove': [], 'revoke': []})
+    for pkg in package_info:
+        url = '{base_url}/{platform}'.format(**pkg)
+        if url in upstream_patches:
+            key = None
+            if f"{pkg['dist_name']}.tar.bz2" in upstream_patches[url]['packages']:
+                key = f"{pkg['dist_name']}.tar.bz2"
+            elif f"{pkg['dist_name']}.conda" in upstream_patches[url]['packages']:
+                key = f"{pkg['dist_name']}.conda"
+            if key is not None:
+                patches[pkg['platform']]['packages'][key] = upstream_patches[url]['packages'][key]
+                if ('patch_instructions_version' in patches[pkg['platform']]
+                    and (patches[pkg['platform']]['patch_instructions_version']
+                         != upstream_patches[url]['patch_instructions_version'])):
+                    logging.warning('patch_instructions_version mismatch')
+                patches[pkg['platform']]['patch_instructions_version'] = \
+                    upstream_patches[url]['patch_instructions_version']
+    patches = dict(patches)
+    return patches
+
+
+def merge_patch_instructions(filenames):
+    """
+    Merges a list of JSON files into a single one.
+
+    This assumes that the JSON file has a top-level dictionary with the following keys:
+    packages, remove, revoke, patch_instructions_version.
+
+    The reason for this is that we make patch files in each platform, which results in potentially
+    different JSON files for the noarch directory, since it depends on the packages actually
+    installed. We then gather all packages and need to merge the patches.
+    """
+    result = {'packages': {}, 'remove': [], 'revoke': []}
+    for f in filenames:
+        with open(f) as fh:
+            patches = json.load(fh)
+            result['packages'].update(patches['packages'])
+            result['remove'] += patches['remove']
+            result['revoke'] += patches['revoke']
+            result['patch_instructions_version'] = patches['patch_instructions_version']
+    result['remove'] = list(set(result['remove']))
+    result['revoke'] = list(set(result['revoke']))
+    return result
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'action',
+        choices=['get', 'merge'],
+        help="Action to perform."
+    )
+    parser.add_argument(
+        'items',
+        nargs='*',
+        help=(
+            'If action==merge: a list of JSON files to merge. '
+            'If action==get: spec strings listing packages we want patch instructions for. '
+            'If not provided, patch instructions are fetched for all installed packages. '
+            'Each spec string must be of the form <name>[==<version>].'
+        )
+    )
+    parser.add_argument(
+        '--out', '-o', type=Path, default=Path('patch_instructions'),
+        help='directory where to place patch_instructions.json files.'
+    )
+    return parser
+
+
+def main():
+    args = get_parser().parse_args()
+
+    if args.action == 'get':
+        patches = get_patch_instructions(args.items)
+        for platform in patches:
+            (args.out / platform).mkdir(parents=True, exist_ok=True)
+            with open(args.out / platform / 'patch_instructions.json', 'w') as fh:
+                json.dump(patches[platform], fh, indent=2)
+    elif args.action == 'merge':
+        patches = merge_patch_instructions(args.items)
+        args.out.mkdir(parents=True, exist_ok=True)
+        with open(args.out / 'patch_instructions.json', 'w') as fh:
+            json.dump(patches, fh, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/pkg_defs/ska3-core-latest/install_from_scratch.py
+++ b/pkg_defs/ska3-core-latest/install_from_scratch.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import pathlib
+import logging
+
+assert "CONDA_PASSWORD" in os.environ, "CONDA_PASSWORD environmental variable is not defined"
+
+CHANNELS = [
+    'defaults',
+    'conda-forge',
+    f'https://ska:{os.environ["CONDA_PASSWORD"]}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight'
+]
+
+
+# This is a list of packages to be installed before installing whatever is in meta.yaml
+PACKAGES = [
+    {
+        'channels': CHANNELS,
+        'options': ['--no-channel-priority'],
+        'packages': ['numpy', 'matplotlib', 'scipy', 'pandas', 'astropy', 'pyyaml', 'conda-build',
+                     'pyqt']
+    },
+    {  # this version is set so it is not the latest
+        'channels': CHANNELS,
+        'options': [],
+        'packages': ['django==3.1.7']
+    },
+    {  # this is not in defaults or conda-forge (for now?)
+        'channels': ['astropy'],
+        'options': [],
+        'packages': ['regions']
+    },
+]
+
+
+# These options are passed to conda_build.metadata.select_lines after reading meta.yaml.
+# This causes, for example, the lines that read " # [win]" to be read only on win-64.
+PLATFORM_OPTIONS = {
+    'linux-64': {'linux': True, 'linux64': True},
+    'osx-64': {'osx': True, 'osx64': True},
+    'win-64': {'win': True, 'win64': True}
+}
+
+
+def install_pkgs(pkgs):
+    channels = sum([['-c', c] for c in pkgs['channels']], [])
+    cmd = ['mamba', 'install', '-y'] + pkgs['options'] + channels + pkgs['packages']
+    logging.info(' '.join(cmd))
+    subprocess.run(cmd)
+
+
+def install_yaml_requirements(meta_yaml):
+    # imported here because they might not be present by default
+    import yaml
+    from conda_build.config import Config
+    from conda_build.metadata import select_lines
+    with open(meta_yaml) as fh:
+        meta = fh.read()
+
+    config = Config()
+    data = select_lines(meta, PLATFORM_OPTIONS[config.target_subdir], {})
+    data = yaml.load(data, Loader=yaml.BaseLoader)
+
+    dependencies = sum(
+        [data['requirements'][k] for k in ['build', 'run'] if k in data['requirements']],
+        []
+    )
+    install_pkgs({
+        'channels': CHANNELS,
+        'options': [],
+        'packages': dependencies,
+    })
+
+
+def main():
+    logging.basicConfig(level="INFO")
+
+    for pkgs in PACKAGES:
+        install_pkgs(pkgs)
+
+    meta_yaml = pathlib.Path(__file__).parent / 'meta.yaml'
+    install_yaml_requirements(meta_yaml)
+
+
+if __name__ == '__main__':
+    main()

--- a/pkg_defs/ska3-flight-latest/install_from_scratch.py
+++ b/pkg_defs/ska3-flight-latest/install_from_scratch.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import pathlib
+import logging
+
+assert "CONDA_PASSWORD" in os.environ, "CONDA_PASSWORD environmental variable is not defined"
+
+CHANNELS = [
+    'defaults',
+    'conda-forge',
+    f'https://ska:{os.environ["CONDA_PASSWORD"]}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight'
+]
+
+
+# This is a list of packages to be installed before installing whatever is in meta.yaml
+PACKAGES = [
+    {
+        'channels': [
+            f'https://ska:{os.environ["CONDA_PASSWORD"]}@cxc.cfa.harvard.edu'
+            '/mta/ASPECT/ska3-conda/flight'],
+        'options': [],
+        'packages': ['quaternion']
+    },
+]
+
+
+# These options are passed to conda_build.metadata.select_lines after reading meta.yaml.
+# This causes, for example, the lines that read " # [win]" to be read only on win-64.
+PLATFORM_OPTIONS = {
+    'linux-64': {'linux': True, 'linux64': True},
+    'osx-64': {'osx': True, 'osx64': True},
+    'win-64': {'win': True, 'win64': True}
+}
+
+
+def install_pkgs(pkgs):
+    channels = sum([['-c', c] for c in pkgs['channels']], [])
+    cmd = ['mamba', 'install', '-y'] + pkgs['options'] + channels + pkgs['packages']
+    logging.info(' '.join(cmd))
+    subprocess.run(cmd)
+
+
+def install_yaml_requirements(meta_yaml):
+    # imported here because they might not be present by default
+    import yaml
+    import conda_build.metadata
+    with open(meta_yaml) as fh:
+        meta = fh.read()
+
+    data = conda_build.metadata.select_lines(meta, PLATFORM_OPTIONS['osx-64'], {})
+    data = yaml.load(data, Loader=yaml.BaseLoader)
+
+    dependencies = sum(
+        [data['requirements'][k] for k in ['build', 'run'] if k in data['requirements']],
+        []
+    )
+    install_pkgs({
+        'channels': CHANNELS,
+        'options': [],
+        'packages': dependencies,
+    })
+
+
+def main():
+    logging.basicConfig(level="INFO")
+
+    for pkgs in PACKAGES:
+        install_pkgs(pkgs)
+
+    meta_yaml = pathlib.Path(__file__).parent / 'meta.yaml'
+    install_yaml_requirements(meta_yaml)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds scripts to update metapackages for the three platforms. They were used to produce release 2022.2.

This particular branch is an interactive rebase of the ska3-next branch. The scripts *should* work (they should be the same), but I have not tested them because an issue appeared with windows runners. I don't think I should spend more time with this and I'd rather push them to master for future reference.