### PR TITLE
2022.4

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -15,22 +15,22 @@ requirements:
     - acis_taco ==4.2.1
     - acis_thermal_check ==4.2.0
     - acispy ==2.4.0
-    - agasc ==4.11.5
+    - agasc ==4.11.7
     - annie ==0.11.1
     - backstop_history ==1.5.3
     - chandra.cmd_states ==3.17.0
     - chandra.maneuver ==3.8.0
-    - chandra.time ==4.0.0
+    - chandra.time ==4.0.1
     - chandra_aca ==4.34.3
     - cxotime ==3.3.0
     - find_attitude ==3.4.2
     - hopper ==4.5.2
     - jobwatch ==0.7.0
-    - kadi ==5.9.1
+    - kadi ==5.10.0
     - maude ==3.9.0
     - mica ==4.28.0
-    - parse_cm ==3.8.0
-    - perigee_health_plots ==0.2.1
+    - parse_cm ==3.9.0
+    - perigee_health_plots ==0.3.0
     - proseco ==5.5.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.0
@@ -47,15 +47,15 @@ requirements:
     - ska.quatutil ==3.4.0
     - ska.report_ranges ==0.4.0
     - ska.shell ==3.5.0
-    - ska.sun ==3.8.0
+    - ska.sun ==3.8.1
     - ska.tdb ==3.6.0
     - ska3-core ==2022.3
     - ska3-template ==2019.09.03
     - ska_helpers ==0.5.0
     - ska_path ==3.1.2
     - ska_sync ==4.10.0
-    - skare3_tools ==1.0.5
+    - skare3_tools ==1.0.6
     - sparkles ==4.16.0
     - starcheck ==13.15.1
-    - testr ==4.8.0
-    - xija ==4.25.0
+    - testr ==4.9.0
+    - xija ==4.26.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2022.3
+  version: 2022.4
 
 build:
   noarch: generic


### PR DESCRIPTION
# ska3-flight 2022.4

This PR includes:
- An update to the kadi Chandra Commands Archive V2 to include the star catalog command times (useful as a star catalog reference time).  Work on this update also resulted in a new system of caching for star catalog data.
- An update to xija to support earthshine for future ACIS FP models.
- An update to parse_cm to support writing "backstop" lines to a file-like object.  This small change will be an interface help for ORViewer integration.
- Minor bugfixes and doc and testing improvements.

## Interface Impacts:
- The update to kadi commands does change the star catalog command date to be the new "reference" date for star catalogs.  The commands archive files (cmds2.h5, cmds2.pkl) will be updated as part of promotion and will be sync'd by users following the usual sync process.

## Testing:

- [2022.4rc1-HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.4rc1-HEAD). Ska.tdb shows a failure due to a deprecation warning. This is harmless.
- [2022.4rc1-GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.4rc1-GRETA). Ska.quatutil test failed because it requires access to Github, which is not enabled from GRETA. This test should have been skipped in this case.

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2022.4rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2022.4rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2022.4 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes
## ska3-flight changes (2022.3 -> 2022.4rc1)
### Updated Packages

- **agasc:** 4.11.5 -> 4.11.7 (4.11.5 -> 4.11.6 -> 4.11.7)
  - [PR 136](https://github.com/sot/agasc/pull/136) (javierggt): fix breakage due to kadi 5.9.1 changing dtypes
  - [PR 133](https://github.com/sot/agasc/pull/133) (javierggt): Fix matplotlib ticks warning
- **chandra.time:** 4.0.0 -> 4.0.1 (4.0.0 -> 4.0.1)
  - [PR 53](https://github.com/sot/Chandra.Time/pull/53) (taldcroft): Allow bytes input to date2secs
- **kadi:** 5.9.1 -> 5.10.0 (5.9.1 -> 5.9.2 -> 5.10.0)
  - [PR 219](https://github.com/sot/kadi/pull/219) (taldcroft): Update homepage URL
  - [PR 224](https://github.com/sot/kadi/pull/224) (taldcroft): Allow outputting all keys in reduce_states
  - [PR 229](https://github.com/sot/kadi/pull/229) (taldcroft): Remake last two years of MajorEvent table each time
  - [PR 221](https://github.com/sot/kadi/pull/221) (taldcroft): _Add starcat_date to observation parameters_ + fix caching and minor issues
- **parse_cm:** 3.8.0 -> 3.9.0 (3.8.0 -> 3.9.0)
  - [PR 37](https://github.com/sot/parse_cm/pull/37) (jjay): _Give write_backstop function the ability to output to a file-like object_
- **perigee_health_plots:** 0.2.1 -> 0.3.0 (0.2.1 -> 0.3.0)
  - [PR 21](https://github.com/sot/perigee_health_plots/pull/21) (jeanconn): Use chandra_models for planning limit
- **ska.sun:** 3.8.0 -> 3.8.1 (3.8.0 -> 3.8.1)
  - [PR 21](https://github.com/sot/Ska.Sun/pull/21) (taldcroft): Fix mistake in docs and update module tagline
- **skare3_tools:** 1.0.5 -> 1.0.6 (1.0.5 -> 1.0.6)
  - [PR 85](https://github.com/sot/skare3_tools/pull/85) (javierggt): Fix: Enable releases with closed PRs
  - [PR 84](https://github.com/sot/skare3_tools/pull/84) (javierggt): change conda channels in default config to what they should be
- **testr:** 4.8.0 -> 4.9.0 (4.8.0 -> 4.9.0)
  - [PR 42](https://github.com/sot/testr/pull/42) (javierggt): Extirpate Ska.Shell
- **xija:** 4.25.0 -> 4.26.0 (4.25.0 -> 4.26.0)
  - [PR 119](https://github.com/sot/xija/pull/119) (mdahmer): Fix epoch interpolation bug, wrong function name for interpolation
  - [PR 117](https://github.com/sot/xija/pull/117) (jzuhone): _Adjust earthshine effect based on Earth phase_

# Related Issues

Fixes #823
Fixes #825
Fixes #826
Fixes #827
Fixes #828
Fixes #830
Fixes #833
Fixes #835
Fixes #836
