### PR TITLE
Remove bs4 from twiki-wg meta recipe

### DIFF
--- a/pkg_defs/twiki-wg/meta.yaml
+++ b/pkg_defs/twiki-wg/meta.yaml
@@ -23,7 +23,6 @@ requirements:
   # will be installed automatically whenever the package is installed.
   run:
     - python
-    - bs4
     - requests
     - ska_ftp
     - cxotime


### PR DESCRIPTION
Remove bs4 from twiki-wg meta recipe

It is the wrong name for the conda package (beautifulsoup4) and we should reduce explicit conda dependencies anyway.