### PR TITLE
2022.6

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2022.3
+  version: 2022.6
 
 requirements:
   run:
@@ -29,7 +29,7 @@ requirements:
     - backports.zoneinfo ==0.2.1
     - bcrypt ==3.2.0
     - beautifulsoup4 ==4.10.0
-    - black ==19.10b0
+    - black ==22.3.0
     - blas ==1.0  # [win]
     - blas ==1.1  # [linux or osx]
     - bleach ==4.1.0
@@ -60,6 +60,7 @@ requirements:
     - cryptography ==36.0.0
     - cycler ==0.11.0
     - cython ==0.29.25
+    - dataclasses ==0.8
     - dbus ==1.13.18  # [linux or osx]
     - debugpy ==1.5.1
     - decorator ==5.1.0
@@ -254,7 +255,7 @@ requirements:
     - paramiko ==2.8.1
     - parso ==0.8.3
     - patchelf ==0.14.3  # [linux]
-    - pathspec ==0.7.0
+    - pathspec ==0.9.0
     - pcre ==8.45  # [linux or osx]
     - pexpect ==4.8.0
     - pickleshare ==0.7.5

--- a/pkg_defs/ska3-flight-latest/meta.yaml
+++ b/pkg_defs/ska3-flight-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight-latest
-  version: 2022.2
+  version: 2022.6
 
 build:
   noarch: generic
@@ -17,6 +17,7 @@ requirements:
     - acis_thermal_check
     - acispy
     - agasc
+    - aimpoint_mon
     - annie
     - backstop_history
     - chandra_aca

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - acis_thermal_check ==4.3.1
     - acispy ==2.4.0
     - agasc ==4.12.0
+    - aimpoint_mon ==1.0.1
     - annie ==0.11.1
     - backstop_history ==1.5.3
     - chandra.cmd_states ==3.17.0
@@ -26,7 +27,7 @@ requirements:
     - find_attitude ==3.4.2
     - fot-matlab ==2.0.0
     - hopper ==4.5.2
-    - jobwatch ==0.7.0
+    - jobwatch ==0.8.0
     - kadi ==5.11.0
     - maude ==3.9.0
     - mica ==4.29.0
@@ -39,7 +40,7 @@ requirements:
     - ska.arc5gl ==3.2.0
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.55.2
+    - ska.engarchive ==4.55.3
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.14.1
@@ -47,11 +48,11 @@ requirements:
     - ska.parsecm ==3.4.0
     - ska.quatutil ==3.4.0
     - ska.report_ranges ==0.4.0
-    - ska.shell ==3.5.0
+    - ska.shell ==3.5.1
     - ska.sun ==3.8.1
     - ska.tdb ==3.6.0
     - ska3-core ==2022.6
-    - ska3-template ==2019.09.03
+    - ska3-template ==2022.06.02
     - ska_helpers ==0.5.0
     - ska_path ==3.1.2
     - ska_sync ==4.10.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - ska.report_ranges ==0.4.0
     - ska.shell ==3.5.1
     - ska.sun ==3.8.1
-    - ska.tdb ==3.6.0
+    - ska.tdb ==3.6.1
     - ska3-core ==2022.6
     - ska3-template ==2022.06.02
     - ska_helpers ==0.5.0
@@ -59,5 +59,5 @@ requirements:
     - skare3_tools ==1.0.6
     - sparkles ==4.18.0
     - starcheck ==13.15.1
-    - testr ==4.10.0
+    - testr ==4.11.0
     - xija ==4.26.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2022.4
+  version: 2022.6
 
 build:
   noarch: generic
@@ -15,30 +15,31 @@ requirements:
     - acis_taco ==4.2.1
     - acis_thermal_check ==4.2.0
     - acispy ==2.4.0
-    - agasc ==4.11.7
+    - agasc ==4.12.0
     - annie ==0.11.1
     - backstop_history ==1.5.3
     - chandra.cmd_states ==3.17.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.1
-    - chandra_aca ==4.34.3
+    - chandra_aca ==4.35.0
     - cxotime ==3.3.0
     - find_attitude ==3.4.2
+    - fot-matlab ==2.0.0
     - hopper ==4.5.2
     - jobwatch ==0.7.0
-    - kadi ==5.10.0
+    - kadi ==5.11.0
     - maude ==3.9.0
-    - mica ==4.28.0
+    - mica ==4.29.0
     - parse_cm ==3.9.0
     - perigee_health_plots ==0.3.0
-    - proseco ==5.5.0
+    - proseco ==5.6.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.0
     - ska-sphinx-theme ==1.3.0
     - ska.arc5gl ==3.2.0
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.55.1
+    - ska.engarchive ==4.55.2
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.14.1
@@ -55,7 +56,7 @@ requirements:
     - ska_path ==3.1.2
     - ska_sync ==4.10.0
     - skare3_tools ==1.0.6
-    - sparkles ==4.16.0
+    - sparkles ==4.17.0
     - starcheck ==13.15.1
-    - testr ==4.9.0
-    - xija ==4.26.0
+    - testr ==4.10.0
+    - xija ==4.26.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - pyyaks ==4.5.0
     - quaternion ==4.1.0
     - ska-sphinx-theme ==1.3.0
-    - ska.arc5gl ==3.2.0
+    - ska.arc5gl ==3.3.0
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
     - ska.engarchive ==4.55.3

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -57,7 +57,7 @@ requirements:
     - ska_path ==3.1.2
     - ska_sync ==4.10.0
     - skare3_tools ==1.0.6
-    - sparkles ==4.17.0
+    - sparkles ==4.18.0
     - starcheck ==13.15.1
     - testr ==4.10.0
     - xija ==4.26.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.8.0
     - acis_taco ==4.2.1
-    - acis_thermal_check ==4.2.0
+    - acis_thermal_check ==4.3.1
     - acispy ==2.4.0
     - agasc ==4.12.0
     - annie ==0.11.1
@@ -30,7 +30,7 @@ requirements:
     - kadi ==5.11.0
     - maude ==3.9.0
     - mica ==4.29.0
-    - parse_cm ==3.9.0
+    - parse_cm ==3.9.1
     - perigee_health_plots ==0.3.0
     - proseco ==5.6.0
     - pyyaks ==4.5.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - ska.shell ==3.5.0
     - ska.sun ==3.8.1
     - ska.tdb ==3.6.0
-    - ska3-core ==2022.3
+    - ska3-core ==2022.6
     - ska3-template ==2019.09.03
     - ska_helpers ==0.5.0
     - ska_path ==3.1.2


### PR DESCRIPTION
# ska3-flight 2022.6

This PR includes:
- acis_thermal_check changes approved in FSDS-36.
- Changes in sparkles and proseco with a modified guide-count calculation for  dynamic background.
- Various fixes for RedHat 8.

The full set of code has also been fully tested on Redhat 8 and at this time we would also like to request approval to use the ska3-flight environment on RHEL8 systems for operational use as those systems become available.

## Interface Impacts:

None

## Testing:

The latest release candidate (2022.6rc3) is installed in `/proj/sot/ska3/test` on HEAD and GRETA, and is available for testing from the usual channels:
```
conda create -n ska3-flight-2022.6rc3 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2022.6rc3
```

### Test results

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt
- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.6-HEAD).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.6-GRETA).

Release candidate tests:
- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.6rc3/).
- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.6rc3-HEAD).
- [HEAD CentOS 7](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.6rc3-HEAD-kady).
- [HEAD CentOS 7 acisfp-check](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.6rc3-HEAD-kady-acisfp_check).
- [HEAD RH8](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.6rc3-HEAD-owen-v).
- [HEAD RH8 acisfp-check](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.6rc3-HEAD-owen-v-acisfp_check).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.6rc3-GRETA).

**Additional Functional Tests**:

**Starcheck**
Starcheck has no unit tests.  A simple single-load regress diff confirms that the only difference between the flight output and the test output run on RHEL8 is the location of the starcheck data (in the test directory in the test).
```
jeanconn-owen-v> diff -u jun0622a_flight.txt jun0622a_rhel_test.txt
--- jun0622a_flight.txt	2022-06-03 12:54:30.494613260 -0400
+++ jun0622a_rhel_test.txt	2022-06-03 12:56:09.810119000 -0400
@@ -1,18 +1,18 @@
  ------------  Starcheck 13.15.1    -----------------
- Run on Fri Jun  3 12:54:28 EDT 2022 by jeanconn from fido.cfa.harvard.edu
- Configuration:  Using AGASC at /proj/sot/ska3/flight/data/agasc/proseco_agasc_1p7.h5
+ Run on Fri Jun  3 12:54:10 EDT 2022 by jeanconn from owen-v.cfa.harvard.edu
+ Configuration:  Using AGASC at /proj/sot/ska3/test/data/agasc/proseco_agasc_1p7.h5
  chandra_models version: 3.40
 
 Short Term Schedule: JUN0622A
 
 ------------  PROCESSING FILES  -----------------
 
-DATA = /proj/sot/ska3/flight/lib/python3.8/site-packages/starcheck/data
+DATA = /proj/sot/ska3/test/lib/python3.8/site-packages/starcheck/data
 Using DOT file /data/mpcrit1/mplogs/2022/JUN0622/oflsa//mps/mdJUN0622A.dot
 Using OR file /data/mpcrit1/mplogs/2022/JUN0622/oflsa//mps/or/JUN0622_A.or
 Using TLR file /data/mpcrit1/mplogs/2022/JUN0622/oflsa//CR157_0903.tlr
 Using acq_star_rdb file ${DATA}/bad_acq_stars.rdb
-Using agasc_file file /proj/sot/ska3/flight/data/agasc/proseco_agasc_1p7.h5
+Using agasc_file file /proj/sot/ska3/test/data/agasc/proseco_agasc_1p7.h5
 Using aimpoint file /data/mpcrit1/mplogs/2022/JUN0622/oflsa//output/JUN0622A_dynamical_offsets.txt
 Using attitude file /data/mpcrit1/mplogs/2022/JUN0622/oflsa//History/ATTITUDE.txt
 Using backstop file /data/mpcrit1/mplogs/2022/JUN0622/oflsa//CR157_0903.backstop
```
**task_schedule**
The task_schedule internal tests were run on RHEL8 and showed expected results, so our processing/cron jobs can be run on RHEL8 systems as those systems become available.

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2022.6 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket and at a time outside of the load review cycle.

# Code changes

## ska3-flight changes (2022.4 -> 2022.6rc3)

### New Packages
- **aimpoint_mon: 1.0.1**
- **fot-matlab: 2.0.0**

### Updated Packages

- **acis_thermal_check:** 4.2.0 -> 4.3.1 (4.2.0 -> 4.3.0 -> 4.3.1)
  - [PR 50](https://github.com/acisops/acis_thermal_check/pull/50) (jzuhone): Check and plot  the ACIS FP safety planning limit, support the new ACIS FP model
  - [PR 51](https://github.com/acisops/acis_thermal_check/pull/51) (jzuhone): Update test answers post-xija 4.26.1
- **agasc:** 4.11.7 -> 4.12.0 (4.11.7 -> 4.12.0)
  - [PR 132](https://github.com/sot/agasc/pull/132) (javierggt): Do not count non-npm times when calculating f_ok
- **chandra_aca:** 4.34.3 -> 4.35.0 (4.34.3 -> 4.35.0)
  - [PR 124](https://github.com/sot/chandra_aca/pull/124) (taldcroft): Allow for broadcastable array inputs in snr_mag_for_t_ccd and guide_count
- **jobwatch:** 0.7.0 -> 0.8.0 (0.7.0 -> 0.8.0)
  - [PR 55](https://github.com/sot/jobwatch/pull/55) (jeanconn): Use new solar wind png instead of old gif
- **kadi:** 5.10.0 -> 5.11.0 (5.10.0 -> 5.11.0)
  - [PR 232](https://github.com/sot/kadi/pull/232) (taldcroft): Allow OCCweb access using noodle path
  - [PR 233](https://github.com/sot/kadi/pull/233) (taldcroft): Fix lucky testing and occweb lucky functionality
- **mica:** 4.28.0 -> 4.29.0 (4.28.0 -> 4.29.0)
  - [PR 270](https://github.com/sot/mica/pull/270) (jeanconn): Update ocat target table first in cron task
  - [PR 271](https://github.com/sot/mica/pull/271) (jeanconn): Use CxoTime and fix time range for update
  - [PR 269](https://github.com/sot/mica/pull/269) (javierggt): Remove use of Ska.Shell
  - [PR 272](https://github.com/sot/mica/pull/272) (taldcroft): Improve speed  of getting local OCAT data
- **parse_cm:** 3.9.0 -> 3.9.1 (3.9.0 -> 3.9.1)
  - [PR 38](https://github.com/sot/parse_cm/pull/38) (taldcroft): Fix flake8 issues
- **proseco:** 5.5.0 -> 5.6.0 (5.5.0 -> 5.6.0)
  - [PR 372](https://github.com/sot/proseco/pull/372) (taldcroft): _Allow bonus faint guide stars for dyn bgd enabled_
- **ska.arc5gl:** 3.2.0 -> 3.3.0 (3.2.0 -> 3.3.0)
  - [PR 13](https://github.com/sot/Ska.arc5gl/pull/13) (jeanconn): Use arc5gl in ska3
- **ska.engarchive:** 4.55.1 -> 4.55.3 (4.55.1 -> 4.55.2 -> 4.55.3)
  - [PR 230](https://github.com/sot/eng_archive/pull/230) (taldcroft): Fix test failure from updated MUPS model
  - [PR 231](https://github.com/sot/eng_archive/pull/231) (taldcroft): Try fixing the sporadic derived params aliases failure
- **ska.shell:** 3.5.0 -> 3.5.1 (3.5.0 -> 3.5.1)
  - [PR 26](https://github.com/sot/Ska.Shell/pull/26) (javierggt): Fix for RedHat 8 (env vars that are functions)
- **ska.tdb:** 3.6.0 -> 3.6.1 (3.6.0 ->  -> 3.6.1)
  - [PR 17](https://github.com/sot/Ska.tdb/pull/17) (javierggt): convert docs to numpydoc
- **ska3-core:** 2022.3 -> 2022.6rc3
- **ska3-template:** 2019.09.03 -> 2022.06.02
   - The updates in the template include changes to the production environment:
      - remove SKA/lib from LD_LIBRARY_PATH (no longer needed by our applications and removing it removes runtime library conflicts with OTS applications)
      - Update default ASCDS release used by Perl code to be the current ASCDS release (overrides logic to default to older DS releases on certain older systems)
      -  Move to use of arc5gl with modern perl in ska3 instead of the old ska2 5.8.9 Perl.     
- **sparkles:** 4.16.0 -> 4.18.0 (4.16.0 -> 4.17.0 -> 4.18.0)
  - [PR 171](https://github.com/sot/sparkles/pull/171) (taldcroft): Allow opening a pickle from Noodle/OCCweb
  - [PR 172](https://github.com/sot/sparkles/pull/172) (taldcroft): _Apply dyn bgd bonus in computing guide_count_
  - [PR 170](https://github.com/sot/sparkles/pull/170) (jeanconn): _Move yoshi into sparkles and add some OCAT convenience_
  - [PR 173](https://github.com/sot/sparkles/pull/173) (taldcroft): Tweaks to sparkles / yoshi based on cycle 24 work
- **testr:** 4.9.0 -> 4.11.0 (4.9.0 -> 4.10.0 -> 4.11.0)
  - [PR 43](https://github.com/sot/testr/pull/43) (taldcroft): Add Coverage
  - [PR 44](https://github.com/sot/testr/pull/44) (jeanconn): Add 185 subnet (owen-v) for on_head_network
- **xija:** 4.26.0 -> 4.26.1 (4.26.0 -> 4.26.1)
  - [PR 121](https://github.com/sot/xija/pull/121) (jkrist): _Updated 'Hack' to only overwrite final prediction mvals instead of all mvals + PEP8_
 
## ska3-core changes (2022.3 -> 2022.6rc3)

### New Packages
- **dataclasses: 0.8**

### Updated Packages

- **black:** 19.10b0 -> 22.3.0
- **pathspec:** 0.7.0 -> 0.9.0

# Related Issues

Fixes #839
Fixes #858
Fixes #859
Fixes #861
Fixes #862
Fixes #863
Fixes #865
Fixes #866
Fixes #867
Fixes #868
Fixes #869
Fixes #870
Fixes #871
