### PR TITLE
2023.2

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - cheta ==4.58.0
     - cxotime ==3.4.0
     - find_attitude ==3.4.3
-    - fot-matlab ==2.1.1
+    - fot-matlab ==2.2.0
     - hopper ==4.5.4
     - jobwatch ==0.10.1
     - kadi ==7.3.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,65 +1,65 @@
 ---
 package:
   name: ska3-matlab
-  version: "2022.10"
+  version: 2023.2
 
 build:
   noarch: generic
 
 requirements:
   run:
-    - aca_hi_bgd ==0.1.6
-    - aca_view ==0.10.0
-    - aca_weekly_report ==0.1.6
-    - acdc ==4.8.1
-    - acis_taco ==4.2.2
-    - acis_thermal_check ==4.3.1
+    - aca_hi_bgd ==0.1.7
+    - aca_view ==0.12.0
+    - aca_weekly_report ==0.1.7
+    - acdc ==4.9.1
+    - acis_taco ==4.2.3
+    - acis_thermal_check ==4.6.0
     - acispy ==2.5.0
-    - agasc ==4.12.1
-    - aimpoint_mon ==1.0.1
-    - astromon ==1.0.1
-    - annie ==0.11.1
-    - backstop_history ==3.1.0
-    - chandra.cmd_states ==3.17.0
-    - chandra.maneuver ==3.8.0
-    - chandra.time ==4.0.1
-    - chandra_aca ==4.35.1
-    - cxotime ==3.3.0
-    - find_attitude ==3.4.2
+    - agasc ==4.14.1
+    - aimpoint_mon ==1.1.1
+    - astromon ==1.1.1
+    - annie ==0.11.2
+    - backstop_history ==3.1.1
+    - chandra_cmd_states ==4.0.0
+    - chandra_maneuver ==4.0.0
+    - chandra_time ==4.1.1
+    - chandra_aca ==4.38.3
+    - cheta ==4.58.0
+    - cxotime ==3.4.0
+    - find_attitude ==3.4.3
     - fot-matlab ==2.1.1
-    - hopper ==4.5.2
-    - jobwatch ==0.10.0
-    - kadi ==7.0.1
-    - kalman_watch ==0.1.0
-    - maude ==3.10.3
-    - mica ==4.31.0
+    - hopper ==4.5.4
+    - jobwatch ==0.10.1
+    - kadi ==7.3.0
+    - kalman_watch ==0.2.0
+    - maude ==3.11.1
+    - mica ==4.31.3
     - parse_cm ==3.9.1
-    - perigee_health_plots ==0.3.1
-    - proseco ==5.8.0
+    - perigee_health_plots ==0.3.2
+    - proseco ==5.8.1
     - pyyaks ==4.5.0
     - quaternion ==4.1.1
     - ska-sphinx-theme ==1.3.0
-    - ska.arc5gl ==3.3.0
-    - ska.astro ==3.3.0
-    - ska.dbi ==4.1.0
-    - ska.engarchive ==4.57.0
-    - ska.file ==3.4.5
-    - ska.ftp ==3.6.0
-    - ska.matplotlib ==3.15.0
-    - ska.numpy ==3.9.1
-    - ska.parsecm ==3.4.0
-    - ska.quatutil ==3.4.0
-    - ska.report_ranges ==0.4.0
-    - ska.shell ==3.5.1
-    - ska.sun ==3.8.1
-    - ska.tdb ==3.6.1
-    - ska3-core ==2022.6
+    - ska_arc5gl ==4.0.1
+    - ska_astro ==4.0.0
+    - ska_dbi ==5.0.0
+    - ska_file ==4.0.0
+    - ska_ftp ==4.0.0
+    - ska_matplotlib ==4.0.0
+    - ska_numpy ==4.0.1
+    - ska_parsecm ==4.0.0
+    - ska_quatutil ==4.0.0
+    - ska_report_ranges ==0.5.0
+    - ska_shell ==4.0.0
+    - ska_sun ==3.9.1
+    - ska_tdb ==4.0.0
+    - ska3-core ==2023.1
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.6.1
+    - ska_helpers ==0.8.0
     - ska_path ==3.1.2
-    - ska_sync ==4.10.0
-    - skare3_tools ==1.0.7
-    - sparkles ==4.20.0
-    - starcheck ==13.16.0
-    - testr ==4.11.1
-    - xija ==4.27.0
+    - ska_sync ==4.10.1
+    - skare3_tools ==1.0.9
+    - sparkles ==4.21.0
+    - starcheck ==14.0.2
+    - testr ==4.11.3
+    - xija ==4.29.3


### PR DESCRIPTION
# ska3-matlab 2023.2

This release follows the ska3-flight 2023.1 release. **This is a major update of the core packages, with the update to ska3-core 2023.1**.  The Python version increases from 3.8.10 to 3.10.8, and all major packages have been updated (numpy, matplotlib, Qt, perl and everything that comes with them).

Other changes in this release:
- Former *namespace* packages (all `Ska.*` and `Chandra.*` packages) were renamed.
- Changes in kadi and acis_thermal_models to properly handle HRC 24V, 15V states.

This PR includes releases of:
- ska3-matlab

## Interface Impacts:

- Major python version update, including updates to all major libraries. Each package might have interface changes. Ska regression tests were run and they pass after some fixes. The only major package with significant interface impact was Qt.
-  Although several packages were renamed, they remain accessible with the older name, and should cause no interface impact.

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.2/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2023.2rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2023.2rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2023.2 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2022.12 -> 2023.2rc1)

### New Packages

- **chandra_cmd_states: 4.0.0**
- **chandra_maneuver: 4.0.0**
- **chandra_time: 4.1.1**
- **cheta: 4.58.0**
- **ska_arc5gl: 4.0.1**
- **ska_astro: 4.0.0**
- **ska_dbi: 5.0.0**
- **ska_file: 4.0.0**
- **ska_ftp: 4.0.0**
- **ska_matplotlib: 4.0.0**
- **ska_numpy: 4.0.1**
- **ska_parsecm: 4.0.0**
- **ska_quatutil: 4.0.0**
- **ska_report_ranges: 0.5.0**
- **ska_shell: 4.0.0**
- **ska_sun: 3.9.1**
- **ska_tdb: 4.0.0**

### Removed Packages

- **chandra.cmd_states**
- **chandra.maneuver**
- **chandra.time**
- **ska.arc5gl**
- **ska.astro**
- **ska.dbi**
- **ska.engarchive**
- **ska.file**
- **ska.ftp**
- **ska.matplotlib**
- **ska.numpy**
- **ska.parsecm**
- **ska.quatutil**
- **ska.report_ranges**
- **ska.shell**
- **ska.sun**
- **ska.tdb**

### Updated Packages

- **aca_hi_bgd:** 0.1.6 -> 0.1.7 (0.1.6 -> 0.1.7)
- **aca_view:** 0.10.1 -> 0.12.0 (0.10.1 -> 0.11.0 -> 0.12.0)
  - [PR 156](https://github.com/sot/aca_view/pull/156) (Javier Gonzalez): Fixes for issues in real-time mode
  - [PR 157](https://github.com/sot/aca_view/pull/157) (Javier Gonzalez): Improve feedback when fetching data
  - [PR 167](https://github.com/sot/aca_view/pull/167) (Javier Gonzalez): Work around issue in pyqtgraph DockLabel
  - [PR 166](https://github.com/sot/aca_view/pull/166) (Javier Gonzalez): Changes for ska3 prime
- **aca_weekly_report:** 0.1.6 -> 0.1.7 (0.1.6 -> 0.1.7)
- **acdc:** 4.9.0 -> 4.9.1 (4.9.0 -> 4.9.1)
- **acis_taco:** 4.2.2 -> 4.2.3 (4.2.2 -> 4.2.3)
- **acis_thermal_check:** 4.4.0 -> 4.6.0 (4.4.0 -> 4.4.1 -> 4.5.0 -> 4.5.2 -> 4.6.0)
  - [PR 57](https://github.com/acisops/acis_thermal_check/pull/57) (John ZuHone): Minor doc updates
  - [PR 58](https://github.com/acisops/acis_thermal_check/pull/58) (John ZuHone): Fix validation-only runs
  - [PR 56](https://github.com/acisops/acis_thermal_check/pull/56) (John ZuHone): Add predictive data for 1dahtbon to cea_check
  - [PR 59](https://github.com/acisops/acis_thermal_check/pull/59) (John ZuHone): Use black, isort, ruff, pre-commit
  - [PR 61](https://github.com/acisops/acis_thermal_check/pull/61) (Tom Aldcroft): Use explicit time units in time delta
  - [PR 62](https://github.com/acisops/acis_thermal_check/pull/62) (John ZuHone): fix ruff, black, gitignore
  - [PR 63](https://github.com/acisops/acis_thermal_check/pull/63) (John ZuHone): More ruff fixes
- **agasc:** 4.13.1 -> 4.14.1 (4.13.1 -> 4.14.0 -> 4.14.1)
  - [PR 144](https://github.com/sot/agasc/pull/144) (Jean Connelly): Reduce peak memory use by not reading full file to get RA DEC columns
  - [PR 137](https://github.com/sot/agasc/pull/137) (Javier Gonzalez): Write JSON when creating star reports.
  - [PR 147](https://github.com/sot/agasc/pull/147) (Javier Gonzalez): make sure the columns in test_update_obs are consistent
- **aimpoint_mon:** 1.0.1 -> 1.1.1 (1.0.1 -> 1.1.0 -> 1.1.1)
  - [PR 24](https://github.com/sot/aimpoint_mon/pull/24) (Tom Aldcroft): Add notebook for 2022-11 update of aimpoint drift model
- **annie:** 0.11.1 -> 0.11.2 (0.11.1 -> 0.11.2)
- **astromon:** 1.1.0 -> 1.1.1 (1.1.0 -> 1.1.1)
- **backstop_history:** 3.1.0 -> 3.1.1 (3.1.0 -> 3.1.1)
- **chandra_aca:** 4.37.1 -> 4.38.3 (4.37.1 -> 4.38.0 -> 4.38.2 -> 4.38.3)
  - [PR 136](https://github.com/sot/chandra_aca/pull/136) (Tom Aldcroft): Modernize
  - [PR 137](https://github.com/sot/chandra_aca/pull/137) (Tom Aldcroft): Update pre-commit hooks and black workflow to latest versions
  - [PR 141](https://github.com/sot/chandra_aca/pull/141) (Tom Aldcroft): Remove deprecated decorator and six dependency
  - [PR 143](https://github.com/sot/chandra_aca/pull/143) (Javier Gonzalez): fix in planets.py: cleanup jplephem.spk.SPK at exit
- **cxotime:** 3.3.0 -> 3.4.0 (3.3.0 -> 3.4.0)
  - [PR 30](https://github.com/sot/cxotime/pull/30) (Tom Aldcroft): Add method and console script to convert time formats
  - [PR 31](https://github.com/sot/cxotime/pull/31) (Tom Aldcroft): Add CxoTimeLike type alias
  - [PR 32](https://github.com/sot/cxotime/pull/32) (Tom Aldcroft): Black and isort
- **find_attitude:** 3.4.2 -> 3.4.3 (3.4.2 -> 3.4.3)
- **fot-matlab:** 2.1.2 -> 2.2.0 (2.1.2 -> 2.2.0)
  - [PR 20](https://github.com/sot/fot-matlab/pull/20) (James Kristoff): Matlab 11984
- **hopper:** 4.5.2 -> 4.5.4 (4.5.2 -> 4.5.3 -> 4.5.4)
  - [PR 24](https://github.com/sot/hopper/pull/24) (Javier Gonzalez): Fix PytestReturnNotNoneWarning
- **jobwatch:** 0.10.0 -> 0.10.1 (0.10.0 -> 0.10.1)
- **kadi:** 7.1.0 -> 7.3.0 (7.1.0 -> 7.2.0 -> 7.2.1 -> 7.2.2 -> 7.3.0)
  - [PR 262](https://github.com/sot/kadi/pull/262) (Tom Aldcroft): Remove WARNING in logging text
  - [PR 263](https://github.com/sot/kadi/pull/263) (Tom Aldcroft): Explicit complete_intervals=True in logical intervals + code tidy
  - [PR 264](https://github.com/sot/kadi/pull/264) (Tom Aldcroft): Add `type` field to Dump event class and update docs and process notes
  - [PR 265](https://github.com/sot/kadi/pull/265) (Tom Aldcroft): Fix issue with cmd query around 30 days before current time
  - [PR 261](https://github.com/sot/kadi/pull/261) (Tom Aldcroft): Validate kadi states
  - [PR 267](https://github.com/sot/kadi/pull/267) (Tom Aldcroft): Fix event maintenance docs
  - [PR 273](https://github.com/sot/kadi/pull/273) (Tom Aldcroft): Remove a testing workaround
  - [PR 275](https://github.com/sot/kadi/pull/275) (Javier Gonzalez): Time units
  - [PR 277](https://github.com/sot/kadi/pull/277) (Tom Aldcroft): Fix issue always logging about NSM during maneuver
  - [PR 281](https://github.com/sot/kadi/pull/281) (James Kristoff): HRC state updates for 24V, 15V (from SCS-134), HRC_I and HRC_S
- **kalman_watch:** 0.1.0 -> 0.2.0 (0.1.0 -> 0.2.0)
  - [PR 8](https://github.com/sot/kalman_watch/pull/8) (Tom Aldcroft): Remove maude from fetch data source
  - [PR 9](https://github.com/sot/kalman_watch/pull/9) (Tom Aldcroft): Use explicit complete_intervals=True in low_kalman_mon
- **maude:** 3.10.4 -> 3.11.1 (3.10.4 -> 3.11.0 -> 3.11.1)
  - [PR 44](https://github.com/sot/maude/pull/44) (Tom Aldcroft): Allow caching requests to the MAUDE server
- **mica:** 4.31.0 -> 4.31.3 (4.31.0 -> 4.31.2 -> 4.31.3)
  - [PR 281](https://github.com/sot/mica/pull/281) (Tom Aldcroft): Fix FITS unit warning
  - [PR 282](https://github.com/sot/mica/pull/282) (Javier Gonzalez): fix TimeDeltaMissingUnitWarning
- **perigee_health_plots:** 0.3.1 -> 0.3.2 (0.3.1 -> 0.3.2)
- **proseco:** 5.8.0 -> 5.8.1 (5.8.0 -> 5.8.1)
  - [PR 380](https://github.com/sot/proseco/pull/380) (Javier Gonzalez): Get rid of pytest.warns deprecation warning
- **ska3-core:** 2022.6 -> 2023.1
- **ska_helpers:** 0.6.1 -> 0.8.0 (0.6.1 -> 0.7.0 -> 0.7.1 -> 0.8.0)
  - [PR 26](https://github.com/sot/ska_helpers/pull/26) (Jean Connelly): Add setup_helper.py with duplicate_package_info
  - [PR 27](https://github.com/sot/ska_helpers/pull/27) (Tom Aldcroft): Apply black and isort and add flake8 checking
  - [PR 28](https://github.com/sot/ska_helpers/pull/28) (Tom Aldcroft): Improve get_version debug output and fully test functionality
  - [PR 30](https://github.com/sot/ska_helpers/pull/30) (Tom Aldcroft): Add `paths` module for global path definitions
  - [PR 32](https://github.com/sot/ska_helpers/pull/32) (Tom Aldcroft): Add support for reading chandra_models data
  - [PR 31](https://github.com/sot/ska_helpers/pull/31) (Tom Aldcroft): Add propagate=False opt to basic_logger()
- **ska_sync:** 4.10.0 -> 4.10.1 (4.10.0 -> 4.10.1)
- **skare3_tools:** 1.0.8 -> 1.0.9 (1.0.8 -> 1.0.9)
  - [PR 91](https://github.com/sot/skare3_tools/pull/91) (Javier Gonzalez): black
  - [PR 92](https://github.com/sot/skare3_tools/pull/92) (Javier Gonzalez): Update docker image to use testr and ska_helpers
- **starcheck:** 13.17.0 -> 14.0.2 (13.17.0 -> 14.0.0 -> 14.0.1 -> 14.0.2)
  - [PR 397](https://github.com/sot/starcheck/pull/397) (Jean Connelly): Allow using maude for thermal model source data
  - [PR 383](https://github.com/sot/starcheck/pull/383) (Jean Connelly): Add 16 arcsec to 'standard' dither in y and z
  - [PR 402](https://github.com/sot/starcheck/pull/402) (Tom Aldcroft): Replace Inline::Python with a light Python function server
  - [PR 404](https://github.com/sot/starcheck/pull/404) (Jean Connelly): Save and return exit status at END
- **testr:** 4.11.1 -> 4.11.3 (4.11.1 -> 4.11.2 -> 4.11.3)
  - [PR 47](https://github.com/sot/testr/pull/47) (Javier Gonzalez): Remove PYTEST_IGNORE_WARNINGS from runner and use pytest.ini instead
  - [PR 49](https://github.com/sot/testr/pull/49) (Javier Gonzalez): remove PYTEST_IGNORE_WARNINGS from setup_helper
- **xija:** 4.29.1 -> 4.29.3 (4.29.1 -> 4.29.2 -> 4.29.3)
  - [PR 132](https://github.com/sot/xija/pull/132) (Jean Connelly): Update location of chandra_models readme
 
# Related Issues

Fixes #1087 
Fixes #1083 