### PR TITLE
2022.11

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -62,4 +62,4 @@ requirements:
     - sparkles ==4.21.0
     - starcheck ==13.17.0
     - testr ==4.11.1
-    - xija ==4.29.0
+    - xija ==4.29.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2022.9
+  version: 2022.11
 
 build:
   noarch: generic
@@ -9,27 +9,27 @@ build:
 requirements:
   run:
     - aca_hi_bgd ==0.1.6
-    - aca_view ==0.10.0
+    - aca_view ==0.10.1
     - aca_weekly_report ==0.1.6
-    - acdc ==4.8.1
+    - acdc ==4.9.0
     - acis_taco ==4.2.2
-    - acis_thermal_check ==4.3.1
+    - acis_thermal_check ==4.4.0
     - acispy ==2.5.0
-    - agasc ==4.12.1
+    - agasc ==4.13.1
     - aimpoint_mon ==1.0.1
-    - astromon ==1.0.1
+    - astromon ==1.1.0
     - annie ==0.11.1
     - backstop_history ==3.1.0
     - chandra.cmd_states ==3.17.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.1
-    - chandra_aca ==4.35.1
+    - chandra_aca ==4.36.1
     - cxotime ==3.3.0
     - find_attitude ==3.4.2
-    - fot-matlab ==2.0.1
+    - fot-matlab ==2.1.1
     - hopper ==4.5.2
     - jobwatch ==0.10.0
-    - kadi ==7.0.2
+    - kadi ==7.1.0
     - kalman_watch ==0.1.0
     - maude ==3.10.4
     - mica ==4.31.0
@@ -59,7 +59,7 @@ requirements:
     - ska_path ==3.1.2
     - ska_sync ==4.10.0
     - skare3_tools ==1.0.8
-    - sparkles ==4.20.0
-    - starcheck ==13.16.0
+    - sparkles ==4.21.0
+    - starcheck ==13.17.0
     - testr ==4.11.1
-    - xija ==4.28.1
+    - xija ==4.29.0


### PR DESCRIPTION
# ska3-flight 2022.11

This PR includes the following changes:

- acis_thermal_check:
   - HRC CEA check tool
   - include checks for the expanded number of observations that can go to -109 C.
- starcheck: set to use "flight" KADI_SCENARIO for all kadi.commands on HEAD; support 8x8 readouts
- kadi: Add HRC states: 15v on, HRC-I on, HRC-S on
- xija: New model component to support HRC thermal modeling

## Interface Impacts:

Includes ACA Load Review Checklist update to version 3.9 (allows for 8x8 image readouts for science observations).

[Github 3.9 Checklist](https://github.com/sot/starcheck/blob/ca52d887e7671962af3adc84d0196873f5d65068/starcheck/src/aca_load_review_cl.rst)

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.11-HEAD).
- [Automated tests GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.11-GRETA/). - some benign deprecation warnings

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2022.11rc2 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2022.11rc2
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2022.11 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-flight changes (2022.9 -> 2022.11rc1)

### Updated Packages

- **aca_view:** 0.10.0 -> 0.10.1 (0.10.0 -> 0.10.1)
  - [PR 153](https://github.com/sot/aca_view/pull/153) (javierggt): Black
- **acdc:** 4.8.1 -> 4.9.0 (4.8.1 -> 4.9.0)
  - [PR 70](https://github.com/sot/acdc/pull/70) (taldcroft): Allow for custom n-combine for flight alg
- **acis_thermal_check:** 4.3.1 -> 4.4.0 (4.3.1 -> 4.4.0)
  - [PR 53](https://github.com/acisops/acis_thermal_check/pull/53) (jzuhone): Enabling the checking of expanded categories of observations that can go to -109 C by 
  - [PR 54](https://github.com/acisops/acis_thermal_check/pull/54) (jzuhone) Tool for HRC CEA 
- **agasc:** 4.12.1 -> 4.13.1 (4.12.1 -> 4.13.0 -> 4.13.1)
  - [PR 143](https://github.com/sot/agasc/pull/143) (javierggt): Use union=True when filtering bad times in MSID set
  - [PR 142](https://github.com/sot/agasc/pull/142) (javierggt): More informative exception logging
  - [PR 140](https://github.com/sot/agasc/pull/140) (javierggt): Use kadi commands v1 for now
- **astromon:** 1.0.1 -> 1.1.0 (1.0.1 -> 1.1.0)
  - [PR 31](https://github.com/sot/astromon/pull/31) (javierggt): Black
  - [PR 33](https://github.com/sot/astromon/pull/33) (javierggt): renamed task schedule log filename to match with jobwatch expectations
  - [PR 32](https://github.com/sot/astromon/pull/32) (javierggt): Add a way to shift offsets according to a reference CalDB 
- **chandra_aca:** 4.35.1 -> 4.36.1 (4.35.1 -> 4.36.1)
  - [PR 132](https://github.com/sot/chandra_aca/pull/132) (jeanconn): Use a public copy of zero offset aimpoint file if local not available
  - [PR 133](https://github.com/sot/chandra_aca/pull/133) (taldcroft): Apply Black and isort formatting
- **fot-matlab:** 2.0.1 -> 2.1.1 (2.0.1 -> 2.1.0 -> 2.1.1)
  - [PR 16](https://github.com/sot/fot-matlab/pull/16) (jskrist): Setting initial conditions to starting time - eps
  - [PR 17](https://github.com/sot/fot-matlab/pull/17) (jskrist): Matlab 11918
  - [PR 18](https://github.com/sot/fot-matlab/pull/18) (jskrist): - inserting initial pitch into state aligned pitches when needed
- **kadi:** 7.0.2 -> 7.1.0 (7.0.2 -> 7.1.0)
  - [PR 257](https://github.com/sot/kadi/pull/257) (taldcroft): Add HRC states: 15v on, HRC-I on, HRC-S on
  - [PR 260](https://github.com/sot/kadi/pull/260) (taldcroft): Fix bug when getting states starting just before NSM
  - [PR 259](https://github.com/sot/kadi/pull/259) (taldcroft): Make noodle path be case insensitive
- **sparkles:** 4.20.0 -> 4.21.0 (4.20.0 -> 4.21.0)
  - [PR 179](https://github.com/sot/sparkles/pull/179) (jeanconn): Update sparkles.yoshi to use get_target_aimpoint
- **starcheck:** 13.16.0 -> 13.17.0 (13.16.0 -> 13.17.0)
  - [PR 401](https://github.com/sot/starcheck/pull/401) (jeanconn): Update checklist for 8x8 for science ORs
  - [PR 396](https://github.com/sot/starcheck/pull/396) (jeanconn): Support move to 8x8 readouts for science observations
  - [PR 400](https://github.com/sot/starcheck/pull/400) (taldcroft): Configure kadi logger globally + other refactoring; set to use "flight" KADI_SCENARIO for all kadi.commands on HEAD
- **xija:** 4.28.1 -> 4.29.1 (4.28.1 -> 4.29.0 -> 4.29.1)
  - [PR 131](https://github.com/sot/xija/pull/131) (javierggt): Add xija.component.heat to installed packages in setup.py
  - [PR 129](https://github.com/sot/xija/pull/129) (jzuhone): Refactor heat.py into a subpackage
  - [PR 128](https://github.com/sot/xija/pull/128) (jzuhone): create a generic solar heating class which is SIM-Z dependent
  
# Related Issues

Fixes #947
Fixes #950
Fixes #951
Fixes #952
Fixes #953
Fixes #954
Fixes #955
Fixes #956
Fixes #957
Fixes #958
Fixes #959
Fixes #960
