### PR TITLE
Add patch instruction files

### DIFF
--- a/patches/linux-64/patch_instructions.json
+++ b/patches/linux-64/patch_instructions.json
@@ -1,0 +1,141 @@
+{
+  "packages": {
+    "_openmp_mutex-4.5-1_llvm.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "blosc-1.21.0-h9c3ff4c_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "conda-build-3.21.7-py38h06a4308_0.tar.bz2": {
+      "depends": [
+        "beautifulsoup4",
+        "chardet",
+        "conda >=4.5",
+        "conda-package-handling >=1.3",
+        "filelock",
+        "glob2 >=0.6",
+        "jinja2 <3.0.0a0",
+        "patchelf",
+        "pkginfo",
+        "psutil",
+        "py-lief",
+        "python >=3.8,<3.9.0a0",
+        "python-libarchive-c",
+        "pytz",
+        "pyyaml",
+        "requests",
+        "ripgrep",
+        "setuptools",
+        "six",
+        "tqdm"
+      ]
+    },
+    "icu-68.2-h9c3ff4c_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "kaleido-core-0.2.1-h3644ca4_0.tar.bz2": {
+      "depends": [
+        "__glibc >=2.17,<3.0.a0",
+        "expat >=2.2.10,<3.0.0a0",
+        "fontconfig",
+        "fonts-conda-forge",
+        "libgcc-ng >=9.3.0",
+        "mathjax 2.7.*",
+        "nspr >=4.29,<5.0a0",
+        "nss >=3.62,<4.0a0",
+        "sqlite >=3.34.0,<4.0a0"
+      ]
+    },
+    "libblas-3.9.0-8_openblas.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libcblas-3.9.0-8_openblas.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libgcc-ng-11.2.0-h1d223b6_11.tar.bz2": {
+      "license_family": "GPL"
+    },
+    "libgfortran-ng-7.5.0-ha8ba4b0_17.tar.bz2": {
+      "depends": [
+        "libgfortran4 7.5.0.*",
+        "__glibc >=2.17"
+      ]
+    },
+    "liblapack-3.9.0-8_openblas.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libopenblas-0.3.12-pthreads_hb3c22a3_1.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libstdcxx-ng-11.2.0-he4da1e4_11.tar.bz2": {
+      "license_family": "GPL"
+    },
+    "libwebp-1.2.1-h3452ae3_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libwebp-base-1.2.1-h7f98852_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libxslt-1.1.33-h15afd5d_2.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "mkl_fft-1.3.1-py38h8666266_1.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "nspr-4.32-h9c3ff4c_1.tar.bz2": {
+      "license_family": "MOZILLA"
+    },
+    "nss-3.69-hb5efdd6_1.tar.bz2": {
+      "license_family": "MOZILLA"
+    },
+    "numpy-base-1.20.3-py38h39b7dee_0.tar.bz2": {
+      "constrains": [
+        "numpy 1.20.3 py38h3dbb7de_0"
+      ]
+    },
+    "openblas-0.3.12-pthreads_h43bd3aa_1.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "patchelf-0.14.3-h58526e2_0.tar.bz2": {
+      "license_family": "GPL"
+    },
+    "qt-5.12.9-hda022c4_4.tar.bz2": {
+      "depends": [
+        "dbus >=1.13.6,<2.0a0",
+        "expat >=2.2.10,<3.0.0a0",
+        "fontconfig >=2.13.1,<3.0a0",
+        "freetype >=2.10.4,<3.0a0",
+        "gst-plugins-base >=1.18.3,<1.19.0a0",
+        "gstreamer >=1.18.3,<1.19.0a0",
+        "icu >=68.1,<69.0a0",
+        "jpeg >=9d,<10a",
+        "libclang >=11.0.1,<12.0a0",
+        "libevent >=2.1.10,<2.1.11.0a0",
+        "libgcc-ng >=9.3.0",
+        "libglib >=2.66.7,<3.0a0",
+        "libpng >=1.6.37,<1.7.0a0",
+        "libpq >=13.1,<14.0a0",
+        "libstdcxx-ng >=9.3.0",
+        "libxcb",
+        "libxkbcommon >=1.0.3,<2.0a0",
+        "libxml2 >=2.9.10,<2.10.0a0",
+        "mysql-libs >=8.0.23,<8.1.0.0a0",
+        "nspr >=4.29,<5.0a0",
+        "nss >=3.61,<4.0a0",
+        "openssl >=1.1.1j,<1.1.2a",
+        "sqlite >=3.34.0,<4.0a0",
+        "zlib >=1.2.11,<1.3.0a0"
+      ],
+      "license_family": "LGPL"
+    },
+    "reproc-14.2.3-h7f98852_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "reproc-cpp-14.2.3-h9c3ff4c_0.tar.bz2": {
+      "license_family": "MIT"
+    }
+  },
+  "patch_instructions_version": 1,
+  "remove": [],
+  "revoke": []
+}

--- a/patches/noarch/patch_instructions.json
+++ b/patches/noarch/patch_instructions.json
@@ -1,0 +1,34 @@
+{
+  "packages": {
+    "astroquery-0.4.5-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "jplephem-2.17-pyhf3f802f_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "pyparsing-3.0.6-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "python-dateutil-2.8.2-pyhd3eb1b0_0.tar.bz2": {
+      "namespace_in_name": true
+    },
+    "python-docx-0.8.11-pyhd8ed1ab_0.tar.bz2": {
+      "depends": [
+        "lxml >=2.3.2",
+        "python ==2.7.*|>=3.4"
+      ],
+      "license_family": "MIT"
+    },
+    "sphinx-argparse-0.3.1-pyhd8ed1ab_0.tar.bz2": {
+      "depends": [
+        "commonmark >=0.5.6",
+        "python ==2.7.*|>=3.6",
+        "sphinx"
+      ],
+      "license_family": "MIT"
+    }
+  },
+  "patch_instructions_version": 1,
+  "remove": [],
+  "revoke": []
+}

--- a/patches/osx-64/patch_instructions.json
+++ b/patches/osx-64/patch_instructions.json
@@ -1,0 +1,92 @@
+{
+  "packages": {
+    "blosc-1.21.0-he49afe7_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "conda-build-3.21.7-py38hecd8cb5_0.tar.bz2": {
+      "depends": [
+        "beautifulsoup4",
+        "chardet",
+        "conda >=4.5",
+        "conda-package-handling >=1.3",
+        "filelock",
+        "glob2 >=0.6",
+        "jinja2 <3.0.0a0",
+        "pkginfo",
+        "psutil",
+        "py-lief",
+        "python >=3.8,<3.9.0a0",
+        "python-libarchive-c",
+        "pytz",
+        "pyyaml",
+        "requests",
+        "ripgrep",
+        "setuptools",
+        "six",
+        "tqdm"
+      ]
+    },
+    "icu-68.2-he49afe7_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "libblas-3.8.0-17_openblas.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libcblas-3.8.0-17_openblas.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "liblapack-3.8.0-17_openblas.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libwebp-1.2.1-h28dabe5_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libwebp-base-1.2.1-h0d85af4_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libxslt-1.1.33-h5739fc3_2.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "nspr-4.32-hcd9eead_1.tar.bz2": {
+      "license_family": "MOZILLA"
+    },
+    "nss-3.69-h31e2bf1_1.tar.bz2": {
+      "license_family": "MOZILLA"
+    },
+    "numpy-base-1.20.3-py38hbbe2e76_0.tar.bz2": {
+      "constrains": [
+        "numpy 1.20.3 py38h0fa1045_0"
+      ]
+    },
+    "openblas-0.3.4-hdc02c5d_1000.tar.bz2": {
+      "depends": [
+        "libgfortran >=3.0.1,<4.0.0.a0"
+      ]
+    },
+    "qt-5.12.9-h126340a_4.tar.bz2": {
+      "depends": [
+        "icu >=68.1,<69.0a0",
+        "jpeg >=9d,<10a",
+        "libclang >=11.0.1,<12.0a0",
+        "libcxx >=11.0.1",
+        "libpng >=1.6.37,<1.7.0a0",
+        "libpq >=13.1,<14.0a0",
+        "mysql-libs >=8.0.23,<8.1.0.0a0",
+        "nspr >=4.29,<5.0a0",
+        "nss >=3.47,<4.0a0",
+        "sqlite >=3.34.0,<4.0a0",
+        "zlib >=1.2.11,<1.3.0a0"
+      ],
+      "license_family": "LGPL"
+    },
+    "reproc-14.2.3-h0d85af4_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "reproc-cpp-14.2.3-he49afe7_0.tar.bz2": {
+      "license_family": "MIT"
+    }
+  },
+  "patch_instructions_version": 1,
+  "remove": [],
+  "revoke": []
+}

--- a/patches/win-64/patch_instructions.json
+++ b/patches/win-64/patch_instructions.json
@@ -1,0 +1,81 @@
+{
+  "packages": {
+    "blosc-1.21.0-h0e60522_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "conda-build-3.21.7-py38haa95532_1.tar.bz2": {
+      "depends": [
+        "beautifulsoup4",
+        "chardet",
+        "conda >=4.5",
+        "conda-package-handling >=1.3",
+        "filelock",
+        "glob2 >=0.6",
+        "jinja2 <3.0.0a0",
+        "pkginfo",
+        "psutil",
+        "py-lief",
+        "python >=3.8,<3.9.0a0",
+        "python-libarchive-c",
+        "pytz",
+        "pyyaml",
+        "requests",
+        "setuptools",
+        "six",
+        "tqdm"
+      ]
+    },
+    "git-2.34.1-haa95532_0.tar.bz2": {
+      "namespace": "global"
+    },
+    "icu-68.2-h0e60522_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "libblas-3.9.0-12_win64_mkl.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libcblas-3.9.0-12_win64_mkl.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "liblapack-3.9.0-12_win64_mkl.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libwebp-1.2.1-h57928b3_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libwebp-base-1.2.1-h8ffe710_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "mkl_random-1.2.2-py38hf11a4ad_0.tar.bz2": {
+      "depends": [
+        "mkl >=2021.2.0,<2022.0a0",
+        "mkl-service >=2.3.0,<3.0a0",
+        "numpy >=1.16,<2.0a0",
+        "python >=3.8,<3.9.0a0",
+        "vc >=14.1,<15.0a0",
+        "vs2015_runtime >=14.16.27012,<15.0a0",
+        "blas * mkl"
+      ]
+    },
+    "numpy-base-1.20.3-py38hc2deb75_0.tar.bz2": {
+      "constrains": [
+        "numpy 1.20.3 py38ha4e8547_0"
+      ]
+    },
+    "qt-5.12.9-h5909a2a_4.tar.bz2": {
+      "license_family": "LGPL"
+    },
+    "reproc-14.2.3-h8ffe710_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "reproc-cpp-14.2.3-h0e60522_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "tbb-2021.5.0-h2d74725_0.tar.bz2": {
+      "license_family": "APACHE"
+    }
+  },
+  "patch_instructions_version": 1,
+  "remove": [],
+  "revoke": []
+}


### PR DESCRIPTION
This PR adds one `patch_instructions.json` file for each platform, which reflects what is currently on `ska3-conda/flight`.

We need to deal with package patches, there is no way around it. We have a few options:
- version control the final `patch_instructions.json` files (what this PR is about)
- have a python script to generate `patch_instructions.json` files ([what Anaconda does](https://github.com/AnacondaRecipes/repodata-hotfixes/))
- Modify the package themselves ([what we first tried](https://github.com/ContinuumIO/anaconda-issues/issues/11920))

The approach I took in producing the 2022.2 release was to run a workflow to:
- assemble a valid environment (using the `install_from_scratch.py` script in each metapackage),
- store a file with package metadata, including URL, as an artifact,
- fetche patch instructions from all upstream repositories,
- combine patch instructions for downloaded packages in a collection of json files (one per platform),
- store the patch instructions as an artifact,
- combine the package mata-data files (one per platform per package) into one `meta.yaml` per package, with the proper platform-dependent keywords.
- store the `meta.yaml` files as artifacts.

Because this is the first time I followed this process, the resulting patch instructions are what is included in this PR.

In future updates, if we need to update the patch instructions, it is necessary to add them to the repository. This can be done using the `-p` or `--patch-generator` option of conda index:

```
tar cf bundle.tar.bz2 -C ./temp .
conda index -p bundle.tar.bz2 www/ASPECT/ska3-conda/test
```

This should make the following two scripts obsolete, and I would remove both:
- [upload_packages.py](https://github.com/sot/skare3/blob/master/upload_packages.py)
- [fix_repodata.py](https://github.com/sot/skare3/blob/master/fix_repodata.py), already deprecated after Tom made `upload_packages.py`