### PR TITLE
Update default ska_builder python and numpy versions

### DIFF
--- a/ska_builder.py
+++ b/ska_builder.py
@@ -47,8 +47,8 @@ def get_opt():
                         action="store_true",
                         help="Build only architecture-specific packages")
     parser.add_argument("--python",
-                        default="3.8",
-                        help="Target version of Python (default=3.8)")
+                        default="3.10",
+                        help="Target version of Python (default=3.10)")
     parser.add_argument("--perl",
                         default="5.26.2",
                         help="Target version of Perl (default=5.26.2)")

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -53,7 +53,7 @@ def get_opt():
                         default="5.26.2",
                         help="Target version of Perl (default=5.26.2)")
     parser.add_argument("--numpy",
-                        default="1.18",
+                        default="1.21",
                         help="Build version of NumPy")
     parser.add_argument("--github-https", action="store_true", default=False,
                         help="Authenticate using basic auth and https. Default is ssh "


### PR DESCRIPTION
Update default ska_builder python to 3.10 and numpy to 1.21

I think this is only used when building manually.