### PR TITLE
2022.8

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2022.5
+  version: 2022.8
 
 build:
   noarch: generic
@@ -13,9 +13,10 @@ requirements:
     - aca_weekly_report ==0.1.5
     - acdc ==4.8.0
     - acis_taco ==4.2.1
-    - acis_thermal_check ==4.2.0
+    - acis_thermal_check ==4.3.1
     - acispy ==2.4.0
-    - agasc ==4.12.0
+    - agasc ==4.12.1
+    - aimpoint_mon ==1.0.1
     - annie ==0.11.1
     - backstop_history ==1.5.3
     - chandra.cmd_states ==3.17.0
@@ -26,20 +27,20 @@ requirements:
     - find_attitude ==3.4.2
     - fot-matlab ==2.0.1
     - hopper ==4.5.2
-    - jobwatch ==0.7.0
-    - kadi ==5.11.0
-    - maude ==3.9.0
-    - mica ==4.29.0
-    - parse_cm ==3.9.0
+    - jobwatch ==0.9.0
+    - kadi ==6.0.1
+    - maude ==3.10.0
+    - mica ==4.30.1
+    - parse_cm ==3.9.1
     - perigee_health_plots ==0.3.0
-    - proseco ==5.6.0
+    - proseco ==5.7.0
     - pyyaks ==4.5.0
-    - quaternion ==4.1.0
+    - quaternion ==4.1.1
     - ska-sphinx-theme ==1.3.0
-    - ska.arc5gl ==3.2.0
+    - ska.arc5gl ==3.3.0
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.55.2
+    - ska.engarchive ==4.56.0
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.14.1
@@ -47,16 +48,16 @@ requirements:
     - ska.parsecm ==3.4.0
     - ska.quatutil ==3.4.0
     - ska.report_ranges ==0.4.0
-    - ska.shell ==3.5.0
+    - ska.shell ==3.5.1
     - ska.sun ==3.8.1
-    - ska.tdb ==3.6.0
-    - ska3-core ==2022.3
-    - ska3-template ==2019.09.03
+    - ska.tdb ==3.6.1
+    - ska3-core ==2022.6
+    - ska3-template ==2022.06.02
     - ska_helpers ==0.5.0
     - ska_path ==3.1.2
     - ska_sync ==4.10.0
     - skare3_tools ==1.0.6
-    - sparkles ==4.17.0
+    - sparkles ==4.19.0
     - starcheck ==13.15.1
-    - testr ==4.10.0
+    - testr ==4.11.0
     - xija ==4.26.1


### PR DESCRIPTION
# ska3-matlab 2022.8

This ska3-matlab release includes changes in ska3-flight 2022.6 and 2022.7:

- acis_thermal_check changes approved in FSDS-36.
- sparkles:
  - When adding a temperature delta for the dynamic background bonus, require that at least 3 stars are so-called "anchor stars" with no bonus applied
  - Move the _bright_ count mag limit from 6.1 to 5.5, in agreement with the star selection move from 5.8 to 5.2.
  - modified guide-count calculation for  dynamic background.
- proseco
  - modified guide-count calculation for  dynamic background.
- maude package now allows STAT_ msids, which correspond to MAUDE's "Aggregate MSID Statistics".
- cheta now can return Quat-valued computed MSIDs for quaternion MSID sets (AOATTQT#, AOATUPQ#, AOCMDQT#, AOTARQT#)
- The web server functionality in the kadi was removed.
- Fixes for RedHat 8.

## Interface Impacts:

None

## Testing:

- [2022.8rc1](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.8rc1).

The latest release candidates is installed in `/proj/sot/ska3/matlab/test` on GRETA, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2022.8rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2022.8rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2022.8 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2022.5 -> 2022.8rc1)

### New Packages
- **aimpoint_mon: 1.0.1**

### Updated Packages

- **acis_thermal_check:** 4.2.0 -> 4.3.1 (4.2.0 -> 4.3.0 -> 4.3.1)
  - [PR 50](https://github.com/acisops/acis_thermal_check/pull/50) (John ZuHone): Check and plot  the ACIS FP safety planning limit, support the new ACIS FP model
  - [PR 51](https://github.com/acisops/acis_thermal_check/pull/51) (John ZuHone): Update test answers post-xija 4.26.1
- **agasc:** 4.12.0 -> 4.12.1 (4.12.0 -> 4.12.1)
  - [PR 138](https://github.com/sot/agasc/pull/138) (Javier Gonzalez): Fix script help
- **jobwatch:** 0.7.0 -> 0.9.0 (0.7.0 -> 0.8.0 -> 0.9.0)
  - [PR 55](https://github.com/sot/jobwatch/pull/55) (jeanconn): Use new solar wind png instead of old gif
  - [PR 56](https://github.com/sot/jobwatch/pull/56) (jeanconn): Remove astromon checking
- **kadi:** 5.11.0 -> 6.0.1 (5.11.0 -> 6.0.0 -> 6.0.1)
  - [PR 237](https://github.com/sot/kadi/pull/237) (taldcroft): Fix various doc issues
  - [PR 240](https://github.com/sot/kadi/pull/240) (taldcroft): Better exception message in get_states for too-early start arg
  - [PR 234](https://github.com/sot/kadi/pull/234) (taldcroft): Add instructions on creating .netrc
  - [PR 231](https://github.com/sot/kadi/pull/231) (taldcroft): Web-free kadi
  - [PR 241](https://github.com/sot/kadi/pull/241) (javierggt): add starcat_date argument to get_observations, get_starcats and get_s…
  - [PR 243](https://github.com/sot/kadi/pull/243) (taldcroft): Add EventQuery to symbols exported from query.py by events/__init__.py
- **maude:** 3.9.0 -> 3.10.0 (3.9.0 -> 3.10.0)
  - [PR 15](https://github.com/sot/maude/pull/15) (Jean Connelly): Allow STAT_ msids
- **mica:** 4.29.0 -> 4.30.1 (4.29.0 -> 4.30.0 -> 4.30.1)
  - [PR 273](https://github.com/sot/mica/pull/273) (javierggt): Added vectorized versions of some archive.dark_cal functions
  - [PR 274](https://github.com/sot/mica/pull/274) (javierggt): Fix issue in vectorized get_dark_cal_id
- **parse_cm:** 3.9.0 -> 3.9.1 (3.9.0 -> 3.9.1)
  - [PR 38](https://github.com/sot/parse_cm/pull/38) (Tom Aldcroft): Fix flake8 issues
- **proseco:** 5.6.0 -> 5.7.0 (5.6.0 -> 5.7.0)
  - [PR 373](https://github.com/sot/proseco/pull/373) (taldcroft): Add man_angle_next kwarg / attribute
- **quaternion:** 4.1.0 -> 4.1.1 (4.1.0 -> 4.1.1)
  - [PR 40](https://github.com/sot/Quaternion/pull/40) (Tom Aldcroft): Improve normalize() function to handle bad input
- **ska.arc5gl:** 3.2.0 -> 3.3.0 (3.2.0 -> 3.3.0)
  - [PR 13](https://github.com/sot/Ska.arc5gl/pull/13) (Jean Connelly): Use arc5gl in ska3
- **ska.engarchive:** 4.55.2 -> 4.56.0 (4.55.2 -> 4.55.3 -> 4.56.0)
  - [PR 231](https://github.com/sot/eng_archive/pull/231) (taldcroft): Try fixing the sporadic derived params aliases failure
  - [PR 233](https://github.com/sot/eng_archive/pull/233) (taldcroft): Add computed MSID to return Quat for quaternion MSID sets
  - [PR 232](https://github.com/sot/eng_archive/pull/232) (taldcroft): Possibly fix derived param aliases test
- **ska.shell:** 3.5.0 -> 3.5.1 (3.5.0 -> 3.5.1)
  - [PR 26](https://github.com/sot/Ska.Shell/pull/26) (Javier Gonzalez): Fix for RedHat 8 (env vars that are functions)
- **ska.tdb:** 3.6.0 -> 3.6.1 (3.6.0 -> 3.6.1)
  - [PR 17](https://github.com/sot/Ska.tdb/pull/17) (Javier Gonzalez): convert docs to numpydoc
- **ska3-core:** 2022.3 -> 2022.6
- **ska3-template:** 2019.09.03 -> 2022.06.02
- **sparkles:** 4.17.0 -> 4.19.0 (4.17.0 -> 4.18.0 -> 4.19.0)
  - [PR 170](https://github.com/sot/sparkles/pull/170) (Jean Connelly): Move yoshi into sparkles and add some OCAT convenience
  - [PR 173](https://github.com/sot/sparkles/pull/173) (Tom Aldcroft): Tweaks to sparkles / yoshi based on cycle 24 work
  - [PR 174](https://github.com/sot/sparkles/pull/174) (Tom Aldcroft): Require minimum number of anchor stars for dyn bgd bonus
  - [PR 175](https://github.com/sot/sparkles/pull/175) (Jean Connelly): Update guide bright count check
- **testr:** 4.10.0 -> 4.11.0 (4.10.0 -> 4.11.0)
  - [PR 44](https://github.com/sot/testr/pull/44) (Jean Connelly): Add 185 subnet for on_head_network

# Related Issues

# Fixes #902 