### PR TITLE
Add simple meta/recipe for chandra_limits

### DIFF
--- a/pkg_defs/chandra_limits/meta.yaml
+++ b/pkg_defs/chandra_limits/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: chandra_limits
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/chandra_limits
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - python
+    - setuptools
+    - setuptools_scm
+    - setuptools_scm_git_archive
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - numpy
+    - pytest
+    - testr
+    - ska_helpers
+
+
+test:
+  imports:
+    - chandra_limits
+
+
+about:
+  home: https://github.com/sot/chandra_limits
+


### PR DESCRIPTION
Add simple meta/recipe for chandra_limits.  

I figured this could be tested with https://github.com/sot/chandra_limits/pull/1 , though I have not done so.  And https://github.com/sot/chandra_limits/pull/1 would still need the workflows for the actions for this to do something on merge.