### PR TITLE
2023.8

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,41 +1,33 @@
 ---
 package:
   name: ska3-matlab
-  version: 2023.6
+  version: 2023.8
 
 build:
   noarch: generic
 
 requirements:
   run:
-    - aca_hi_bgd ==0.1.7
-    - aca_view ==0.12.0
-    - aca_weekly_report ==0.2.0
-    - acdc ==4.10.1
+    - aca_view ==0.13.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==4.6.0
+    - acis_thermal_check ==4.7.0
     - acispy ==2.5.0
-    - agasc ==4.15.0
-    - aimpoint_mon ==1.1.2
-    - astromon ==1.1.1
-    - annie ==0.11.2
+    - agasc ==4.16.0
     - backstop_history ==3.2.1
     - chandra_cmd_states ==4.0.0
+    - chandra_limits ==0.5.0
     - chandra_maneuver ==4.0.0
     - chandra_time ==4.1.2
-    - chandra_aca ==4.41.0
-    - cheta ==4.59.0
+    - chandra_aca ==4.42.0
+    - cheta ==4.60.0
     - cxotime ==3.6.0
     - find_attitude ==3.4.3
     - fot-matlab ==2.3.0
     - hopper ==4.5.4
-    - jobwatch ==0.10.1
-    - kadi ==7.5.0
-    - kalman_watch ==0.2.0
+    - kadi ==7.6.0
     - maude ==3.11.1
-    - mica ==4.33.0
-    - parse_cm ==3.11.0
-    - perigee_health_plots ==0.3.2
+    - mica ==4.33.1
+    - parse_cm ==3.12.0
     - proseco ==5.10.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.1
@@ -49,17 +41,16 @@ requirements:
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.0
     - ska_quatutil ==4.0.0
-    - ska_report_ranges ==0.5.0
     - ska_shell ==4.0.1
-    - ska_sun ==3.10.1
+    - ska_sun ==3.11.0
     - ska_tdb ==4.0.0
     - ska3-core ==2023.3
     - ska3-template ==2022.06.02
     - ska_helpers ==0.11.0
     - ska_path ==3.1.2
     - ska_sync ==4.11.0
-    - skare3_tools ==1.0.10
+    - skare3_tools ==1.1.0
     - sparkles ==4.23.0
-    - starcheck ==14.3.0
+    - starcheck ==14.4.0
     - testr ==4.12.0
     - xija ==4.31.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -12,7 +12,7 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==4.7.0
     - acispy ==2.5.0
-    - agasc ==4.16.0
+    - agasc ==4.17.0
     - backstop_history ==3.2.1
     - chandra_cmd_states ==4.0.0
     - chandra_limits ==0.5.0
@@ -20,15 +20,15 @@ requirements:
     - chandra_time ==4.1.2
     - chandra_aca ==4.42.0
     - cheta ==4.60.0
-    - cxotime ==3.6.0
+    - cxotime ==3.6.1
     - find_attitude ==3.4.3
     - fot-matlab ==2.3.0
-    - hopper ==4.5.4
+    - hopper ==4.6.0
     - kadi ==7.6.0
     - maude ==3.11.1
-    - mica ==4.33.1
-    - parse_cm ==3.12.0
-    - proseco ==5.10.0
+    - mica ==4.33.2
+    - parse_cm ==3.13.0
+    - proseco ==5.11.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.1
     - ska-sphinx-theme ==1.3.0
@@ -46,11 +46,11 @@ requirements:
     - ska_tdb ==4.0.0
     - ska3-core ==2023.3
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.11.0
+    - ska_helpers ==0.12.0
     - ska_path ==3.1.2
     - ska_sync ==4.11.0
     - skare3_tools ==1.1.0
-    - sparkles ==4.23.0
-    - starcheck ==14.4.0
+    - sparkles ==4.24.0
+    - starcheck ==14.5.0
     - testr ==4.12.0
     - xija ==4.31.0


### PR DESCRIPTION
# ska3-matlab 2023.8

This PR includes:
- A list of packages is being removed from ska3-flight. These packages, which have a narrow scope an audience, will be grouped in a separate category and installed separately. In order to improve flexibility and reduce unnecessary labor of full FSDS review, these packages will be delegated from FSDS control to a lower level ([see here](https://github.com/sot/skare3/wiki/Non-FSDS-Package-Maintenance))
- One new package: chandra_limits, a package for limit management.
- Changes to proseco, sparkles and starcheck to make the ACA penalty limit optional.
- Changes in parse_cm to handle machine-readable comments ([see here](https://docs.google.com/document/d/1zIh3eQQv45RL0T1jCJgMANNGs_uYFa-ikspsA4A0hMQ))
- Small updates to improve chandra_models access, including a change to xija so it will use ska_helpers.chandra_models.
- **changes in agasc to handle a HEALPix-index catalog**
- **allow specifying the AGASC file/version in proseco and sparkles (in preparation for AGASC 1.8)**

## Interface Impacts:

- 11 packages removed.
- `parse_cm.or_list.read_or_list` is deprecated. `parse_cm.or_list.read_or_list_full ` should be used instead. Use of `parse_cm.or_list.read_or_list` will result in a warning.
- `parse_cm.common. _coerce_type` is deprecated. Use `ska_helpers.utils.convert_to_int_float_str` instead.
- xija models now will respect the CHANDRA_MODELS_DEFAULT_VERSION and CHANDRA_MODELS_REPO_DIR env vars end determine which model is used.



## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.8rc1/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.8rc1-GRETA).
- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.8rc1-HEAD).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2023.8rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2023.8rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2023.8 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2023.6 -> 2023.8rc1)

### New Packages

- **chandra_limits: 0.5.0**

### Removed Packages

- **aca_hi_bgd**
- **aca_weekly_report**
- **acdc**
- **aimpoint_mon**
- **annie**
- **astromon**
- **jobwatch**
- **kalman_watch**
- **perigee_health_plots**
- **ska_report_ranges**

### Updated Packages

- **aca_view:** 0.12.0 -> 0.13.0 (0.12.0 ->  -> 0.13.0)
  - [PR 171](https://github.com/sot/aca_view/pull/171) (Javier Gonzalez): Updates to dark style
  - [PR 169](https://github.com/sot/aca_view/pull/169) (Javier Gonzalez): Data improvements
  - [PR 174](https://github.com/sot/aca_view/pull/174) (Javier Gonzalez): Show AABGDTYP
  - [PR 173](https://github.com/sot/aca_view/pull/173) (Javier Gonzalez): Change log color scale so negative values are not nan
  - [PR 176](https://github.com/sot/aca_view/pull/176) (Javier Gonzalez): Dynbgd fixes
- **acis_thermal_check:** 4.6.0 -> 4.7.0 (4.6.0 -> 4.7.0)
  - [PR 65](https://github.com/acisops/acis_thermal_check/pull/65) (John ZuHone): Improve logging to screen and run.dat
- **agasc:** 4.15.0 -> 4.17.0 (4.15.0 -> 4.16.0 -> 4.17.0)
  - [PR 154](https://github.com/sot/agasc/pull/154) (Javier Gonzalez): In agasc supplement processing, only process observations that already happened.
  - [PR 155](https://github.com/sot/agasc/pull/155) (Tom Aldcroft): Support HEALpix-indexed AGASC HDF5 files and more
- **chandra_aca:** 4.41.0 -> 4.42.0 (4.41.0 -> 4.42.0)
  - [PR 156](https://github.com/sot/chandra_aca/pull/156) (Tom Aldcroft): Convert docstrings to numpydocs format and add dark_model API docs
- **cheta:** 4.59.0 -> 4.60.0 (4.59.0 -> 4.60.0)
  - [PR 250](https://github.com/sot/cheta/pull/250) (Tom Aldcroft): Fix problems that came up in `pitch/roll-comp` when using real-time data
- **cxotime:** 3.6.0 -> 3.6.1 (3.6.0 -> 3.6.1)
  - [PR 39](https://github.com/sot/cxotime/pull/39) (Javier Gonzalez): Fix tests on GRETA
- **hopper:** 4.5.4 -> 4.6.0 (4.5.4 -> 4.6.0)
  - [PR 25](https://github.com/sot/hopper/pull/25) (Jean Connelly): Update to use parse_cm.read_or_list_full
- **kadi:** 7.5.0 -> 7.6.0 (7.5.0 -> 7.6.0)
  - [PR 291](https://github.com/sot/kadi/pull/291) (Tom Aldcroft): Improve SPM eclipse enable state
- **mica:** 4.33.0 -> 4.33.2 (4.33.0 -> 4.33.1 -> 4.33.2)
  - [PR 284](https://github.com/sot/mica/pull/284) (Jean Connelly): Change acq anomaly notification from aca_alert to aca email
  - [PR 285](https://github.com/sot/mica/pull/285) (Jean Connelly): Set mica agasc calls to use miniagasc*
- **parse_cm:** 3.11.0 -> 3.13.0 (3.11.0 -> 3.12.0 -> 3.13.0)
  - [PR 42](https://github.com/sot/parse_cm/pull/42) (Tom Aldcroft): Add support for machine readable comments
  - [PR 43](https://github.com/sot/parse_cm/pull/43) (Tom Aldcroft): Apply black and organize imports in `acis_tables.py` + update flake8 workflow
  - [PR 44](https://github.com/sot/parse_cm/pull/44) (Tom Aldcroft): Use ska_helpers.utils.convert_to_int_float_str instead of _coerce_type
- **proseco:** 5.10.0 -> 5.11.0 (5.10.0 -> 5.11.0)
  - [PR 387](https://github.com/sot/proseco/pull/387) (Tom Aldcroft): Allow specifying AGASC HDF5 file or latest proseco_agasc as default
- **ska_helpers:** 0.11.0 -> 0.12.0 (0.11.0 -> 0.12.0)
  - [PR 49](https://github.com/sot/ska_helpers/pull/49) (Tom Aldcroft): Add function convert_to_int_float_str
- **ska_sun:** 3.10.1 -> 3.11.0 (3.10.1 ->  -> 3.11.0)
  - [PR 24](https://github.com/sot/ska_sun/pull/24) (Tom Aldcroft): Performance
  - [PR 25](https://github.com/sot/ska_sun/pull/25) (Tom Aldcroft): Support multiple sun position dispatch methods
  - [PR 34](https://github.com/sot/ska_sun/pull/34) (Jean Connelly): Set to use nominal roll range 0-360
- **skare3_tools:** 1.0.10 -> 1.1.0 (1.0.10 ->  -> 1.1.0)
  - [PR 99](https://github.com/sot/skare3_tools/pull/99) (Jean Connelly): Update docstring to note it works on non-metapackages
  - [PR 98](https://github.com/sot/skare3_tools/pull/98) (Javier Gonzalez): Fixes to package info summaries
  - [PR 101](https://github.com/sot/skare3_tools/pull/101) (Tom Aldcroft): Add module for converting docstrings to numpydoc format
  - [PR 103](https://github.com/sot/skare3_tools/pull/103) (Javier Gonzalez): Requirements
- **sparkles:** 4.23.0 -> 4.24.0 (4.23.0 -> 4.24.0)
  - [PR 197](https://github.com/sot/sparkles/pull/197) (Tom Aldcroft): Update tests for AGASC >= 1.8 and lazy import matplotlib
- **starcheck:** 14.3.0 -> 14.5.0 (14.3.0 -> 14.4.0 -> 14.5.0)
  - [PR 424](https://github.com/sot/starcheck/pull/424) (Jean Connelly): Set 'too cold for fid placement' check to use acq t_ccd
  - [PR 430](https://github.com/sot/starcheck/pull/430) (Jean Connelly): Update to use read_or_list_full



# Related Issues

Fixes #1189
Fixes #1191
Fixes #1192
Fixes #1193
Fixes #1194
Fixes #1195
Fixes #1196
Fixes #1197
Fixes #1198
Fixes #1199


