### PR TITLE
2023.2

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - cheta ==4.58.0
     - cxotime ==3.4.0
     - find_attitude ==3.4.3
-    - fot-matlab ==2.1.1
+    - fot-matlab ==2.2.0
     - hopper ==4.5.4
     - jobwatch ==0.10.1
     - kadi ==7.3.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,65 +1,65 @@
 ---
 package:
   name: ska3-matlab
-  version: "2022.10"
+  version: 2023.2
 
 build:
   noarch: generic
 
 requirements:
   run:
-    - aca_hi_bgd ==0.1.6
-    - aca_view ==0.10.0
-    - aca_weekly_report ==0.1.6
-    - acdc ==4.8.1
-    - acis_taco ==4.2.2
-    - acis_thermal_check ==4.3.1
+    - aca_hi_bgd ==0.1.7
+    - aca_view ==0.12.0
+    - aca_weekly_report ==0.1.7
+    - acdc ==4.9.1
+    - acis_taco ==4.2.3
+    - acis_thermal_check ==4.6.0
     - acispy ==2.5.0
-    - agasc ==4.12.1
-    - aimpoint_mon ==1.0.1
-    - astromon ==1.0.1
-    - annie ==0.11.1
-    - backstop_history ==3.1.0
-    - chandra.cmd_states ==3.17.0
-    - chandra.maneuver ==3.8.0
-    - chandra.time ==4.0.1
-    - chandra_aca ==4.35.1
-    - cxotime ==3.3.0
-    - find_attitude ==3.4.2
+    - agasc ==4.14.1
+    - aimpoint_mon ==1.1.1
+    - astromon ==1.1.1
+    - annie ==0.11.2
+    - backstop_history ==3.1.1
+    - chandra_cmd_states ==4.0.0
+    - chandra_maneuver ==4.0.0
+    - chandra_time ==4.1.1
+    - chandra_aca ==4.38.3
+    - cheta ==4.58.0
+    - cxotime ==3.4.0
+    - find_attitude ==3.4.3
     - fot-matlab ==2.1.1
-    - hopper ==4.5.2
-    - jobwatch ==0.10.0
-    - kadi ==7.0.1
-    - kalman_watch ==0.1.0
-    - maude ==3.10.3
-    - mica ==4.31.0
+    - hopper ==4.5.4
+    - jobwatch ==0.10.1
+    - kadi ==7.3.0
+    - kalman_watch ==0.2.0
+    - maude ==3.11.1
+    - mica ==4.31.3
     - parse_cm ==3.9.1
-    - perigee_health_plots ==0.3.1
-    - proseco ==5.8.0
+    - perigee_health_plots ==0.3.2
+    - proseco ==5.8.1
     - pyyaks ==4.5.0
     - quaternion ==4.1.1
     - ska-sphinx-theme ==1.3.0
-    - ska.arc5gl ==3.3.0
-    - ska.astro ==3.3.0
-    - ska.dbi ==4.1.0
-    - ska.engarchive ==4.57.0
-    - ska.file ==3.4.5
-    - ska.ftp ==3.6.0
-    - ska.matplotlib ==3.15.0
-    - ska.numpy ==3.9.1
-    - ska.parsecm ==3.4.0
-    - ska.quatutil ==3.4.0
-    - ska.report_ranges ==0.4.0
-    - ska.shell ==3.5.1
-    - ska.sun ==3.8.1
-    - ska.tdb ==3.6.1
-    - ska3-core ==2022.6
+    - ska_arc5gl ==4.0.1
+    - ska_astro ==4.0.0
+    - ska_dbi ==5.0.0
+    - ska_file ==4.0.0
+    - ska_ftp ==4.0.0
+    - ska_matplotlib ==4.0.0
+    - ska_numpy ==4.0.1
+    - ska_parsecm ==4.0.0
+    - ska_quatutil ==4.0.0
+    - ska_report_ranges ==0.5.0
+    - ska_shell ==4.0.0
+    - ska_sun ==3.9.1
+    - ska_tdb ==4.0.0
+    - ska3-core ==2023.1
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.6.1
+    - ska_helpers ==0.8.0
     - ska_path ==3.1.2
-    - ska_sync ==4.10.0
-    - skare3_tools ==1.0.7
-    - sparkles ==4.20.0
-    - starcheck ==13.16.0
-    - testr ==4.11.1
-    - xija ==4.27.0
+    - ska_sync ==4.10.1
+    - skare3_tools ==1.0.9
+    - sparkles ==4.21.0
+    - starcheck ==14.0.2
+    - testr ==4.11.3
+    - xija ==4.29.3


### PR DESCRIPTION
# ska3-matlab 2023.2

This PR includes:
- 

## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.2/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2023.2rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2023.2rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2023.2 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

# Related Issues
