### PR TITLE
2022.12

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - chandra_aca ==4.37.1
     - cxotime ==3.3.0
     - find_attitude ==3.4.2
-    - fot-matlab ==2.1.1
+    - fot-matlab ==2.1.2
     - hopper ==4.5.2
     - jobwatch ==0.10.0
     - kadi ==7.1.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: "2022.10"
+  version: 2022.12
 
 build:
   noarch: generic
@@ -9,29 +9,29 @@ build:
 requirements:
   run:
     - aca_hi_bgd ==0.1.6
-    - aca_view ==0.10.0
+    - aca_view ==0.10.1
     - aca_weekly_report ==0.1.6
-    - acdc ==4.8.1
+    - acdc ==4.9.0
     - acis_taco ==4.2.2
-    - acis_thermal_check ==4.3.1
+    - acis_thermal_check ==4.4.0
     - acispy ==2.5.0
-    - agasc ==4.12.1
+    - agasc ==4.13.1
     - aimpoint_mon ==1.0.1
-    - astromon ==1.0.1
+    - astromon ==1.1.0
     - annie ==0.11.1
     - backstop_history ==3.1.0
     - chandra.cmd_states ==3.17.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.1
-    - chandra_aca ==4.35.1
+    - chandra_aca ==4.36.1
     - cxotime ==3.3.0
     - find_attitude ==3.4.2
     - fot-matlab ==2.1.1
     - hopper ==4.5.2
     - jobwatch ==0.10.0
-    - kadi ==7.0.1
+    - kadi ==7.1.0
     - kalman_watch ==0.1.0
-    - maude ==3.10.3
+    - maude ==3.10.4
     - mica ==4.31.0
     - parse_cm ==3.9.1
     - perigee_health_plots ==0.3.1
@@ -58,8 +58,8 @@ requirements:
     - ska_helpers ==0.6.1
     - ska_path ==3.1.2
     - ska_sync ==4.10.0
-    - skare3_tools ==1.0.7
-    - sparkles ==4.20.0
-    - starcheck ==13.16.0
+    - skare3_tools ==1.0.8
+    - sparkles ==4.21.0
+    - starcheck ==13.17.0
     - testr ==4.11.1
-    - xija ==4.27.0
+    - xija ==4.29.1

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - chandra.cmd_states ==3.17.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.1
-    - chandra_aca ==4.36.1
+    - chandra_aca ==4.37.1
     - cxotime ==3.3.0
     - find_attitude ==3.4.2
     - fot-matlab ==2.1.1


### PR DESCRIPTION
# ska3-matlab 2022.12

This PR includes the following changes:

- acis_thermal_check:
   - HRC CEA check tool
   - include checks for the expanded number of observations that can go to -109 C.
- starcheck: set to use "flight" KADI_SCENARIO for all kadi.commands on HEAD; support 8x8 readouts
- kadi: Add HRC states: 15v on, HRC-I on, HRC-S on
- xija: New model component to support HRC thermal modeling

## Interface Impacts:

## Testing:

- [rc1](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.12rc1/).
- [rc2](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.12rc2/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.12rc1-GRETA/).
- [2022.12rc3-GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.12rc3-GRETA)

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2022.12rc3 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2022.12rc3
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2022.12rc1 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes
## ska3-matlab changes (2022.10.1 -> 2022.12rc3)

### Updated Packages

- **aca_view:** 0.10.0 -> 0.10.1 (0.10.0 -> 0.10.1)
  - [PR 153](https://github.com/sot/aca_view/pull/153) (Javier Gonzalez): Black
- **acdc:** 4.8.1 -> 4.9.0 (4.8.1 -> 4.9.0)
  - [PR 70](https://github.com/sot/acdc/pull/70) (Tom Aldcroft): Allow for custom n-combine for flight alg
- **acis_thermal_check:** 4.3.1 -> 4.4.0 (4.3.1 -> 4.4.0)
- **agasc:** 4.12.1 -> 4.13.1 (4.12.1 -> 4.13.0 -> 4.13.1)
  - [PR 143](https://github.com/sot/agasc/pull/143) (Javier Gonzalez): Use union=True when filtering bad times in MSID set
  - [PR 142](https://github.com/sot/agasc/pull/142) (Javier Gonzalez): More informative exception logging
  - [PR 140](https://github.com/sot/agasc/pull/140) (Javier Gonzalez): Use kadi commands v1 for now
- **astromon:** 1.0.1 -> 1.1.0 (1.0.1 -> 1.1.0)
  - [PR 31](https://github.com/sot/astromon/pull/31) (Javier Gonzalez): Black
  - [PR 33](https://github.com/sot/astromon/pull/33) (Javier Gonzalez): renamed task schedule log filename to match with jobwatch expectations
  - [PR 32](https://github.com/sot/astromon/pull/32) (Javier Gonzalez): Add a way to shift offsets according to a reference CalDB 
- **chandra_aca:** 4.35.1 -> 4.37.1 (4.35.1 -> 4.36.1 -> 4.37.0 -> 4.37.1)
  - [PR 132](https://github.com/sot/chandra_aca/pull/132) (Jean Connelly): Use a public copy of zero offset aimpoint file if local not available
  - [PR 133](https://github.com/sot/chandra_aca/pull/133) (Tom Aldcroft): Apply Black and isort formatting
  - [PR 134](https://github.com/sot/chandra_aca/pull/134) (Tom Aldcroft): Use ACA drift model from chandra_models JSON file
  - [PR 135](https://github.com/sot/chandra_aca/pull/135) (Tom Aldcroft): Use FOT tools env var to override drift model root dir
- **fot-matlab:** 2.1.1 -> 2.1.2 (2.1.1 -> 2.1.2)
  - [PR 19](https://github.com/sot/fot-matlab/pull/19) (James Kristoff): MATLAB-11938
- **kadi:** 7.0.1 -> 7.1.0 (7.0.1 -> 7.0.2 -> 7.1.0)
  - [PR 256](https://github.com/sot/kadi/pull/256) (Tom Aldcroft): Set lookforward for Orbit event class
  - [PR 255](https://github.com/sot/kadi/pull/255) (Tom Aldcroft): Suppress v1 FutureWarning for testing
  - [PR 257](https://github.com/sot/kadi/pull/257) (Tom Aldcroft): Add HRC states: 15v on, HRC-I on, HRC-S on
  - [PR 260](https://github.com/sot/kadi/pull/260) (Tom Aldcroft): Fix bug when getting states starting just before NSM
  - [PR 259](https://github.com/sot/kadi/pull/259) (Tom Aldcroft): Make noodle path be case insensitive
- **maude:** 3.10.3 -> 3.10.4 (3.10.3 -> 3.10.4)
  - [PR 43](https://github.com/sot/maude/pull/43) (Tom Aldcroft): Make state codes test more tolerant of time-tag changes
- **skare3_tools:** 1.0.7 -> 1.0.8 (1.0.7 -> 1.0.8)
  - [PR 89](https://github.com/sot/skare3_tools/pull/89) (Javier Gonzalez): fix template in skare3-changes-summary
- **sparkles:** 4.20.0 -> 4.21.0 (4.20.0 -> 4.21.0)
  - [PR 179](https://github.com/sot/sparkles/pull/179) (Jean Connelly): Update sparkles.yoshi to use get_target_aimpoint
- **starcheck:** 13.16.0 -> 13.17.0 (13.16.0 -> 13.17.0)
  - [PR 401](https://github.com/sot/starcheck/pull/401) (Jean Connelly): Update checklist for 8x8 for science ORs
  - [PR 396](https://github.com/sot/starcheck/pull/396) (Jean Connelly): Support move to 8x8 readouts for science observations
  - [PR 400](https://github.com/sot/starcheck/pull/400) (Tom Aldcroft): Configure kadi logger globally + other refactoring
- **xija:** 4.27.0 -> 4.29.1 (4.27.0 -> 4.28.0 -> 4.28.1 -> 4.29.0 -> 4.29.1)
  - [PR 123](https://github.com/sot/xija/pull/123) (Tom Aldcroft): Improve performance of bad_times and mask_times
  - [PR 130](https://github.com/sot/xija/pull/130) (Tom Aldcroft): Fix problem of dropping bad_times in spec file and y-scale divergence
  - [PR 129](https://github.com/sot/xija/pull/129) (John ZuHone): Refactor heat.py into a subpackage
  - [PR 131](https://github.com/sot/xija/pull/131) (Javier Gonzalez): Add xija.component.heat to installed packages in setup.py
  - [PR 128](https://github.com/sot/xija/pull/128) (jzuhone): create a generic solar heating class which is SIM-Z dependent
# Related Issues

Fixes #965