### PR TITLE
Update pyproject.toml to configure pylance behavior in VS code

### DIFF
--- a/templates/pyproject.toml
+++ b/templates/pyproject.toml
@@ -18,3 +18,11 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
+
+[tool.pyright]
+ignore = [
+    "**/node_modules",
+    "**/__pycache__",
+    "**/*.ipynb",
+    ".git"
+]


### PR DESCRIPTION
## Description

This might be controversial, but I often see many code warnings from pylance that come from half-baked notebooks that I'm working on within a code repo. These warnings obscure real warnings from production code. This update to `pyproject.toml` fixes that so that pylance warnings never appear for ipynb notebooks.

Annoyingly, there is a VS code setting that *should* work, but it doesn't:

<img width="717" alt="image" src="https://github.com/sot/skare3/assets/348089/c69349f8-5c0e-404e-8a40-8fe66be02dce">

This might stem from the odd difference between `exclude` and `ignore` in pyright (which is called by pylance):
https://github.com/microsoft/pyright/blob/main/docs/configuration.md#main-configuration-options

## Testing

I used this in the `agasc` repo and VS code stopped showing warnings from a notebook in my editor.