### PR TITLE
Add testr to chandra_time build dependencies

### DIFF
--- a/pkg_defs/chandra_time/meta.yaml
+++ b/pkg_defs/chandra_time/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - setuptools_scm_git_archive
     - cython
     - ska_helpers
+    - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:


### PR DESCRIPTION
It seems we missed this one, so the build fails.