### PR TITLE
Update ruff template for ruff >= 0.2

### DIFF
--- a/templates/ruff.toml
+++ b/templates/ruff.toml
@@ -1,10 +1,10 @@
-# Copied originally from pandas
+# Copied originally from pandas. This config requires ruff >= 0.2.
 target-version = "py310"
 
 # fix = true
-unfixable = []
+lint.unfixable = []
 
-select = [
+lint.select = [
   "I", # isort
   "F", # pyflakes
   "E", "W", # pycodestyle
@@ -24,7 +24,7 @@ select = [
 ]
 
 # Some additional rules that are useful
-extend-select = [
+lint.extend-select = [
 "UP009",  # UTF-8 encoding declaration is unnecessary
 "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
 "D205",  # One blank line required between summary line and description
@@ -33,7 +33,7 @@ extend-select = [
 "PERF401",  # Use a list comprehension to create a transformed list
 ]
 
-ignore = [
+lint.ignore = [
   "ISC001", # Disable this for compatibility with ruff format
   "B028", # No explicit `stacklevel` keyword argument found
   "B905", # `zip()` without an explicit `strict=` parameter
@@ -48,14 +48,14 @@ ignore = [
 ]
 
 # TODO : fix these and stop ignoring. Commented out ones are common and OK to except.
-extend-ignore = [
+lint.extend-ignore = [
   "PGH004", # Use specific rule codes when using `noqa`
 #  "C401", # Unnecessary generator (rewrite as a `set` comprehension)
 #  "C402", # Unnecessary generator (rewrite as a dict comprehension)
 #  "C405", # Unnecessary `list` literal (rewrite as a `set` literal)
 #  "C408", # Unnecessary `dict` call (rewrite as a literal)
 #  "C416", # Unnecessary `dict` comprehension (rewrite using `dict()`)
-#  "PGH002", # warn is deprecated in favor of warning
+#  "G010", # warn is deprecated in favor of warning
 #  "PYI056", # Calling `.append()` on `__all__` may not be supported by all type checkers
 ]
 
@@ -63,7 +63,7 @@ extend-exclude = [
   "docs",
 ]
 
-[pycodestyle]
+[lint.pycodestyle]
 max-line-length = 100 # E501 reports lines that exceed the length of 100.
 
 [lint.extend-per-file-ignores]


### PR DESCRIPTION
There are some deprecation warnings showing up in CI now that are related to breaking changes in [ruff 0.2](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#020). This fixes the issues.

## Testing

Ran ruff locally in this repo using ruff 0.2.1. Confirmed that deprecation warnings appear without the update and they are gone after the update.
