### PR TITLE
Remove acis_taco from non-fsds package list

### DIFF
--- a/environment-non-fsds.yml
+++ b/environment-non-fsds.yml
@@ -5,7 +5,6 @@ dependencies:
   - aca_hi_bgd
   - aca_weekly_report
   - acdc
-  - acis_taco
   - aimpoint_mon
   - astromon
   - annie


### PR DESCRIPTION
Remove acis_taco from non-fsds package list

Our plan is to manage this non-fsds package list from master so this doesn't necessarily need to be in 2023.7 .