### PR TITLE
2022.7

### DIFF
--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -12,6 +12,7 @@ requirements:
    - backports.zoneinfo
    - beautifulsoup4
    - bokeh
+   - black
    - cloudpickle # [win]
    - conda
    - conda-build

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - ska.report_ranges ==0.4.0
     - ska.shell ==3.5.1
     - ska.sun ==3.8.1
-    - ska.tdb ==3.6.2
+    - ska.tdb ==3.6.1
     - ska3-core ==2022.6
     - ska3-template ==2022.06.02
     - ska_helpers ==0.5.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -28,9 +28,9 @@ requirements:
     - fot-matlab ==2.0.1
     - hopper ==4.5.2
     - jobwatch ==0.8.0
-    - kadi ==6.0.0
+    - kadi ==6.0.1
     - maude ==3.9.0
-    - mica ==4.30.0
+    - mica ==4.30.1
     - parse_cm ==3.9.1
     - perigee_health_plots ==0.3.0
     - proseco ==5.7.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -27,9 +27,9 @@ requirements:
     - find_attitude ==3.4.2
     - fot-matlab ==2.0.1
     - hopper ==4.5.2
-    - jobwatch ==0.8.0
+    - jobwatch ==0.9.0
     - kadi ==6.0.1
-    - maude ==3.9.0
+    - maude ==3.10.0
     - mica ==4.30.1
     - parse_cm ==3.9.1
     - perigee_health_plots ==0.3.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2022.6
+  version: 2022.7
 
 build:
   noarch: generic
@@ -15,7 +15,7 @@ requirements:
     - acis_taco ==4.2.1
     - acis_thermal_check ==4.3.1
     - acispy ==2.4.0
-    - agasc ==4.12.0
+    - agasc ==4.12.1
     - aimpoint_mon ==1.0.1
     - annie ==0.11.1
     - backstop_history ==1.5.3
@@ -25,22 +25,22 @@ requirements:
     - chandra_aca ==4.35.0
     - cxotime ==3.3.0
     - find_attitude ==3.4.2
-    - fot-matlab ==2.0.0
+    - fot-matlab ==2.0.1
     - hopper ==4.5.2
     - jobwatch ==0.8.0
-    - kadi ==5.11.0
+    - kadi ==6.0.0
     - maude ==3.9.0
-    - mica ==4.29.0
+    - mica ==4.30.0
     - parse_cm ==3.9.1
     - perigee_health_plots ==0.3.0
-    - proseco ==5.6.0
+    - proseco ==5.7.0
     - pyyaks ==4.5.0
-    - quaternion ==4.1.0
+    - quaternion ==4.1.1
     - ska-sphinx-theme ==1.3.0
     - ska.arc5gl ==3.3.0
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.55.3
+    - ska.engarchive ==4.56.0
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.14.1
@@ -50,14 +50,14 @@ requirements:
     - ska.report_ranges ==0.4.0
     - ska.shell ==3.5.1
     - ska.sun ==3.8.1
-    - ska.tdb ==3.6.1
+    - ska.tdb ==3.6.2
     - ska3-core ==2022.6
     - ska3-template ==2022.06.02
     - ska_helpers ==0.5.0
     - ska_path ==3.1.2
     - ska_sync ==4.10.0
     - skare3_tools ==1.0.6
-    - sparkles ==4.18.0
+    - sparkles ==4.19.0
     - starcheck ==13.15.1
     - testr ==4.11.0
     - xija ==4.26.1


### PR DESCRIPTION
# ska3-flight 2022.7

In addition to the code changes shown later, this PR includes the following highlights:

- sparkles:
  - When adding a temperature delta for the dynamic background bonus, require that at least 3 stars are so-called "anchor stars" with no bonus applied
  - Move the _bright_ count mag limit from 6.1 to 5.5, in agreement with the star selection move from 5.8 to 5.2.
- maude package now allows STAT_ msids, which correspond to MAUDE's "Aggregate MSID Statistics".
- cheta now can return Quat-valued computed MSIDs for quaternion MSID sets (AOATTQT#, AOATUPQ#, AOCMDQT#, AOTARQT#)
- The web server functionality in the kadi was removed.

## Interface Impacts:

This version of kadi removes the django functionality that underlies the current kadi web server. This functionality is being moved to a new package that is not part of ska3-flight. The corresponding changes on the kadi web server have been made and are being tested. *There are no expected kadi user interface changes for accessing kadi events and commands via Python scripts*. An FSDS ticket for the kadi web server update will follow this ska3-flight update.

## Testing:

- [HEAD tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.7rc4-HEAD). Tests on HEAD were done on RH8 (luke8-v).
- [GRETA tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.7rc4-GRETA).



skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates is installed in `/proj/sot/ska3/test` on HEAD and GRETA, and all release candidates are available for testing from the usual channels:
```
conda create -n ska3-flight-2022.7rc4 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2022.7rc4
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2022.7 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-flight changes (2022.6 -> 2022.7rc4)

### Updated Packages

- **agasc:** 4.12.0 -> 4.12.1 (4.12.0 -> 4.12.1)
  - [PR 138](https://github.com/sot/agasc/pull/138) (javierggt): Fix script help
- **fot-matlab:** 2.0.0 -> 2.0.1 (2.0.0 -> 1.0.0 -> 2.0.1)
  - [PR 10](https://github.com/sot/fot-matlab/pull/10) (jskrist): Matlab 11834
  - [PR 11](https://github.com/sot/fot-matlab/pull/11) (jskrist): Create kadi_utils.py
  - [PR 12](https://github.com/sot/fot-matlab/pull/12) (jskrist): fixed PEP8 syntax violations
  - [PR 13](https://github.com/sot/fot-matlab/pull/13) (jskrist): Updated np.array() call to include explicit dtype argument
  - [PR 14](https://github.com/sot/fot-matlab/pull/14) (jskrist): Acis fp sun eph support
  - [PR 15](https://github.com/sot/fot-matlab/pull/15) (jskrist): forced all state times to be dtype=float64.
- **jobwatch:** 0.8.0 -> 0.9.0 (0.8.0 -> 0.9.0)
  - [PR 56](https://github.com/sot/jobwatch/pull/56) (jeanconn): Remove astromon checking
- **kadi:** 5.11.0 -> 6.0.1 (5.11.0 -> 6.0.0 -> 6.0.1)
  - [PR 237](https://github.com/sot/kadi/pull/237) (taldcroft): Fix various doc issues
  - [PR 240](https://github.com/sot/kadi/pull/240) (taldcroft): Better exception message in get_states for too-early start arg
  - [PR 234](https://github.com/sot/kadi/pull/234) (taldcroft): Add instructions on creating .netrc
  - [PR 231](https://github.com/sot/kadi/pull/231) (taldcroft): Web-free kadi
  - [PR 241](https://github.com/sot/kadi/pull/241) (javierggt): add starcat_date argument to get_observations, get_starcats and get_s…
  - [PR 243](https://github.com/sot/kadi/pull/243) (taldcroft): Add EventQuery to symbols exported from query.py by events/__init__.py
- **maude:** 3.9.0 -> 3.10.0 (3.9.0 -> 3.10.0)
  - [PR 15](https://github.com/sot/maude/pull/15) (jeanconn): Allow STAT_ msids
- **mica:** 4.29.0 -> 4.30.1 (4.29.0 -> 4.30.0 -> 4.30.1)
  - [PR 273](https://github.com/sot/mica/pull/273) (javierggt): Added vectorized versions of some archive.dark_cal functions
  - [PR 274](https://github.com/sot/mica/pull/274) (javierggt): Fix issue in vectorized get_dark_cal_id
- **proseco:** 5.6.0 -> 5.7.0 (5.6.0 -> 5.7.0)
  - [PR 373](https://github.com/sot/proseco/pull/373) (jeanconn): Add man_angle_next kwarg / attribute
- **quaternion:** 4.1.0 -> 4.1.1 (4.1.0 -> 4.1.1)
  - [PR 40](https://github.com/sot/Quaternion/pull/40) (taldcroft): Improve normalize() function to handle bad input
- **ska.engarchive:** 4.55.3 -> 4.56.0 (4.55.3 -> 4.56.0)
  - [PR 233](https://github.com/sot/eng_archive/pull/233) (taldcroft): Add computed MSID to return Quat for quaternion MSID sets
  - [PR 232](https://github.com/sot/eng_archive/pull/232) (taldcroft): Possibly fix derived param aliases test
- **sparkles:** 4.18.0 -> 4.19.0 (4.18.0 -> 4.19.0)
  - [PR 174](https://github.com/sot/sparkles/pull/174) (taldcroft): Require minimum number of anchor stars for dyn bgd bonus
  - [PR 175](https://github.com/sot/sparkles/pull/175) (jeanconn): Update guide bright count check


# Related Issues

Fixes #765
Fixes #874
Fixes #875
Fixes #876
Fixes #877
Fixes #878
Fixes #879
Fixes #880
Fixes #881
Fixes #882
Fixes #884
Fixes #885
Fixes #886
Fixes #887
Fixes #888