### PR TITLE
add missing testr to some build recipe dependencies

### DIFF
--- a/pkg_defs/chandra_cmd_states/meta.yaml
+++ b/pkg_defs/chandra_cmd_states/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
     - ska_helpers
+    - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/chandra_maneuver/meta.yaml
+++ b/pkg_defs/chandra_maneuver/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
     - ska_helpers
+    - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/ska_dbi/meta.yaml
+++ b/pkg_defs/ska_dbi/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
     - ska_helpers
+    - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/ska_ftp/meta.yaml
+++ b/pkg_defs/ska_ftp/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
     - ska_helpers
+    - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/ska_numpy/meta.yaml
+++ b/pkg_defs/ska_numpy/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - setuptools_scm_git_archive
     - cython
     - ska_helpers
+    - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/ska_quatutil/meta.yaml
+++ b/pkg_defs/ska_quatutil/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
     - ska_helpers
+    - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/ska_shell/meta.yaml
+++ b/pkg_defs/ska_shell/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
     - ska_helpers
+    - testr
 
   run:
     - python

--- a/pkg_defs/ska_tdb/meta.yaml
+++ b/pkg_defs/ska_tdb/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools_scm
     - setuptools_scm_git_archive
     - ska_helpers
+    - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:


### PR DESCRIPTION
This PR adds a missing testr build dependency to some recipes.

We don't run test as part of the conda build process, but these packages now import testr in their setup.py files and need the package in the build environment to build successfully. 

testr itself is only used (after import) in these packages when running their tests.