### PR TITLE
add ska_helpers to build recipes

### DIFF
--- a/pkg_defs/Chandra.Maneuver/meta.yaml
+++ b/pkg_defs/Chandra.Maneuver/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Chandra.Time/meta.yaml
+++ b/pkg_defs/Chandra.Time/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
     - cython
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Chandra.cmd_states/meta.yaml
+++ b/pkg_defs/Chandra.cmd_states/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.DBI/meta.yaml
+++ b/pkg_defs/Ska.DBI/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.File/meta.yaml
+++ b/pkg_defs/Ska.File/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
 
   run:
     - python

--- a/pkg_defs/Ska.Matplotlib/meta.yaml
+++ b/pkg_defs/Ska.Matplotlib/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
 
   run:
     - python

--- a/pkg_defs/Ska.Numpy/meta.yaml
+++ b/pkg_defs/Ska.Numpy/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
     - cython
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.ParseCM/meta.yaml
+++ b/pkg_defs/Ska.ParseCM/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.Shell/meta.yaml
+++ b/pkg_defs/Ska.Shell/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
 
   run:
     - python

--- a/pkg_defs/Ska.Sun/meta.yaml
+++ b/pkg_defs/Ska.Sun/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   run:
     - python
     - ska.quatutil

--- a/pkg_defs/Ska.arc5gl/meta.yaml
+++ b/pkg_defs/Ska.arc5gl/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.astro/meta.yaml
+++ b/pkg_defs/Ska.astro/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.engarchive/meta.yaml
+++ b/pkg_defs/Ska.engarchive/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
 
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/Ska.ftp/meta.yaml
+++ b/pkg_defs/Ska.ftp/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.quatutil/meta.yaml
+++ b/pkg_defs/Ska.quatutil/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/Ska.report_ranges/meta.yaml
+++ b/pkg_defs/Ska.report_ranges/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
 
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/Ska.tdb/meta.yaml
+++ b/pkg_defs/Ska.tdb/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:


### PR DESCRIPTION
These changes will be needed in all current namespace packages if they are modified like in https://github.com/sot/Ska.Sun/pull/22

I noticed that many packages include this in their `setup.py`:
```python
try:
    from testr.setup_helper import cmdclass
except ImportError:
    cmdclass = {}
```

Up to now, this is never used, because testr is not a build dependency. This PR does not change that.