### PR TITLE
2022.13

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2022.6
+  version: 2022.13
 
 requirements:
   run:
@@ -148,7 +148,7 @@ requirements:
     - libcblas ==3.9.0  # [linux or win]
     - libclang ==11.1.0
     - libcurl ==7.80.0
-    - libcxx ==12.0.0  # [osx]
+    - libcxx ==14.0.6  # [osx]
     - libdeflate ==1.7
     - libedit ==3.1.20210910  # [linux or osx]
     - libev ==4.33  # [linux or osx]

--- a/pkg_defs/ska3-flight-latest/meta.yaml
+++ b/pkg_defs/ska3-flight-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight-latest
-  version: 2022.9
+  version: 2022.13
 
 build:
   noarch: generic
@@ -25,6 +25,7 @@ requirements:
     - chandra.cmd_states
     - chandra.maneuver
     - chandra_time
+    - cheta
     - cxotime
     - find_attitude
     - fot-matlab
@@ -43,7 +44,6 @@ requirements:
     - ska.arc5gl
     - ska.astro
     - ska.dbi
-    - cheta
     - ska.file
     - ska.ftp
     - ska.numpy

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - aca_weekly_report ==0.1.6
     - acdc ==4.9.0
     - acis_taco ==4.2.2
-    - acis_thermal_check ==4.4.1
+    - acis_thermal_check ==4.5.0
     - acispy ==2.5.0
     - agasc ==4.14.0
     - aimpoint_mon ==1.1.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2022.11
+  version: 2022.13
 
 build:
   noarch: generic
@@ -9,29 +9,29 @@ build:
 requirements:
   run:
     - aca_hi_bgd ==0.1.6
-    - aca_view ==0.10.1
+    - aca_view ==0.11.0
     - aca_weekly_report ==0.1.6
     - acdc ==4.9.0
     - acis_taco ==4.2.2
-    - acis_thermal_check ==4.4.0
+    - acis_thermal_check ==4.4.1
     - acispy ==2.5.0
-    - agasc ==4.13.1
-    - aimpoint_mon ==1.0.1
+    - agasc ==4.14.0
+    - aimpoint_mon ==1.1.0
     - astromon ==1.1.0
     - annie ==0.11.1
     - backstop_history ==3.1.0
     - chandra.cmd_states ==3.17.0
     - chandra.maneuver ==3.8.0
     - chandra.time ==4.0.1
-    - chandra_aca ==4.36.1
-    - cxotime ==3.3.0
+    - chandra_aca ==4.38.0
+    - cxotime ==3.4.0
     - find_attitude ==3.4.2
     - fot-matlab ==2.1.1
     - hopper ==4.5.2
     - jobwatch ==0.10.0
-    - kadi ==7.1.0
-    - kalman_watch ==0.1.0
-    - maude ==3.10.4
+    - kadi ==7.2.0
+    - kalman_watch ==0.2.0
+    - maude ==3.11.0
     - mica ==4.31.0
     - parse_cm ==3.9.1
     - perigee_health_plots ==0.3.1
@@ -55,11 +55,11 @@ requirements:
     - ska.tdb ==3.6.1
     - ska3-core ==2022.6
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.6.1
+    - ska_helpers ==0.7.1
     - ska_path ==3.1.2
     - ska_sync ==4.10.0
-    - skare3_tools ==1.0.8
+    - skare3_tools ==1.0.9
     - sparkles ==4.21.0
-    - starcheck ==13.17.0
+    - starcheck ==14.0.0
     - testr ==4.11.1
-    - xija ==4.29.1
+    - xija ==4.29.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - ska.shell ==3.5.1
     - ska_sun ==3.9.0
     - ska.tdb ==3.6.1
-    - ska3-core ==2022.6
+    - ska3-core ==2022.13
     - ska3-template ==2022.06.02
     - ska_helpers ==0.7.1
     - ska_path ==3.1.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -60,6 +60,6 @@ requirements:
     - ska_sync ==4.10.0
     - skare3_tools ==1.0.9
     - sparkles ==4.21.0
-    - starcheck ==14.0.0
+    - starcheck ==14.0.1
     - testr ==4.11.1
     - xija ==4.29.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -22,8 +22,9 @@ requirements:
     - backstop_history ==3.1.0
     - chandra.cmd_states ==3.17.0
     - chandra.maneuver ==3.8.0
-    - chandra.time ==4.0.1
+    - chandra_time ==4.1.1
     - chandra_aca ==4.38.0
+    - cheta ==4.58.0
     - cxotime ==3.4.0
     - find_attitude ==3.4.2
     - fot-matlab ==2.1.1
@@ -42,7 +43,6 @@ requirements:
     - ska.arc5gl ==3.3.0
     - ska.astro ==3.3.0
     - ska.dbi ==4.1.0
-    - ska.engarchive ==4.57.0
     - ska.file ==3.4.5
     - ska.ftp ==3.6.0
     - ska.matplotlib ==3.15.0
@@ -51,7 +51,7 @@ requirements:
     - ska.quatutil ==3.4.0
     - ska.report_ranges ==0.4.0
     - ska.shell ==3.5.1
-    - ska.sun ==3.8.1
+    - ska_sun ==3.9.0
     - ska.tdb ==3.6.1
     - ska3-core ==2022.6
     - ska3-template ==2022.06.02


### PR DESCRIPTION
Highlights of this new Ska3 release include:

- `acis_thermal_check` changes to:
  -  fix the definition of "old criteria" for determining whether ACIS observations can go to -109 C ([PR 55](https://github.com/acisops/acis_thermal_check/pull/55))
  - add predictive data for `1dhatbon` to `cea_check` to prevent crashes ([PR 56](https://github.com/acisops/acis_thermal_check/pull/56)),
  - update the `acis_thermal_check` documentation to include more information about how to run models outside of load review ([PR 57](https://github.com/acisops/acis_thermal_check/pull/57)),
  - fix a bug with running in validation-only mode and adds tests for that mode ([PR 58](https://github.com/acisops/acis_thermal_check/pull/58)). 
- `acis_thermal_check` includes check_cea.py.
  check_cea.py is a *new load review tool to evaluate the HRC CEA temperatures*. It is based on ACIS load review tools such as check_dpa.py, and makes use of the HRC CEA thermal model.
- `agasc`: changes to reduce peak memory use.
- `chandra_aca`: Use ACA drift model from chandra_models JSON file
- `cxotime`: Add method and command line script `cxotime` to convert time formats. See https://github.com/sot/cxotime/pull/30 for examples of this handy new option from the command line.
- `kadi`: 
  - Add a new commanded states validation module to replace the legacy Python 2 script. This new validation uses MAUDE data and generates interactive web plots, making the app suitable for validation of changes to the [Chandra Command Events sheet](https://docs.google.com/spreadsheets/d/19d6XqBhWoFjC-z1lS1nM6wLE_zjr4GYB1lOvrEGCbKQ/edit#gid=0).
  - Add `type` field to Dump event class and include both ground-commanded (`type="GRND"`) and autonomous (`type="AUTO"`) unloads.
- `maude`: Allow caching requests to the MAUDE server.
- `starcheck`:
   - Add 16 arcsec dither in y and z to "standard" set.
   - Replace Inline::Python with a light Python function server.
   - Allow using MAUDE for thermal model source data.

The following packages were renamed. The previous names are still valid and link to the renamed packages:
- Chandra.Time -> chandra_time
- Ska.engarchive -> cheta
- Ska.Sun -> ska_sun

## Interface Impacts:

The tables in `$SKA/data/kadi/events3.db` include a new field.  

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.13-HEAD/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.13-GRETA/).
- [OS-X](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2022.13rc2-OSX/)

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2022.13rc2 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2022.13rc2
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight2022.13 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes
## ska3-core changes (2022.6 -> 2022.13rc2)

- **libcxx:** 12.0.0 -> 14.0.6 (Mac OS only)

## ska3-flight changes (2022.11 -> 2022.13rc2)

### New Packages

- **chandra_time: 4.1.1**
- **cheta: 4.58.0**
- **ska_sun: 3.9.0**

### Removed Packages

- **chandra.time**
- **ska.engarchive**
- **ska.sun**

### Updated Packages

- **aca_view:** 0.10.1 -> 0.11.0 (0.10.1 -> 0.11.0)
  - [PR 156](https://github.com/sot/aca_view/pull/156) (Javier Gonzalez): Fixes for issues in real-time mode
  - [PR 157](https://github.com/sot/aca_view/pull/157) (Javier Gonzalez): Improve feedback when fetching data
- **acis_thermal_check:** 4.4.0 -> 4.5.0 (4.4.0 -> 4.4.1 ->  -> 4.5.0)
  - [PR 57](https://github.com/acisops/acis_thermal_check/pull/57) (John ZuHone): Minor doc updates
  - [PR 58](https://github.com/acisops/acis_thermal_check/pull/58) (John ZuHone): Fix validation-only runs
  - [PR 56](https://github.com/acisops/acis_thermal_check/pull/56) (John ZuHone): Add predictive data for 1dahtbon to cea_check
  - [PR 55](https://github.com/acisops/acis_thermal_check/pull/55) (John ZuHone): Update hot ACIS observations criteria
- **agasc:** 4.13.1 -> 4.14.0 (4.13.1 -> 4.14.0)
  - [PR 144](https://github.com/sot/agasc/pull/144) (Jean Connelly): Reduce peak memory use by not reading full file to get RA DEC columns
  - [PR 137](https://github.com/sot/agasc/pull/137) (Javier Gonzalez): Write JSON when creating star reports.
- **aimpoint_mon:** 1.0.1 -> 1.1.0 (1.0.1 -> 1.1.0)
  - [PR 24](https://github.com/sot/aimpoint_mon/pull/24) (Tom Aldcroft): Add notebook for 2022-11 update of aimpoint drift model
- **chandra_aca:** 4.36.1 -> 4.38.0 (4.36.1 -> 4.37.0 -> 4.37.1 -> 4.38.0)
  - [PR 134](https://github.com/sot/chandra_aca/pull/134) (Tom Aldcroft): Use ACA drift model from chandra_models JSON file
  - [PR 135](https://github.com/sot/chandra_aca/pull/135) (Tom Aldcroft): Use FOT tools env var to override drift model root dir
  - [PR 136](https://github.com/sot/chandra_aca/pull/136) (Tom Aldcroft): Modernize
  - [PR 137](https://github.com/sot/chandra_aca/pull/137) (Tom Aldcroft): Update pre-commit hooks and black workflow to latest versions
- **cxotime:** 3.3.0 -> 3.4.0 (3.3.0 -> 3.4.0)
  - [PR 30](https://github.com/sot/cxotime/pull/30) (Tom Aldcroft): Add method and console script to convert time formats
  - [PR 31](https://github.com/sot/cxotime/pull/31) (Tom Aldcroft): Add CxoTimeLike type alias
  - [PR 32](https://github.com/sot/cxotime/pull/32) (Tom Aldcroft): Black and isort
- **kadi:** 7.1.0 -> 7.2.0 (7.1.0 -> 7.2.0)
  - [PR 262](https://github.com/sot/kadi/pull/262) (Tom Aldcroft): Remove WARNING in logging text
  - [PR 263](https://github.com/sot/kadi/pull/263) (Tom Aldcroft): Explicit complete_intervals=True in logical intervals + code tidy
  - [PR 264](https://github.com/sot/kadi/pull/264) (Tom Aldcroft): Add `type` field to Dump event class and update docs and process notes
  - [PR 265](https://github.com/sot/kadi/pull/265) (Tom Aldcroft): Fix issue with cmd query around 30 days before current time
  - [PR 261](https://github.com/sot/kadi/pull/261) (Tom Aldcroft): Validate kadi states
- **kalman_watch:** 0.1.0 -> 0.2.0 (0.1.0 -> 0.2.0)
  - [PR 8](https://github.com/sot/kalman_watch/pull/8) (Tom Aldcroft): Remove maude from fetch data source
  - [PR 9](https://github.com/sot/kalman_watch/pull/9) (Tom Aldcroft): Use explicit complete_intervals=True in low_kalman_mon
- **maude:** 3.10.4 -> 3.11.0 (3.10.4 -> 3.11.0)
  - [PR 44](https://github.com/sot/maude/pull/44) (Tom Aldcroft): Allow caching requests to the MAUDE server
- **ska3-core:** 2022.6 -> 2022.13rc2
- **ska_helpers:** 0.6.1 -> 0.7.1 (0.6.1 -> 0.7.0 -> 0.7.1)
  - [PR 26](https://github.com/sot/ska_helpers/pull/26) (Jean Connelly): Add setup_helper.py with duplicate_package_info
  - [PR 27](https://github.com/sot/ska_helpers/pull/27) (Tom Aldcroft): Apply black and isort and add flake8 checking
  - [PR 28](https://github.com/sot/ska_helpers/pull/28) (Tom Aldcroft): Improve get_version debug output and fully test functionality
- **skare3_tools:** 1.0.8 -> 1.0.9 (1.0.8 -> 1.0.9)
  - [PR 91](https://github.com/sot/skare3_tools/pull/91) (Javier Gonzalez): black
  - [PR 92](https://github.com/sot/skare3_tools/pull/92) (Javier Gonzalez): Update docker image to use testr and ska_helpers
- **starcheck:** 13.17.0 -> 14.0.1 (13.17.0 -> 14.0.0 ->  -> 14.0.1)
  - [PR 397](https://github.com/sot/starcheck/pull/397) (Jean Connelly): Allow using maude for thermal model source data
  - [PR 383](https://github.com/sot/starcheck/pull/383) (Jean Connelly): Add 16 arcsec to 'standard' dither in y and z
  - [PR 402](https://github.com/sot/starcheck/pull/402) (Tom Aldcroft): Replace Inline::Python with a light Python function server
  - [PR 404](https://github.com/sot/starcheck/pull/404) (Jean Connelly): Save and return exit status at END
- **xija:** 4.29.1 -> 4.29.2 (4.29.1 -> 4.29.2)
  - [PR 132](https://github.com/sot/xija/pull/132) (Jean Connelly): Update location of chandra_models readme


## ska3-flight-latest changes (2022.9 -> 2022.13rc2)

### New Packages

- **chandra_time: **
- **cheta: **
- **ska_sun: **

### Removed Packages

- **chandra.time**
- **ska.engarchive**
- **ska.sun**

# Related Issues

Fixes #975
Fixes #976
Fixes #985
Fixes #987
Fixes #988
Fixes #989
Fixes #990
Fixes #991
Fixes #992
Fixes #993
Fixes #994
Fixes #995
Fixes #996
Fixes #998
Fixes #1000
Fixes #1002
Fixes #1003
Fixes #1006
