### PR TITLE
Bugfix: Use gxx, not gcc, when building chandra.time.

### DIFF
--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -14,7 +14,7 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - gcc_linux-64==8.4.0 # [linux]
+    - gxx_linux-64==8.4.0 # [linux]
     - libgcc-ng==9.1.0  # [linux]
     - clangxx_osx-64 # [osx]
     - python==3.8.10


### PR DESCRIPTION
Use gxx, not gcc, when building chandra.time. With this change now the build succeeds.

Fixes #821