### PR TITLE
2023.5

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2023.1
+  version: 2023.5
 
 requirements:
   run:
@@ -16,7 +16,7 @@ requirements:
     - argon2-cffi-bindings ==21.2.0
     - asgiref ==3.3.4
     - astroid ==2.13.2
-    - astropy ==5.2.1
+    - astropy ==5.3.1
     - astropy-healpix ==0.7
     - astropy-sphinx-theme ==1.1
     - astroquery ==0.4.6
@@ -176,7 +176,7 @@ requirements:
     - libclang13 ==15.0.7  # [linux or win]
     - libcups ==2.3.3  # [linux]
     - libcurl ==7.88.1
-    - libcxx ==14.0.6  # [osx]
+    - libcxx ==16.0.4  # [osx]
     - libdb ==6.2.32  # [linux]
     - libdeflate ==1.17
     - libedit ==3.1.20191231  # [linux or osx]

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2023.5
+  version: 2023.1
 
 requirements:
   run:
@@ -16,7 +16,7 @@ requirements:
     - argon2-cffi-bindings ==21.2.0
     - asgiref ==3.3.4
     - astroid ==2.13.2
-    - astropy ==5.3.1
+    - astropy ==5.2.1
     - astropy-healpix ==0.7
     - astropy-sphinx-theme ==1.1
     - astroquery ==0.4.6
@@ -176,7 +176,7 @@ requirements:
     - libclang13 ==15.0.7  # [linux or win]
     - libcups ==2.3.3  # [linux]
     - libcurl ==7.88.1
-    - libcxx ==16.0.4  # [osx]
+    - libcxx ==14.0.6  # [osx]
     - libdb ==6.2.32  # [linux]
     - libdeflate ==1.17
     - libedit ==3.1.20191231  # [linux or osx]

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - ska_shell ==4.0.1
     - ska_sun ==3.10.1
     - ska_tdb ==4.0.0
-    - ska3-core ==2023.3
+    - ska3-core ==2023.5
     - ska3-template ==2022.06.02
     - ska_helpers ==0.10.2
     - ska_path ==3.1.2

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -53,7 +53,7 @@ requirements:
     - ska_shell ==4.0.1
     - ska_sun ==3.10.1
     - ska_tdb ==4.0.0
-    - ska3-core ==2023.5
+    - ska3-core ==2023.1
     - ska3-template ==2022.06.02
     - ska_helpers ==0.10.2
     - ska_path ==3.1.2

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2023.4
+  version: 2023.5
 
 build:
   noarch: generic
@@ -11,7 +11,7 @@ requirements:
     - aca_hi_bgd ==0.1.7
     - aca_view ==0.12.0
     - aca_weekly_report ==0.2.0
-    - acdc ==4.10.0
+    - acdc ==4.10.1
     - acis_taco ==4.2.3
     - acis_thermal_check ==4.6.0
     - acispy ==2.5.0
@@ -19,24 +19,24 @@ requirements:
     - aimpoint_mon ==1.1.2
     - astromon ==1.1.1
     - annie ==0.11.2
-    - backstop_history ==3.1.1
+    - backstop_history ==3.2.1
     - chandra_cmd_states ==4.0.0
     - chandra_maneuver ==4.0.0
-    - chandra_time ==4.1.1
-    - chandra_aca ==4.40.0
+    - chandra_time ==4.1.2
+    - chandra_aca ==4.41.0
     - cheta ==4.59.0
-    - cxotime ==3.5.0
+    - cxotime ==3.6.0
     - find_attitude ==3.4.3
     - fot-matlab ==2.2.0
     - hopper ==4.5.4
     - jobwatch ==0.10.1
-    - kadi ==7.4.0
+    - kadi ==7.4.1
     - kalman_watch ==0.2.0
     - maude ==3.11.1
-    - mica ==4.32.0
+    - mica ==4.33.0
     - parse_cm ==3.10.0
     - perigee_health_plots ==0.3.2
-    - proseco ==5.8.1
+    - proseco ==5.9.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.1
     - ska-sphinx-theme ==1.3.0
@@ -45,21 +45,21 @@ requirements:
     - ska_dbi ==5.0.0
     - ska_file ==4.0.0
     - ska_ftp ==4.0.0
-    - ska_matplotlib ==4.0.0
+    - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.0
     - ska_quatutil ==4.0.0
     - ska_report_ranges ==0.5.0
-    - ska_shell ==4.0.0
-    - ska_sun ==3.10.0
+    - ska_shell ==4.0.1
+    - ska_sun ==3.10.1
     - ska_tdb ==4.0.0
-    - ska3-core ==2023.1
+    - ska3-core ==2023.3
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.9.1
+    - ska_helpers ==0.10.2
     - ska_path ==3.1.2
     - ska_sync ==4.10.1
-    - skare3_tools ==1.0.9
-    - sparkles ==4.22.1
-    - starcheck ==14.0.3
+    - skare3_tools ==1.0.10
+    - sparkles ==4.22.2
+    - starcheck ==14.1.0
     - testr ==4.11.3
     - xija ==4.30.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - ska_tdb ==4.0.0
     - ska3-core ==2023.1
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.10.2
+    - ska_helpers ==0.10.3
     - ska_path ==3.1.2
     - ska_sync ==4.10.1
     - skare3_tools ==1.0.10


### PR DESCRIPTION
# ska3-matlab2023.5

This PR includes small incremental changes to Ska python packages, including changes to test, ACA regular processing, and small performance improvements. Most changes are not relevant on the matlab side, but these might be worth mentioning:

- cxotime: Add generic fast format converters for better performance
- starcheck:
   - Calculate maneuver times and angle from cmds, replace maneuver summary file
   - Ignore mag clipping chandra_aca warnings
   - Update for expanded high-IR zone
   - Use dyn_bgd_n_faint = 2
   - Use ccd_temp instead of t_ccd from dark cal data

## Interface Impacts:

None.

## Testing:

- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.5rc5-GRETA/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2023.5rc5 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2023.5rc5
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2023.5 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2023.4 -> 2023.5rc5)

### Updated Packages

- **acdc:** 4.10.0 -> 4.10.1 (4.10.0 -> 4.10.1)
  - [PR 73](https://github.com/sot/acdc/pull/73) (Tom Aldcroft): Improve error message for not enough quads
- **backstop_history:** 3.1.1 -> 3.2.1 (3.1.1 -> 3.2.1)
  - [PR 25](https://github.com/acisops/backstop_history/pull/25) (None): Incorporation of new RTS files for new Long Term ECS SI modes
- **chandra_aca:** 4.40.0 -> 4.41.0 (4.40.0 -> 4.41.0)
  - [PR 151](https://github.com/sot/chandra_aca/pull/151) (Tom Aldcroft): Add function to get default acq prob model info
  - [PR 150](https://github.com/sot/chandra_aca/pull/150) (Tom Aldcroft): Use chandra_models_cache for caching not lru_cache
- **chandra_time:** 4.1.1 -> 4.1.2 (4.1.1 -> 4.1.2)
  - [PR 58](https://github.com/sot/chandra_time/pull/58) (Tom Aldcroft): Use chandra_time modules for Chandra.Time
- **cxotime:** 3.5.0 -> 3.6.0 (3.5.0 -> 3.6.0)
  - [PR 38](https://github.com/sot/cxotime/pull/38) (Javier Gonzalez): Fix test on Windows
  - [PR 33](https://github.com/sot/cxotime/pull/33) (Tom Aldcroft): Add generic fast format converters for better performance
- **kadi:** 7.4.0 -> 7.4.1 (7.4.0 -> 7.4.1)
  - [PR 286](https://github.com/sot/kadi/pull/286) (Javier Gonzalez): fix test on windows
  - [PR 288](https://github.com/sot/kadi/pull/288) (Jean Connelly): Compare regression test quaternions with delta-quat tolerance check
  - [PR 287](https://github.com/sot/kadi/pull/287) (Tom Aldcroft): Improve error message for stale local commands archive
- **mica:** 4.32.0 -> 4.33.0 (4.32.0 -> 4.33.0)
  - [PR 283](https://github.com/sot/mica/pull/283) (Jean Connelly): Update CDA code and tests for DS10.12
- **proseco:** 5.8.1 -> 5.9.0 (5.8.1 -> 5.9.0)
  - [PR 381](https://github.com/sot/proseco/pull/381) (Jean Connelly): Pin chandra_models version to 3.48 for all tests
  - [PR 382](https://github.com/sot/proseco/pull/382) (Tom Aldcroft): Add acq prob model info dict as a new pickled attribute
- **ska_helpers:** 0.9.1 -> 0.10.3 (0.9.1 -> 0.10.0 -> 0.10.2 -> 0.10.3)
  - [PR 35](https://github.com/sot/ska_helpers/pull/35) (Tom Aldcroft): Add git_helpers.py w/ function for safe directory handling
  - [PR 36](https://github.com/sot/ska_helpers/pull/36) (Tom Aldcroft): Chandra models caching and a generic LRUDict class (evict least recently used entries)
  - [PR 37](https://github.com/sot/ska_helpers/pull/37) (Jean Connelly): Add the repo dir to safe config if used directly
  - [PR 38](https://github.com/sot/ska_helpers/pull/38) (Tom Aldcroft): Remove the check on repo tip being at the latest tag
  - [PR 39](https://github.com/sot/ska_helpers/pull/39) (Javier Gonzalez): clear git_helpers.make_git_repo_safe cache in test
  - [PR 41](https://github.com/sot/ska_helpers/pull/41) (Jean Connelly): Remove auto git repo safe handling
- **ska_matplotlib:** 4.0.0 -> 4.0.1 (4.0.0 -> 4.0.1)
  - [PR 28](https://github.com/sot/ska_matplotlib/pull/28) (Jean Connelly): Add a note to cxctime2plotdate about CxoTime
- **ska_shell:** 4.0.0 -> 4.0.1 (4.0.0 -> 4.0.1)
  - [PR 28](https://github.com/sot/ska_shell/pull/28) (Jean Connelly): Rename test setup() setup_method()
- **ska_sun:** 3.10.0 -> 3.10.1 (3.10.0 -> 3.10.1)
  - [PR 32](https://github.com/sot/ska_sun/pull/32) (Tom Aldcroft): Allow repeated pitch vals and make unit tests work after chandra_models updates
- **skare3_tools:** 1.0.9 -> 1.0.10 (1.0.9 -> 1.0.10)
  - [PR 95](https://github.com/sot/skare3_tools/pull/95) (Javier Gonzalez): Remove use of --tags option to git
  - [PR 94](https://github.com/sot/skare3_tools/pull/94) (Javier Gonzalez): Fixes and improvements in Ska dashboard
- **sparkles:** 4.22.1 -> 4.22.2 (4.22.1 -> 4.22.2)
  - [PR 194](https://github.com/sot/sparkles/pull/194) (Jean Connelly): Pin chandra_models version to 3.48 for tests
- **starcheck:** 14.0.3 -> 14.1.0 (14.0.3 -> 14.1.0)
  - [PR 408](https://github.com/sot/starcheck/pull/408) (Jean Connelly): Calculate maneuver times and angle from cmds, replace maneuver summary file
  - [PR 416](https://github.com/sot/starcheck/pull/416) (Jean Connelly): Ignore mag clipping chandra_aca warnings
  - [PR 413](https://github.com/sot/starcheck/pull/413) (Jean Connelly): Update for expanded high-IR zone 
  - [PR 418](https://github.com/sot/starcheck/pull/418) (Jean Connelly): Add a unit test for dyn bgd hotpix imposter calc
  - [PR 412](https://github.com/sot/starcheck/pull/412) (Jean Connelly): Use dyn_bgd_n_faint = 2 
  - [PR 419](https://github.com/sot/starcheck/pull/419) (Jean Connelly): Use ccd_temp instead of t_ccd from dark cal data

# Related Issues

Fixes #1131