### PR TITLE
2023.6

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2023.5
+  version: 2023.6
 
 build:
   noarch: generic
@@ -27,16 +27,16 @@ requirements:
     - cheta ==4.59.0
     - cxotime ==3.6.0
     - find_attitude ==3.4.3
-    - fot-matlab ==2.2.0
+    - fot-matlab ==2.3.0
     - hopper ==4.5.4
     - jobwatch ==0.10.1
-    - kadi ==7.4.1
+    - kadi ==7.5.0
     - kalman_watch ==0.2.0
     - maude ==3.11.1
     - mica ==4.33.0
-    - parse_cm ==3.10.0
+    - parse_cm ==3.11.0
     - perigee_health_plots ==0.3.2
-    - proseco ==5.9.0
+    - proseco ==5.10.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.1
     - ska-sphinx-theme ==1.3.0
@@ -53,13 +53,13 @@ requirements:
     - ska_shell ==4.0.1
     - ska_sun ==3.10.1
     - ska_tdb ==4.0.0
-    - ska3-core ==2023.1
+    - ska3-core ==2023.3
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.10.3
+    - ska_helpers ==0.11.0
     - ska_path ==3.1.2
-    - ska_sync ==4.10.1
+    - ska_sync ==4.11.0
     - skare3_tools ==1.0.10
-    - sparkles ==4.22.2
-    - starcheck ==14.1.0
-    - testr ==4.11.3
-    - xija ==4.30.0
+    - sparkles ==4.23.0
+    - starcheck ==14.3.0
+    - testr ==4.12.0
+    - xija ==4.31.0


### PR DESCRIPTION
# ska3-matlab 2023.6

This PR includes:
- Changes in proseco and sparkles to make ACA penalty limit optional
- A fix to ska_helpers so it won't modify the git index in the chandra_models repo -- this was causing fot tools SVN to warn/complain
- Some improvements to the `testr` module to make it possible to run Python unit tests from Matlab / pyexec
- Small updates to improve chandra_models access, including a change to xija so it will use ska_helpers.chandra_models -- the consequence of this is that xija thermal model access will respect the CHANDRA_MODELS_DIR and CHANDRA_MODELS_DEFAULT_VERSION environment variables.

## Interface Impacts:

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.6rc1-HEAD).
- [Windows](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.6rc1-Windows).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.6rc1-OSX).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2023.6rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2023.6rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2023.6 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2023.5 -> 2023.6rc1)

### Updated Packages

- **fot-matlab:** 2.2.0 -> 2.3.0 (2.2.0 -> 2.3.0)
  - [PR 21](https://github.com/sot/fot-matlab/pull/21) (James Kristoff): MATLAB-12004 - parallelize star acquisition
  - [PR 22](https://github.com/sot/fot-matlab/pull/22) (James Kristoff): parallelized aca results
  - [PR 23](https://github.com/sot/fot-matlab/pull/23) (James Kristoff): fixing call args for single catalog acq path.
  - [PR 24](https://github.com/sot/fot-matlab/pull/24) (James Kristoff): MATLAB-12001 - SIM position states and plot do not agree with each other
- **kadi:** 7.4.1 -> 7.5.0 (7.4.1 -> 7.5.0)
  - [PR 292](https://github.com/sot/kadi/pull/292) (Tom Aldcroft): Add validator for sun position monitor
- **parse_cm:** 3.10.0 -> 3.11.0 (3.10.0 -> 3.11.0)
  - [PR 41](https://github.com/sot/parse_cm/pull/41) (John ZuHone): Only use local paths for fetching the ACIS tables
- **proseco:** 5.9.0 -> 5.10.0 (5.9.0 -> 5.10.0)
  - [PR 384](https://github.com/sot/proseco/pull/384) (Tom Aldcroft): Make ACA penalty limit optional
  - [PR 385](https://github.com/sot/proseco/pull/385) (Tom Aldcroft): Add test of optional ACA limits
  - [PR 386](https://github.com/sot/proseco/pull/386) (Tom Aldcroft): Improve implementation of characteristics from ACA xija model
- **ska3-core:** 2023.1 -> 2023.3
- **ska_helpers:** 0.10.3 -> 0.11.0 (0.10.3 -> 0.10.4 -> 0.11.0)
  - [PR 42](https://github.com/sot/ska_helpers/pull/42) (Jean Connelly): Replace git_helpers subprocess with gitpython and revert [#41](https://github.com/sot/ska_helpers/pull/41)
  - [PR 46](https://github.com/sot/ska_helpers/pull/46) (Jean Connelly): Remove extra repo from git config command
  - [PR 45](https://github.com/sot/ska_helpers/pull/45) (Jean Connelly): Skip git safe test on old git
  - [PR 48](https://github.com/sot/ska_helpers/pull/48) (Jean Connelly): Skip is_dirty check from matlab tools
- **ska_sync:** 4.10.1 -> 4.11.0 (4.10.1 -> 4.11.0)
  - [PR 32](https://github.com/sot/ska_sync/pull/32) (John ZuHone): Sync ACIS tables
- **sparkles:** 4.22.2 -> 4.23.0 (4.22.2 -> 4.23.0)
  - [PR 195](https://github.com/sot/sparkles/pull/195) (Jean Connelly): Update to use more test fixtures
  - [PR 193](https://github.com/sot/sparkles/pull/193) (Jean Connelly): With dyn_bgd_n_faint option, override it in the GuideTable too
  - [PR 196](https://github.com/sot/sparkles/pull/196) (Jean Connelly): Do not use aca_t_ccd_penalty_limit via import
- **starcheck:** 14.1.0 -> 14.3.0 (14.1.0 -> 14.2.1 -> 14.3.0)
  - [PR 411](https://github.com/sot/starcheck/pull/411) (Jean Connelly): Set plot ymin relative to planning not penalty limit
  - [PR 420](https://github.com/sot/starcheck/pull/420) (Jean Connelly): Downgrade bad guide data warning
  - [PR 423](https://github.com/sot/starcheck/pull/423) (Jean Connelly): Handle vehicle mode with custom filtered backstop (was PR 421)
  - [PR 429](https://github.com/sot/starcheck/pull/429) (Jean Connelly): Work with optional penalty limit in model spec
  - [PR 425](https://github.com/sot/starcheck/pull/425) (Jean Connelly): Planning t_ccd critical warning
- **testr:** 4.11.3 -> 4.12.0 (4.11.3 -> 4.12.0)
  - [PR 50](https://github.com/sot/testr/pull/50) (Jean Connelly): Add handling for missing isatty attr on stdout
  - [PR 51](https://github.com/sot/testr/pull/51) (Jean Connelly): Handle StdOutWrapper class with context manager
- **xija:** 4.30.0 -> 4.31.0 (4.30.0 -> 4.31.0)
  - [PR 134](https://github.com/sot/xija/pull/134) (Tom Aldcroft): Refactor get_model_spec to use ska_helpers.chandra_models


# Related Issues
Fixes #1155
Fixes #1157
Fixes #1158
Fixes #1159
Fixes #1160
Fixes #1161
Fixes #1162
Fixes #1163
Fixes #1164
Fixes #1165
Fixes #1167
Fixes #1169

