### PR TITLE
2023.4

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - chandra_cmd_states ==4.0.0
     - chandra_maneuver ==4.0.0
     - chandra_time ==4.1.1
-    - chandra_aca ==4.39.0
+    - chandra_aca ==4.40.0
     - cheta ==4.59.0
     - cxotime ==3.5.0
     - find_attitude ==3.4.3

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - ska_tdb ==4.0.0
     - ska3-core ==2023.1
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.9.0
+    - ska_helpers ==0.9.1
     - ska_path ==3.1.2
     - ska_sync ==4.10.1
     - skare3_tools ==1.0.9

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - ska_path ==3.1.2
     - ska_sync ==4.10.1
     - skare3_tools ==1.0.9
-    - sparkles ==4.22.0
+    - sparkles ==4.22.1
     - starcheck ==14.0.3
     - testr ==4.11.3
     - xija ==4.30.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2023.2
+  version: 2023.4
 
 build:
   noarch: generic
@@ -10,31 +10,31 @@ requirements:
   run:
     - aca_hi_bgd ==0.1.7
     - aca_view ==0.12.0
-    - aca_weekly_report ==0.1.7
-    - acdc ==4.9.1
+    - aca_weekly_report ==0.2.0
+    - acdc ==4.10.0
     - acis_taco ==4.2.3
     - acis_thermal_check ==4.6.0
     - acispy ==2.5.0
-    - agasc ==4.14.1
-    - aimpoint_mon ==1.1.1
+    - agasc ==4.15.0
+    - aimpoint_mon ==1.1.2
     - astromon ==1.1.1
     - annie ==0.11.2
     - backstop_history ==3.1.1
     - chandra_cmd_states ==4.0.0
     - chandra_maneuver ==4.0.0
-    - chandra_time ==4.1.1
-    - chandra_aca ==4.38.3
-    - cheta ==4.58.0
-    - cxotime ==3.4.0
+    - chandra_time ==4.1.2
+    - chandra_aca ==4.39.0
+    - cheta ==4.59.0
+    - cxotime ==3.5.0
     - find_attitude ==3.4.3
     - fot-matlab ==2.2.0
     - hopper ==4.5.4
     - jobwatch ==0.10.1
-    - kadi ==7.3.0
+    - kadi ==7.4.0
     - kalman_watch ==0.2.0
     - maude ==3.11.1
-    - mica ==4.31.3
-    - parse_cm ==3.9.1
+    - mica ==4.32.0
+    - parse_cm ==3.10.0
     - perigee_health_plots ==0.3.2
     - proseco ==5.8.1
     - pyyaks ==4.5.0
@@ -51,15 +51,15 @@ requirements:
     - ska_quatutil ==4.0.0
     - ska_report_ranges ==0.5.0
     - ska_shell ==4.0.0
-    - ska_sun ==3.9.1
+    - ska_sun ==3.10.0
     - ska_tdb ==4.0.0
     - ska3-core ==2023.1
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.8.0
+    - ska_helpers ==0.9.0
     - ska_path ==3.1.2
     - ska_sync ==4.10.1
     - skare3_tools ==1.0.9
-    - sparkles ==4.21.0
-    - starcheck ==14.0.2
+    - sparkles ==4.22.0
+    - starcheck ==14.0.3
     - testr ==4.11.3
-    - xija ==4.29.3
+    - xija ==4.30.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - backstop_history ==3.1.1
     - chandra_cmd_states ==4.0.0
     - chandra_maneuver ==4.0.0
-    - chandra_time ==4.1.2
+    - chandra_time ==4.1.1
     - chandra_aca ==4.39.0
     - cheta ==4.59.0
     - cxotime ==3.5.0


### PR DESCRIPTION
# ska3-matlab 2023.4

This PR includes:
- chandra_aca:
  - Read grid acq probability model data from chandra_models repo
  - Allow for glob specification of acq prob model
- agasc supplement processing: use kadi commands v2
- cheta:
  - Enable use of MAUDE with computed quaternion pseudo-MSID
  - Improve pitch/roll_comp, logical_intervals, state_intervals, get_ofp_states, get_telem_table
- remove use of deprecated `timelines` package in several packages

## Interface Impacts:

Data that needs to be updated after promotion:
- agasc `rc/*.fits` files (unless ska3-flight 2023.3 is promoted first)

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.4rc3-HEAD/)
- [OS-X](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.4rc3-OSX/)
- [Windows](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.4rc3-Windows/)

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2023.4rc6 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2023.4rc6
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2023.4 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2023.2 -> 2023.4rc6)

### Updated Packages

- **aca_weekly_report:** 0.1.7 -> 0.2.0 (0.1.7 -> 0.2.0)
  - [PR 12](https://github.com/sot/aca_weekly_report/pull/12) (Jean Connelly): Fix warning for obsid 0 at 2023:044
  - [PR 11](https://github.com/sot/aca_weekly_report/pull/11) (Tom Aldcroft): Remove timelines dependency
- **acdc:** 4.9.1 -> 4.10.0 (4.9.1 -> 4.10.0)
  - [PR 69](https://github.com/sot/acdc/pull/69) (Jean Connelly): Add a dark current caldb process
- **agasc:** 4.14.1 -> 4.15.0 (4.14.1 -> 4.15.0)
  - [PR 135](https://github.com/sot/agasc/pull/135) (Javier Gonzalez): Use commands v2 for AGASC supplement update
  - [PR 151](https://github.com/sot/agasc/pull/151) (Javier Gonzalez): Fix process failures
- **aimpoint_mon:** 1.1.1 -> 1.1.2 (1.1.1 -> 1.1.2)
  - [PR 25](https://github.com/sot/aimpoint_mon/pull/25) (Tom Aldcroft): Fix some residual issues in the Py3 implementation
- **chandra_aca:** 4.38.3 -> 4.40.0 (4.38.3 -> 4.39.0 ->  -> 4.40.0)
  - [PR 140](https://github.com/sot/chandra_aca/pull/140) (Tom Aldcroft): Read grid acq probability model data from in chandra models repo
  - [PR 144](https://github.com/sot/chandra_aca/pull/144) (Javier Gonzalez): Fix maude_decom.get_raw_aca_packets
  - [PR 145](https://github.com/sot/chandra_aca/pull/145) (Javier Gonzalez): Update pre-commit config and flake workflow
  - [PR 147](https://github.com/sot/chandra_aca/pull/147) (Javier Gonzalez): renamed BGDTYP/PIXTLM to AABGDTYP/AAPIXTLM
  - [PR 149](https://github.com/sot/chandra_aca/pull/149) (Tom Aldcroft): Allow for glob specification of acq prob model + documentation overhaul
  - [PR 148](https://github.com/sot/chandra_aca/pull/148) (Javier Gonzalez): Prevent crash when IMGTYPE==3 when using blobs
- **cheta:** 4.58.0 -> 4.59.0 (4.58.0 -> 4.59.0)
  - [PR 248](https://github.com/sot/cheta/pull/248) (Tom Aldcroft): Add overwrite=True to cheta sync index table write statement
  - [PR 246](https://github.com/sot/cheta/pull/246) (Tom Aldcroft): Enable use of MAUDE with computed quaternion pseudo-MSID
  - [PR 249](https://github.com/sot/cheta/pull/249) (Tom Aldcroft): Improve pitch/roll_comp, logical_intervals, state_intervals, get_ofp_states, get_telem_table
  - [PR 251](https://github.com/sot/cheta/pull/251) (Tom Aldcroft): Fix misleading doc string
- **cxotime:** 3.4.0 -> 3.5.0 (3.4.0 -> 3.5.0)
  - [PR 37](https://github.com/sot/cxotime/pull/37) (Tom Aldcroft): Update pre-commit yaml to make it work again
  - [PR 34](https://github.com/sot/cxotime/pull/34) (Tom Aldcroft): Remove CxoTime custom fast parser, use astropy built-in
  - [PR 36](https://github.com/sot/cxotime/pull/36) (Tom Aldcroft): Improve time conversion helpers
- **kadi:** 7.3.0 -> 7.4.0 (7.3.0 -> 7.4.0)
  - [PR 269](https://github.com/sot/kadi/pull/269) (Tom Aldcroft): Add task_schedule_validate.cfg
  - [PR 282](https://github.com/sot/kadi/pull/282) (Tom Aldcroft): pre-commit autoupdate
  - [PR 284](https://github.com/sot/kadi/pull/284) (Tom Aldcroft): Ensure that timezone TZ env var is unmodified by `django.setup()`
  - [PR 285](https://github.com/sot/kadi/pull/285) (Tom Aldcroft): Factor out `get_ofp_states` and `get_telem_values` for cheta #249 improvements
- **mica:** 4.31.3 -> 4.32.0 (4.31.3 -> 4.32.0)
  - [PR 279](https://github.com/sot/mica/pull/279) (Tom Aldcroft): Remove timelines / cmd_states.db3 from mica
- **parse_cm:** 3.9.1 -> 3.10.0 (3.9.1 -> 3.10.0)
  - [PR 39](https://github.com/sot/parse_cm/pull/39) (John ZuHone): Routine to read the ACIS tables
- **ska_helpers:** 0.8.0 -> 0.9.1 (0.8.0 -> 0.9.0 ->  -> 0.9.1)
  - [PR 29](https://github.com/sot/ska_helpers/pull/29) (Tom Aldcroft): Add environment module with new function configure_ska_environment()
  - [PR 33](https://github.com/sot/ska_helpers/pull/33) (Tom Aldcroft): Add support for two new environment variables for `chandra_models` defaults
  - [PR 34](https://github.com/sot/ska_helpers/pull/34) (Tom Aldcroft): Fixes to get chandra_models and paths working on Windows
- **ska_sun:** 3.9.1 -> 3.10.0 (3.9.1 -> 3.10.0)
  - [PR 28](https://github.com/sot/ska_sun/pull/28) (Tom Aldcroft): Fix a test fail from numerical issues
  - [PR 27](https://github.com/sot/ska_sun/pull/27) (Tom Aldcroft): Change allowed_rolldev to use chandra_models
  - [PR 31](https://github.com/sot/ska_sun/pull/31) (Tom Aldcroft): Update for new ska_helpers.chandra_models
- **sparkles:** 4.21.0 -> 4.22.1 (4.21.0 -> 4.22.1)
  - [PR 182](https://github.com/sot/sparkles/pull/182) (Jean Connelly): Use creep-away to downgrade guide count and cluster critical warns
  - [PR 183](https://github.com/sot/sparkles/pull/183) (Jean Connelly): Check for 4x4 dither for 3.5 to 4.0 guide_count
  - [PR 185](https://github.com/sot/sparkles/pull/185) (Jean Connelly): Handle updated pitch roll table in roll optimizations
  - [PR 186](https://github.com/sot/sparkles/pull/186) (Tom Aldcroft): Fix pickling
  - [PR 187](https://github.com/sot/sparkles/pull/187) (Tom Aldcroft): Apply black formatting and add config files
  - [PR 192](https://github.com/sot/sparkles/pull/192) (Tom Aldcroft): Fix issue computing t_ccds_bonus and refactor into function
  - [PR 188](https://github.com/sot/sparkles/pull/188) (Tom Aldcroft): Add linting with ruff and add workflow for black + ruff
  - [PR 189](https://github.com/sot/sparkles/pull/189) (Jean Connelly): Add dyn-bgd-n-faint option for review
- **starcheck:** 14.0.2 -> 14.0.3 (14.0.2 -> 14.0.3)
  - [PR 405](https://github.com/sot/starcheck/pull/405) (Tom Aldcroft): Apply perltidy to starcheck
- **xija:** 4.29.3 -> 4.30.0 (4.29.3 -> 4.30.0)
  - [PR 133](https://github.com/sot/xija/pull/133) (Tom Aldcroft): Use ska_helpers.paths for model paths
  - [PR 124](https://github.com/sot/xija/pull/124) (Tom Aldcroft): Apply black and isort formatting and modernize config files
  
# Related Issues

Fixes #1107
