### PR TITLE
2023.7

### DIFF
--- a/pkg_defs/ska3-flight-latest/meta.yaml
+++ b/pkg_defs/ska3-flight-latest/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - backstop_history
     - chandra_aca
     - chandra_cmd_states
+    - chandra_limits
     - chandra_maneuver
     - chandra_time
     - cheta

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - agasc ==4.15.0
     - backstop_history ==3.2.1
     - chandra_cmd_states ==4.0.0
+    - chandra_limits ==0.5.0
     - chandra_maneuver ==4.0.0
     - chandra_time ==4.1.2
     - chandra_aca ==4.41.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -8,25 +8,25 @@ build:
 
 requirements:
   run:
-    - aca_view ==0.12.0
-    - acis_thermal_check ==4.6.0
+    - aca_view ==0.13.0
+    - acis_thermal_check ==4.7.0
     - acispy ==2.5.0
-    - agasc ==4.15.0
+    - agasc ==4.16.0
     - backstop_history ==3.2.1
     - chandra_cmd_states ==4.0.0
     - chandra_limits ==0.5.0
     - chandra_maneuver ==4.0.0
     - chandra_time ==4.1.2
-    - chandra_aca ==4.41.0
-    - cheta ==4.59.0
+    - chandra_aca ==4.42.0
+    - cheta ==4.60.0
     - cxotime ==3.6.0
     - find_attitude ==3.4.3
     - fot-matlab ==2.3.0
     - hopper ==4.5.4
-    - kadi ==7.5.0
+    - kadi ==7.6.0
     - maude ==3.11.1
-    - mica ==4.33.0
-    - parse_cm ==3.11.0
+    - mica ==4.33.1
+    - parse_cm ==3.12.0
     - proseco ==5.10.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.1
@@ -41,15 +41,15 @@ requirements:
     - ska_parsecm ==4.0.0
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
-    - ska_sun ==3.10.1
+    - ska_sun ==3.11.0
     - ska_tdb ==4.0.0
     - ska3-core ==2023.3
     - ska3-template ==2022.06.02
     - ska_helpers ==0.11.0
     - ska_path ==3.1.2
     - ska_sync ==4.11.0
-    - skare3_tools ==1.0.10
+    - skare3_tools ==1.1.0
     - sparkles ==4.23.0
-    - starcheck ==14.3.0
+    - starcheck ==14.4.0
     - testr ==4.12.0
     - xija ==4.31.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2023.3
+  version: 2023.7
 
 build:
   noarch: generic
@@ -20,13 +20,13 @@ requirements:
     - cheta ==4.59.0
     - cxotime ==3.6.0
     - find_attitude ==3.4.3
-    - fot-matlab ==2.2.0
+    - fot-matlab ==2.3.0
     - hopper ==4.5.4
-    - kadi ==7.4.1
+    - kadi ==7.5.0
     - maude ==3.11.1
     - mica ==4.33.0
-    - parse_cm ==3.10.0
-    - proseco ==5.9.0
+    - parse_cm ==3.11.0
+    - proseco ==5.10.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.1
     - ska-sphinx-theme ==1.3.0
@@ -44,11 +44,11 @@ requirements:
     - ska_tdb ==4.0.0
     - ska3-core ==2023.3
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.10.4
+    - ska_helpers ==0.11.0
     - ska_path ==3.1.2
-    - ska_sync ==4.10.1
+    - ska_sync ==4.11.0
     - skare3_tools ==1.0.10
-    - sparkles ==4.22.2
-    - starcheck ==14.2.1
-    - testr ==4.11.3
-    - xija ==4.30.0
+    - sparkles ==4.23.0
+    - starcheck ==14.3.0
+    - testr ==4.12.0
+    - xija ==4.31.0


### PR DESCRIPTION
# ska3-flight 2023.7

This PR includes:
- 

## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.7/).

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2023.7rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2023.7rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2023.7 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

# Related Issues

Fixes #1154 