### PR TITLE
2023.9

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - backstop_history ==3.2.1
     - chandra_cmd_states ==4.0.0
     - chandra_limits ==0.5.0
-    - chandra_maneuver == 4.1.0
+    - chandra_maneuver ==4.1.0
     - chandra_time ==4.1.2
     - chandra_aca ==4.43.0
     - cheta ==4.60.0
@@ -24,9 +24,9 @@ requirements:
     - find_attitude ==3.4.3
     - fot-matlab ==2.3.0
     - hopper ==4.6.0
-    - kadi == 7.7.0
+    - kadi ==7.7.0
     - maude ==3.11.1
-    - mica == 4.34.0
+    - mica ==4.34.0
     - parse_cm ==3.13.0
     - proseco ==5.11.0
     - pyyaks ==4.5.0
@@ -50,7 +50,7 @@ requirements:
     - ska_path ==3.1.2
     - ska_sync ==4.11.0
     - skare3_tools ==1.1.0
-    - sparkles == 4.24.1
+    - sparkles ==4.24.1
     - starcheck ==14.6.0
     - testr ==4.12.0
     - xija ==4.31.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - find_attitude ==3.4.3
     - fot-matlab ==2.3.0
     - hopper ==4.6.0
-    - kadi ==7.7.0
+    - kadi ==7.7.1
     - maude ==3.11.1
     - mica ==4.34.0
     - parse_cm ==3.13.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2023.7
+  version: 2023.9
 
 build:
   noarch: generic
@@ -12,7 +12,7 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==4.7.0
     - acispy ==2.5.0
-    - agasc ==4.16.0
+    - agasc ==4.17.0
     - backstop_history ==3.2.1
     - chandra_cmd_states ==4.0.0
     - chandra_limits ==0.5.0
@@ -20,15 +20,15 @@ requirements:
     - chandra_time ==4.1.2
     - chandra_aca ==4.42.0
     - cheta ==4.60.0
-    - cxotime ==3.6.0
+    - cxotime ==3.6.1
     - find_attitude ==3.4.3
     - fot-matlab ==2.3.0
-    - hopper ==4.5.4
+    - hopper ==4.6.0
     - kadi ==7.6.0
     - maude ==3.11.1
-    - mica ==4.33.1
-    - parse_cm ==3.12.0
-    - proseco ==5.10.0
+    - mica ==4.33.2
+    - parse_cm ==3.13.0
+    - proseco ==5.11.0
     - pyyaks ==4.5.0
     - quaternion ==4.1.1
     - ska-sphinx-theme ==1.3.0
@@ -46,11 +46,11 @@ requirements:
     - ska_tdb ==4.0.0
     - ska3-core ==2023.3
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.11.0
+    - ska_helpers ==0.12.0
     - ska_path ==3.1.2
     - ska_sync ==4.11.0
     - skare3_tools ==1.1.0
-    - sparkles ==4.23.0
-    - starcheck ==14.4.0
+    - sparkles ==4.24.0
+    - starcheck ==14.5.0
     - testr ==4.12.0
     - xija ==4.31.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - chandra_limits ==0.5.0
     - chandra_maneuver ==4.1.0
     - chandra_time ==4.1.2
-    - chandra_aca ==4.43.0
+    - chandra_aca ==4.44.0
     - cheta ==4.60.0
     - cxotime ==3.7.0
     - find_attitude ==3.4.3

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -12,25 +12,25 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==4.7.0
     - acispy ==2.5.0
-    - agasc ==4.17.0
+    - agasc ==4.17.1
     - backstop_history ==3.2.1
     - chandra_cmd_states ==4.0.0
     - chandra_limits ==0.5.0
-    - chandra_maneuver ==4.0.0
+    - chandra_maneuver == 4.1.0
     - chandra_time ==4.1.2
-    - chandra_aca ==4.42.0
+    - chandra_aca ==4.43.0
     - cheta ==4.60.0
-    - cxotime ==3.6.1
+    - cxotime ==3.7.0
     - find_attitude ==3.4.3
     - fot-matlab ==2.3.0
     - hopper ==4.6.0
-    - kadi ==7.6.0
+    - kadi == 7.7.0
     - maude ==3.11.1
-    - mica ==4.33.2
+    - mica == 4.34.0
     - parse_cm ==3.13.0
     - proseco ==5.11.0
     - pyyaks ==4.5.0
-    - quaternion ==4.1.1
+    - quaternion ==4.2.0
     - ska-sphinx-theme ==1.3.0
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
@@ -42,15 +42,15 @@ requirements:
     - ska_parsecm ==4.0.0
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
-    - ska_sun ==3.11.0
+    - ska_sun ==3.12.0
     - ska_tdb ==4.0.0
     - ska3-core ==2023.3
     - ska3-template ==2022.06.02
-    - ska_helpers ==0.12.0
+    - ska_helpers ==0.13.0
     - ska_path ==3.1.2
     - ska_sync ==4.11.0
     - skare3_tools ==1.1.0
-    - sparkles ==4.24.0
-    - starcheck ==14.5.0
+    - sparkles == 4.24.1
+    - starcheck ==14.6.0
     - testr ==4.12.0
     - xija ==4.31.0


### PR DESCRIPTION
# ska3-flight 2023.9

This PR includes:
- starcheck: Update High IR Zone check to -25 +27 around perigee.
- agasc: Support HEALpix-indexed AGASC HDF5 files.
- performance improvements in chandra_aca, chandra_maneuver, kadi and quaternion
- chandra_aca: adds new fid offset code to use aimpoint drift model to estimate fid positions on CCD 
- small test fixes and general code maintenance.

## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.9rc3).
- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.9rc3-HEAD).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2023.9rc3-OSX).

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2023.9rc3 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2023.9rc3
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2023.9 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-flight changes (2023.7 -> 2023.9rc3)

### Updated Packages

- **agasc:** 4.16.0 -> 4.17.1 (4.16.0 -> 4.17.0 -> 4.17.1)
  - [PR 155](https://github.com/sot/agasc/pull/155) (Tom Aldcroft): Support HEALpix-indexed AGASC HDF5 files and more
  - [PR 160](https://github.com/sot/agasc/pull/160) (Tom Aldcroft): Apply ruff check and format redux
  - [PR 158](https://github.com/sot/agasc/pull/158) (Tom Aldcroft): Update with black formatting and ruff linting
- **chandra_aca:** 4.42.0 -> 4.44.0 (4.42.0 -> 4.43.0 -> 4.44.0)
  - [PR 138](https://github.com/sot/chandra_aca/pull/138) (Tom Aldcroft): Performance improvements for planets
  - [PR 160](https://github.com/sot/chandra_aca/pull/160) (Jean Connelly): Support fid drift times before 2012:001
  - [PR 157](https://github.com/sot/chandra_aca/pull/157) (Jean Connelly): Add fid offset support to drift
  - [PR 158](https://github.com/sot/chandra_aca/pull/158) (Tom Aldcroft): Update docstring in drift.py
  - [PR 161](https://github.com/sot/chandra_aca/pull/161) (Tom Aldcroft): Add tolerance args to clip_and_warn
- **chandra_maneuver:** 4.0.0 -> 4.1.0 (4.0.0 -> 4.1.0)
  - [PR 26](https://github.com/sot/chandra_maneuver/pull/26) (Tom Aldcroft): Enforce quaternion sign convention
  - [PR 24](https://github.com/sot/chandra_maneuver/pull/24) (Tom Aldcroft): Performance improvements
- **cxotime:** 3.6.0 -> 3.7.0 (3.6.0 -> 3.6.1 -> 3.7.0)
  - [PR 39](https://github.com/sot/cxotime/pull/39) (Javier Gonzalez): Fix tests on GRETA
  - [PR 42](https://github.com/sot/cxotime/pull/42) (Tom Aldcroft): Fix a precision issue in convert_time_format
  - [PR 40](https://github.com/sot/cxotime/pull/40) (Tom Aldcroft): Short circuit convert_time_format for a CxoTime object
- **hopper:** 4.5.4 -> 4.6.0 (4.5.4 -> 4.6.0)
  - [PR 25](https://github.com/sot/hopper/pull/25) (Jean Connelly): Update to use parse_cm.read_or_list_full
- **kadi:** 7.6.0 -> 7.7.1 (7.6.0 -> 7.7.0 -> 7.7.1)
  - [PR 266](https://github.com/sot/kadi/pull/266) (Tom Aldcroft): Performance improvement kadi states
  - [PR 268](https://github.com/sot/kadi/pull/268) (Tom Aldcroft): Use ruff for linting and formatting
  - [PR 296](https://github.com/sot/kadi/pull/296) (Jean Connelly): Use ska_helpers.utils.convert_to_int_float_str to stop Deprecation warns
  - [PR 294](https://github.com/sot/kadi/pull/294) (Jean Connelly): Update log statement with a time that prints
  - [PR 303](https://github.com/sot/kadi/pull/303) (Jean Connelly): Broaden setup.py package data glob to install pkl.gz and ecsv.gz test data
  - [PR 300](https://github.com/sot/kadi/pull/300) (Tom Aldcroft): Add unit and regression tests for validation
  - [PR 299](https://github.com/sot/kadi/pull/299) (Tom Aldcroft): Revert the change to decorate `Validate.update_tlm` method
  - [PR 298](https://github.com/sot/kadi/pull/298) (Tom Aldcroft): Convert docstrings to numpydoc style and refactor API docs
- **mica:** 4.33.1 -> 4.34.0 (4.33.1 -> 4.33.2 -> 4.34.0)
  - [PR 285](https://github.com/sot/mica/pull/285) (Jean Connelly): Set mica agasc calls to use miniagasc*
  - [PR 286](https://github.com/sot/mica/pull/286) (Jean Connelly): Handle no-starcat observations better in reports
- **parse_cm:** 3.12.0 -> 3.13.0 (3.12.0 -> 3.13.0)
  - [PR 44](https://github.com/sot/parse_cm/pull/44) (Tom Aldcroft): Use ska_helpers.utils.convert_to_int_float_str instead of _coerce_type
- **proseco:** 5.10.0 -> 5.11.0 (5.10.0 -> 5.11.0)
  - [PR 387](https://github.com/sot/proseco/pull/387) (Tom Aldcroft): Allow specifying AGASC HDF5 file or latest proseco_agasc as default
- **quaternion:** 4.1.1 -> 4.2.0 (4.1.1 -> 4.2.0)
  - [PR 42](https://github.com/sot/Quaternion/pull/42) (Tom Aldcroft): Apply ruff format (black) and linting
  - [PR 41](https://github.com/sot/Quaternion/pull/41) (Tom Aldcroft): Add functions for improved performance for scalar operations
  - [PR 43](https://github.com/sot/Quaternion/pull/43) (Tom Aldcroft): Use astropy.utils.shapes instead of copied version
- **ska_helpers:** 0.11.0 -> 0.13.0 (0.11.0 -> 0.12.0 -> 0.13.0)
  - [PR 49](https://github.com/sot/ska_helpers/pull/49) (Tom Aldcroft): Add function convert_to_int_float_str
  - [PR 50](https://github.com/sot/ska_helpers/pull/50) (Jean Connelly): Rename test so error isn't in the name
- **ska_sun:** 3.11.0 -> 3.12.0 (3.11.0 -> 3.12.0)
  - [PR 35](https://github.com/sot/ska_sun/pull/35) (Tom Aldcroft): Add position_at_jd to __all__
- **sparkles:** 4.23.0 -> 4.24.1 (4.23.0 -> 4.24.0 -> 4.24.1)
  - [PR 197](https://github.com/sot/sparkles/pull/197) (Tom Aldcroft): Update tests for AGASC >= 1.8 and lazy import matplotlib
  - [PR 200](https://github.com/sot/sparkles/pull/200) (Tom Aldcroft): Ruff changes
- **starcheck:** 14.4.0 -> 14.6.0 (14.4.0 -> 14.5.0 -> 14.6.0)
  - [PR 430](https://github.com/sot/starcheck/pull/430) (Jean Connelly): Update to use read_or_list_full
  - [PR 433](https://github.com/sot/starcheck/pull/433) (Jean Connelly): Update High IR Zone check to -25 +27 around perigee

# Related Issues

Fixes #1152
Fixes #1186
Fixes #1205
Fixes #1206
Fixes #1207
Fixes #1208
Fixes #1209
Fixes #1210
Fixes #1211
Fixes #1212
Fixes #1214
Fixes #1216
Fixes #1218
Fixes #1219
