### PR TITLE
Include ska3-matlab in output of ska_version when appropriate

### DIFF
--- a/pkg_defs/ska3-template/bin/ska_version
+++ b/pkg_defs/ska3-template/bin/ska_version
@@ -33,7 +33,7 @@ if args.full:
                  for pkg in pkgs if pkg['name'].startswith('ska3-')]
 else:
     ska3_pkgs = [pkg['version']
-                 for pkg in pkgs if pkg['name'] == 'ska3-flight']
+                 for pkg in pkgs if pkg['name'] in ['ska3-flight', 'ska3-matlab']]
 
 # Get a list of all non-ska3-* metapackages conda pkgs and their versions
 # (not builds or channels)


### PR DESCRIPTION
This is a trivial case. Up to now, "ska3-flight" is included in the version string if it is installed. This PR just adds ska3-matlab too.

Fixes #143 
