### PR TITLE
Python 3.11 build (speedy)

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -1,23 +1,132 @@
 name: Build Ska Package
 
+# This workflow builds a Ska package and optionally uploads it to a ska3-conda channel.
+
+# It takes the following arguments:
+#
+#   - package: the name of the package to build
+#   - tag: the tag to use for the package
+#   - arch: whether to build it for all architectures or as noarch (default is false)
+#   - upload: whether to upload the package to the ska3-conda channel (default is false)
+#   - python_version: the python version to use for the build (default is 3.11)
+#   - numpy_version: the numpy version to use for the build (default is 1.26.2)
+#   - channel_in: the channel to use for the build environment (default is flight).
+#     This channel gets passed to package_build workflow, which also adds conda-forge
+#   - channel_out: the channel to upload the package to (default is test)
+#   - skare3_branch: the branch of skare3 to use for the build (default is master)
+#
+# You call it like this:
+#     from skare3_tools import github
+#     repo = github.Repository("sot/skare3")
+#     repo.dispatch_event(
+#         "build-package",
+#         client_payload={
+#             "package": "sot/ska_helpers",
+#             "tag": '0.13.0',
+#             "arch": False,
+#             "upload": True
+#         }
+#     )
+
 on:
   repository_dispatch:
     types:
       - build-package
 
 jobs:
+  # this job checks the arguments, sets defaults, and writes a summary
+  arguments:
+    runs-on: ubuntu-latest
+    outputs:
+      # this section is needed so later jobs can use the arguments
+      # as ${{ steps.arguments.outputs.<variable name> }}
+      package: ${{ steps.arguments.outputs.package }}
+      tag: ${{ steps.arguments.outputs.tag }}
+      arch: ${{ steps.arguments.outputs.arch }}
+      upload: ${{ steps.arguments.outputs.upload }}
+      python_version: ${{ steps.arguments.outputs.python_version }}
+      numpy_version: ${{ steps.arguments.outputs.numpy_version }}
+      channel_in: ${{ steps.arguments.outputs.channel_in }}
+      channel_out: ${{ steps.arguments.outputs.channel_out }}
+      skare3_branch: ${{ steps.arguments.outputs.skare3_branch }}
+    steps:
+    - name: Check arguments
+      id: arguments
+      run: |
+        MISSING=""
+        set_default() {
+          if [[ -z "$2" ]]; then
+            echo "Setting default value for $1"
+            echo "$1=$3" >> $GITHUB_OUTPUT
+          else
+            echo "$1=$2" >> $GITHUB_OUTPUT
+          fi
+        }
+        require () {
+          if [[ -z "$2" ]]; then
+            echo "Required value $1 not given"
+            MISSING="$MISSING $1"
+          else
+            echo "$1=$2" >> $GITHUB_OUTPUT
+          fi
+        }
+        set_boolean_default() {
+          if [[ -z "$2" ]]; then
+            echo "Setting default value for $1"
+            echo "$1=$3" >> $GITHUB_OUTPUT
+          elif [[ "$2" == "true" || "$2" == "True" ]]; then
+            echo "$1=true" >> $GITHUB_OUTPUT
+          else
+            echo "$1=false" >> $GITHUB_OUTPUT
+          fi
+        }
+        require package ${{ github.event.client_payload.package }}
+        require tag ${{ github.event.client_payload.tag }}
+        set_boolean_default arch "${{ github.event.client_payload.arch }}" false
+        set_boolean_default upload "${{ github.event.client_payload.upload }}" false
+        set_default python_version "${{ github.event.client_payload.python_version }}" 3.11
+        set_default numpy_version "${{ github.event.client_payload.numpy_version }}" 1.26.2
+        set_default channel_in "${{ github.event.client_payload.channel_in }}" "flight"
+        set_default channel_out "${{ github.event.client_payload.channel_out }}" "test"
+        set_default skare3_branch "${{ github.event.client_payload.skare3_branch }}" "master"
+        if [ "${{ github.event.client_payload.upload }}" == "" ]; then echo upload is not given; fi
+        if [ "${{ github.event.client_payload.upload }}" == "false" ]; then echo upload is false; fi
+        if [ "${{ github.event.client_payload.upload }}" == "False" ]; then echo upload is False; fi
+        if [[ ! -z $MISSING ]]; then echo "::warning:: Missing parameters: $MISSING"; exit 1; fi
+    - name: Add summary
+      run: |
+        echo "## Payload Arguments" >> $GITHUB_STEP_SUMMARY
+        echo "- Package: ${{ steps.arguments.outputs.package }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Tag: ${{ steps.arguments.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Arch: ${{ steps.arguments.outputs.arch }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Upload: ${{ steps.arguments.outputs.upload }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Skare3 branch: ${{ steps.arguments.outputs.skare3_branch }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Python version: ${{ steps.arguments.outputs.python_version }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Numpy version: ${{ steps.arguments.outputs.numpy_version }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Input channel: ${{ steps.arguments.outputs.channel_in }}" >> $GITHUB_STEP_SUMMARY
+        echo "- Output channel: ${{ steps.arguments.outputs.channel_out }}" >> $GITHUB_STEP_SUMMARY
   build:
+    # This steps does the actual building
+    needs: arguments  # this job needs the arguments job because it uses the outputs
     uses: sot/skare3/.github/workflows/package_build.yml@master
     with:
       repository: ${{ github.event.client_payload.package }}
       tag: ${{ github.event.client_payload.tag }}
-      noarch: ${{ !github.event.client_payload.arch }}
+      noarch: ${{ !github.event.client_payload.arch && (github.event.client_payload.arch != 'true') && (github.event.client_payload.arch != 'True')}}
+      python_version: ${{ needs.arguments.outputs.python_version }}
+      numpy_version: ${{ needs.arguments.outputs.numpy_version }}
+      skare3_branch: ${{ needs.arguments.outputs.skare3_branch }}
+      # the following channel in ska3-conda is used to create the build environment
+      channel: ${{ needs.arguments.outputs.channel_in }}
     secrets:
       CONDA_PASSWORD: ${{ secrets.CONDA_PASSWORD }}
       CHANDRA_XRAY_TOKEN: ${{ secrets.CHANDRA_XRAY_TOKEN }}
       token: ${{ secrets.GITHUB_TOKEN }}
 
   upload:
-    if: ${{ github.event.client_payload.upload }}
-    needs: [build]
+    if: ${{ github.event.client_payload.upload == 'true' }}
+    needs: [build, arguments]  # this job needs the arguments job because it uses the outputs
     uses: sot/skare3/.github/workflows/package_upload.yml@master
+    with:
+      # this is the destination ska3-conda channel
+      channel: ${{ needs.arguments.outputs.channel_out }}

--- a/.github/workflows/conda_meta.yml
+++ b/.github/workflows/conda_meta.yml
@@ -14,11 +14,14 @@ jobs:
       matrix:
         os: ["ubuntu", "macos", "windows"]
     steps:
-      - uses: sot/setup-miniconda@v2
+      - name: Setup Conda Environment
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          miniconda-version: "py39_4.12.0"
-          python-version: "3.9"
-          channels: defaults,conda-forge,https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight
+          auto-update-conda: true
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          python-version: ${{ github.event.client_payload.python_version }}
+          activate-environment: conda-build
+          channels: conda-forge,https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/${{ github.event.client_payload.channel }}
       - name: Checkout Skare3
         uses: actions/checkout@v2
         with:
@@ -29,7 +32,7 @@ jobs:
         shell: bash -l -e {0}
         run: |
           conda info
-          conda env update -f skare3/pkg_defs/ska3-core-latest/environment.yml
+          conda env update -f skare3/pkg_defs/ska3-core-latest/base_environment.yml
           python ./skare3/pkg_defs/ska3-core-latest/install_from_scratch.py
           conda list --json > ska3-core-${ARCH}.json
       - name: ska3-flight

--- a/.github/workflows/package_build.yml
+++ b/.github/workflows/package_build.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: master
+      channel:
+        description: Ska Conda channel
+        required: false
+        type: string
+        default: flight
     secrets:
       CONDA_PASSWORD:
         required: true
@@ -58,37 +63,122 @@ jobs:
         shell: bash -l {0}
     steps:
     - name: Fetch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+    - name: Show Inputs
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
+      run: |
+        echo OS: ${{ matrix.os }}
+        echo repository: \'${{ inputs.repository }}\'
+        echo tag: \'${{ inputs.tag }}\'
+        echo noarch: \'${{ inputs.noarch }}\'
+        echo python_version: \'${{ inputs.python_version }}\'
+        echo numpy_version: \'${{ inputs.numpy_version }}\'
+        echo miniconda_version: \'${{ inputs.miniconda_version }}\'
+        echo skare3_branch: \'${{ inputs.skare3_branch }}\'
     - name: Fetch Skare3
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
       with:
         repository: sot/skare3
         ref: ${{ inputs.skare3_branch }}
         path: skare3
     - name: Fetch Skare3-tools
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
       with:
         repository: sot/skare3_tools
         ref: master
         path: skare3_tools
-    - uses: sot/setup-miniconda@v2
+    - name: Cache Conda Packages
+      uses: actions/cache@v4
+      env:
+        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        CACHE_NUMBER: 0
       with:
-        miniconda-version: py39_4.12.0
-        environment-file: ./skare3/build-environment.yml
-        channels: https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight,conda-forge
+        path: ~/conda_pkgs_dir
+        key:
+          conda-build-pkgs-${{ runner.os }}-${{hashFiles('./skare3/build-environment.yml') }}-${{ env.CACHE_NUMBER }}
+    - name: Setup Conda Environment
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        # mamba-version: "*"
+        auto-update-conda: true
+        use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+        python-version: ${{ inputs.python_version }}
+        activate-environment: conda-build
+        channels: https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/${{ inputs.channel }},conda-forge
+    #- name: Debug
+    #  if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
+    #  run: |
+    #    env
+    #    echo $CONDA_EXE info --envs
+    #    $CONDA_EXE info --envs
+    - name: Cache Conda Environment
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
+      uses: actions/cache@v4
+      with:
+        # it seems that env.CONDA is not available, so I am caching the directories for windows and
+        # linux (only one will succeed)
+        # path: ${{ env.CONDA }}/envs
+        path: /c/Miniconda/envs
+        key:
+          conda-build-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('./skare3/build-environment.yml') }}-${{ env.CACHE_NUMBER }}
+      env:
+        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        CACHE_NUMBER: 0
+      id: conda_cache
+    - name: Cache Conda Environment
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
+      uses: actions/cache@v4
+      with:
+        # path: ${{ env.CONDA }}/envs
+        path: /usr/share/miniconda/envs
+        key:
+          conda-build-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('./skare3/build-environment.yml') }}-${{ env.CACHE_NUMBER }}
+      env:
+        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        CACHE_NUMBER: 0
+      id: conda_cache_win
+    - name: Update Conda Environment
+      if: ${{ ((steps.conda_cache.outputs.cache-hit != 'true') && (steps.conda_cache_win.outputs.cache-hit != 'true')) && ((matrix.os == 'ubuntu-latest') || !inputs.noarch) }}
+      run:
+        conda env update -n conda-build -f ./skare3/build-environment.yml
+    - name: Install ska_helpers
+      if: ${{ ((steps.conda_cache.outputs.cache-hit != 'true') && (steps.conda_cache_win.outputs.cache-hit != 'true')) && ((matrix.os == 'ubuntu-latest') || !inputs.noarch) }}
+      run: |
+        conda search ska_helpers
+        err=$?
+        if [ !$err ]
+        then ${CONDA_EXE} install ska_helpers
+        fi
+        conda search testr
+        err=$?
+        if [ !$err ]
+        then ${CONDA_EXE} install testr
+        fi
     - name: Env List
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
       run: conda list
     - name: Build Package
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
       run: |
         arch_arg=`if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then echo; else echo '--arch-specific'; fi`
-        python skare3_tools/actions/build/files/build.py $arch_arg ${{ inputs.repository }} --tag ${{ inputs.tag }} --python ${{ inputs.python_version }} --numpy ${{ inputs.numpy_version }} --skare3-branch ${{ inputs.skare3_branch }}
+        python skare3_tools/actions/build/files/build.py $arch_arg ${{ inputs.repository }} --tag ${{ inputs.tag }} --python ${{ inputs.python_version }} --numpy ${{ inputs.numpy_version }} --skare3-branch ${{ inputs.skare3_branch }} -c https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/${{ inputs.channel }} -c conda-forge
       env:
         CONDA_PASSWORD: ${{ secrets.CONDA_PASSWORD }}
         GIT_USERNAME: chandra-xray
         GIT_ASKPASS: ${{ github.workspace }}/skare3_tools/actions/build/files/git_pass.py
         GIT_PASSWORD: ${{ secrets.CHANDRA_XRAY_TOKEN }}
+    - name: Summary
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
+      run: |
+        files=`find  builds/noarch/ builds/linux-64/ builds/osx-64/ builds/win-64/ -not -name \*repodata\* -not -name index.html -not -name .ensure-non-empty-dir -type f`
+        echo "## Packages Built:" >> $GITHUB_STEP_SUMMARY
+        for f in $files; do echo "- $f" >> $GITHUB_STEP_SUMMARY; done;
     - name: Save package
       uses: actions/upload-artifact@v2.2.4
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
       with:
         name: conda-package
         path: |

--- a/.github/workflows/package_release.yml
+++ b/.github/workflows/package_release.yml
@@ -22,7 +22,7 @@ jobs:
     name: Patch Release
     steps:
     - name: Fetch Skare3 Tools
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: sot/skare3_tools
         ref: master

--- a/build-environment.yml
+++ b/build-environment.yml
@@ -1,8 +1,9 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
-  - conda-forge::libarchive  # libarchive from defaults is not good for mamba
+  # note that ska3 packages should not be here, because this is used to build all ska3 packages
+  - python                   # python version specified in the workflow
+  - libarchive               # libarchive from defaults might not be good for mamba
   - mamba
   - setuptools_scm
   - gitpython
@@ -11,5 +12,3 @@ dependencies:
   - pyyaml
   - numpy
   - packaging
-  - ska_helpers
-  - testr

--- a/pkg_defs/Quaternion/meta.yaml
+++ b/pkg_defs/Quaternion/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/aca_hi_bgd/meta.yaml
+++ b/pkg_defs/aca_hi_bgd/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/aca_hi_bgd

--- a/pkg_defs/aca_view/meta.yaml
+++ b/pkg_defs/aca_view/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - setuptools_scm_git_archive
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/aca_view/meta.yaml
+++ b/pkg_defs/aca_view/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/aca_view

--- a/pkg_defs/aca_weekly_report/meta.yaml
+++ b/pkg_defs/aca_weekly_report/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/aca_weekly_report

--- a/pkg_defs/acdc/meta.yaml
+++ b/pkg_defs/acdc/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/acdc

--- a/pkg_defs/acis_taco/meta.yaml
+++ b/pkg_defs/acis_taco/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/acis_thermal_check/meta.yaml
+++ b/pkg_defs/acis_thermal_check/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/acisfp_check/meta.yaml
+++ b/pkg_defs/acisfp_check/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/acisfp_check

--- a/pkg_defs/acispy/meta.yaml
+++ b/pkg_defs/acispy/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/acispy

--- a/pkg_defs/agasc/meta.yaml
+++ b/pkg_defs/agasc/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/agasc

--- a/pkg_defs/aimpoint_mon/meta.yaml
+++ b/pkg_defs/aimpoint_mon/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/aimpoint_mon

--- a/pkg_defs/annie/meta.yaml
+++ b/pkg_defs/annie/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/astromon/meta.yaml
+++ b/pkg_defs/astromon/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - setuptools_scm_git_archive
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/astromon/meta.yaml
+++ b/pkg_defs/astromon/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/astromon

--- a/pkg_defs/attitude_error_mon/meta.yaml
+++ b/pkg_defs/attitude_error_mon/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/attitude_error_mon

--- a/pkg_defs/backstop_history/meta.yaml
+++ b/pkg_defs/backstop_history/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/bep_pcb_check/meta.yaml
+++ b/pkg_defs/bep_pcb_check/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/bep_pcb_check

--- a/pkg_defs/bep_pcb_check/meta.yaml
+++ b/pkg_defs/bep_pcb_check/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - setuptools_scm_git_archive
 
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/chandra_aca/meta.yaml
+++ b/pkg_defs/chandra_aca/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/chandra_cmd_states/meta.yaml
+++ b/pkg_defs/chandra_cmd_states/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/chandra_limits/meta.yaml
+++ b/pkg_defs/chandra_limits/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/chandra_limits

--- a/pkg_defs/chandra_maneuver/meta.yaml
+++ b/pkg_defs/chandra_maneuver/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/chandra_time/meta.yaml
+++ b/pkg_defs/chandra_time/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/chandra_time

--- a/pkg_defs/cheta/meta.yaml
+++ b/pkg_defs/cheta/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/cheta

--- a/pkg_defs/cxotime/meta.yaml
+++ b/pkg_defs/cxotime/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/cxotime

--- a/pkg_defs/dea_check/meta.yaml
+++ b/pkg_defs/dea_check/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/dea_check

--- a/pkg_defs/dpa_check/meta.yaml
+++ b/pkg_defs/dpa_check/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/dpa_check

--- a/pkg_defs/fep1_actel_check/meta.yaml
+++ b/pkg_defs/fep1_actel_check/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/fep1_actel_check

--- a/pkg_defs/fep1_actel_check/meta.yaml
+++ b/pkg_defs/fep1_actel_check/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - setuptools_scm_git_archive
 
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/fep1_mong_check/meta.yaml
+++ b/pkg_defs/fep1_mong_check/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/fep1_mong_check

--- a/pkg_defs/fep1_mong_check/meta.yaml
+++ b/pkg_defs/fep1_mong_check/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - setuptools_scm_git_archive
 
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.

--- a/pkg_defs/find_attitude/meta.yaml
+++ b/pkg_defs/find_attitude/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 build:
   number: 1
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/fot-matlab/meta.yaml
+++ b/pkg_defs/fot-matlab/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/fss_check/meta.yaml
+++ b/pkg_defs/fss_check/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/fss_check

--- a/pkg_defs/hopper/meta.yaml
+++ b/pkg_defs/hopper/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/jobwatch/meta.yaml
+++ b/pkg_defs/jobwatch/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/jobwatch

--- a/pkg_defs/kadi-apps/meta.yaml
+++ b/pkg_defs/kadi-apps/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/kadi-apps/meta.yaml
+++ b/pkg_defs/kadi-apps/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - setuptools_scm_git_archive
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/kadi/meta.yaml
+++ b/pkg_defs/kadi/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/kadi

--- a/pkg_defs/kalman_watch/meta.yaml
+++ b/pkg_defs/kalman_watch/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/kalman_watch

--- a/pkg_defs/kalman_watch/meta.yaml
+++ b/pkg_defs/kalman_watch/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - setuptools_scm_git_archive
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/maude/meta.yaml
+++ b/pkg_defs/maude/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 

--- a/pkg_defs/mica/meta.yaml
+++ b/pkg_defs/mica/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/parse_cm/meta.yaml
+++ b/pkg_defs/parse_cm/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/perigee_health_plots/meta.yaml
+++ b/pkg_defs/perigee_health_plots/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/perigee_health_plots

--- a/pkg_defs/prompt-toolkit/meta.yaml
+++ b/pkg_defs/prompt-toolkit/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   skip: True  # [not win]
 
 source:

--- a/pkg_defs/proseco/meta.yaml
+++ b/pkg_defs/proseco/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/psmc_check/meta.yaml
+++ b/pkg_defs/psmc_check/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/psmc_check

--- a/pkg_defs/pyyaks/meta.yaml
+++ b/pkg_defs/pyyaks/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska-sphinx-theme/meta.yaml
+++ b/pkg_defs/ska-sphinx-theme/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_arc5gl/meta.yaml
+++ b/pkg_defs/ska_arc5gl/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_astro/meta.yaml
+++ b/pkg_defs/ska_astro/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_dbi/meta.yaml
+++ b/pkg_defs/ska_dbi/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_file/meta.yaml
+++ b/pkg_defs/ska_file/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_ftp/meta.yaml
+++ b/pkg_defs/ska_ftp/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_helpers/meta.yaml
+++ b/pkg_defs/ska_helpers/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_matplotlib/meta.yaml
+++ b/pkg_defs/ska_matplotlib/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_numpy/meta.yaml
+++ b/pkg_defs/ska_numpy/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - gcc_linux-64 # [linux]
     - libgcc-ng  # [linux]
     - clang_osx-64 # [osx]
-    - python==3.10
+    - python
     - numpy
     - setuptools
     - setuptools_scm

--- a/pkg_defs/ska_numpy/meta.yaml
+++ b/pkg_defs/ska_numpy/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/ska_numpy

--- a/pkg_defs/ska_parsecm/meta.yaml
+++ b/pkg_defs/ska_parsecm/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_path/meta.yaml
+++ b/pkg_defs/ska_path/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_quatutil/meta.yaml
+++ b/pkg_defs/ska_quatutil/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_report_ranges/meta.yaml
+++ b/pkg_defs/ska_report_ranges/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/ska_report_ranges

--- a/pkg_defs/ska_shell/meta.yaml
+++ b/pkg_defs/ska_shell/meta.yaml
@@ -5,7 +5,7 @@ package:
 
 build:
   noarch: python
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/ska_shell

--- a/pkg_defs/ska_sun/meta.yaml
+++ b/pkg_defs/ska_sun/meta.yaml
@@ -5,7 +5,7 @@ package:
 
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/ska_sync/meta.yaml
+++ b/pkg_defs/ska_sync/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/ska_sync

--- a/pkg_defs/ska_tdb/meta.yaml
+++ b/pkg_defs/ska_tdb/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: python
 
 source:

--- a/pkg_defs/skare3_tools/meta.yaml
+++ b/pkg_defs/skare3_tools/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python
     - setuptools
     - setuptools_scm
+    - setuptools_scm_git_archive
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/skare3_tools/meta.yaml
+++ b/pkg_defs/skare3_tools/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/skare3_tools

--- a/pkg_defs/sparkles/meta.yaml
+++ b/pkg_defs/sparkles/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/sparkles

--- a/pkg_defs/starcheck/meta.yaml
+++ b/pkg_defs/starcheck/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   number: 0
   noarch: python
 

--- a/pkg_defs/testr/meta.yaml
+++ b/pkg_defs/testr/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/testr

--- a/pkg_defs/twiki-wg/meta.yaml
+++ b/pkg_defs/twiki-wg/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/twiki-wg

--- a/pkg_defs/vv_trending/meta.yaml
+++ b/pkg_defs/vv_trending/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/vv_trending

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -3,7 +3,7 @@ package:
   version:  {{ SKA_PKG_VERSION }}
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/xija

--- a/pkg_defs_archived/django/meta.yaml
+++ b/pkg_defs_archived/django/meta.yaml
@@ -17,7 +17,7 @@ source:
 build:
   number: 0
   skip: True  # [py2k]
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   entry_points:
     - django-admin = django.core.management:execute_from_command_line
 

--- a/pkg_defs_archived/ska3_builder/meta.yaml
+++ b/pkg_defs_archived/ska3_builder/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 2020.01.13
 
 build:
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
   noarch: generic
 
 requirements:

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -129,7 +129,7 @@ def build_package(name, args, src_dir, build_dir, conda_args=None):
         overwrite_skare3_version(skare3_old_version, skare3_new_version, pkg_path)
 
     try:
-        version = subprocess.check_output(['python', 'setup.py', '--version'],
+        version = subprocess.check_output(['python', '-m', 'setuptools_scm'],
                                           cwd=os.path.join(src_dir, name))
         version = version.decode().split()[-1].strip()
         print(f'  - SKA_PKG_VERSION={version}')

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -60,6 +60,8 @@ def get_opt():
                         "except on Windows")
     parser.add_argument("--repo-url",
                         help="Use this URL instead of meta['about']['home']")
+    parser.add_argument("--channel", "-c", help="channel", action="append", default=[])
+    parser.add_argument("--override-channels", action="store_true", default=False)
     parser.add_argument('--ska3-overwrite-version',
                         metavar='[<initial-version>:]<final-version>',
                         help="This option is intended to overwrite ska3-* meta-package versions "
@@ -73,7 +75,7 @@ def get_opt():
 
 def clone_repo(name, args, src_dir, meta):
     tag = args.tag
-    print("  - Cloning or updating source source %s." % name)
+    print("  - Cloning or updating source: %s." % name)
     clone_path = os.path.join(src_dir, name)
 
     # Upstream (home) URL is for the tags
@@ -114,7 +116,9 @@ def clone_repo(name, args, src_dir, meta):
         print(f'  - Checked out at {tag} and pulled')
 
 
-def build_package(name, args, src_dir, build_dir):
+def build_package(name, args, src_dir, build_dir, conda_args=None):
+    if conda_args is None:
+        conda_args = []
     pkg_path = Path(src_dir) / 'pkg_defs' / name
     shutil.copytree(PKG_DEFS_PATH / name, pkg_path)
 
@@ -140,6 +144,7 @@ def build_package(name, args, src_dir, build_dir):
                 "--python", args.python,
                 "--numpy", args.numpy,
                 "--perl", args.perl]
+    cmd_list += conda_args
 
     if not args.test:
         cmd_list.append("--no-test")
@@ -170,7 +175,7 @@ def build_package(name, args, src_dir, build_dir):
     subprocess.run(cmd_list, check=True, shell=is_windows).check_returncode()
 
 
-def build_list_packages(pkg_names, args, src_dir, build_dir):
+def build_list_packages(pkg_names, args, src_dir, build_dir, conda_args=None):
     failures = []
     tstart = time.time()
 
@@ -200,7 +205,7 @@ def build_list_packages(pkg_names, args, src_dir, build_dir):
         try:
             if has_git:
                 clone_repo(pkg_name, args, src_dir, meta)
-            build_package(pkg_name, args, src_dir, build_dir)
+            build_package(pkg_name, args, src_dir, build_dir, conda_args=conda_args)
             print('')
         except Exception:
             # If there's a failure, confirm before continuing
@@ -306,11 +311,17 @@ def main():
         # Always use https on Windows since it just works
         args.github_https = True
 
+    conda_args = []
+    if args.override_channels:
+        conda_args += ["--override-channels"]
+    for channel in args.channel:
+        conda_args += ["-c", channel]
+
     build_dir = Path(args.build_root) / 'builds'
     with tempfile.TemporaryDirectory() as src_dir:
         print(f'Using temporary directory {src_dir} for cloning')
         os.environ["SKA_TOP_SRC_DIR"] = src_dir
-        build_list_packages(pkg_names, args, src_dir, build_dir)
+        build_list_packages(pkg_names, args, src_dir, build_dir, conda_args=conda_args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These are updates/improvements to the recipes and workflows for python 3.11. I used these to build python 3.11 packages from scratch. 

Normally, I do not include workflows in PRs, and do it directly instead. **This PR includes changes to recipes**.

Fixes #1203

## Updatest to recipes:
- build recipes use `pip install` instead of `python setup.py install`.
- add setuptools_scm_git_archive to build requirements wherever it was needed.
- `ska_builder.py` now passes arguments to `conda build`. This is so the build environment that is created by `conda build` can have our packages (`testr` and `ska_helpers`).
- Use `python -m setuptools_scm` instead of `python setup.py --version` in `ska_builder`. This finally gets rid of the PEP517 warning.

## Updates to workflows:

package_build workflow:
- use the latest setup-miniconda
- add optional channel to build workflow
  - use channel to create top-level environment
  - use channel in build environment (passing arguments to conda build)
- install ska_helpers and testr in top-level environment (only if they are in the conda channel)
- fix so build does not run on Mac and Windows unless noarch==False
- cache conda environment and packages
- cache conda env using hardwired directory names (a workaround)


build_package workflow:
- specify python and numpy versions
- fix the conditional to upload
- Make it so it writes a summary in the workflow summary page
- add arguments so it can be used to build packages with different python versions
- add arguments so packages can be uploaded to any conda channel (test, speedy, etc)

conda_meta.yml workflow:
- use the latest setup-miniconda
- change conda channels in environment


# Functional Tests

These workflows were used to produce the 2024.0 pre-releases. Yesterday and today I made some updates to improve documentation, and to make sure I can use the same workflow to build in different python versions, and using different conda channels.

To test these workflows, one needs the main workflow in master, so I have a copy of the `build_package.yml` workflow in another repo (test-actions), and there I ran the following:
```
from skare3_tools import github
repo = github.Repository("sot/test-actions")

repo.dispatch_event(
   "build-package",
   client_payload={
       "package": "sot/cxotime",
       "tag": '3.8.0',
       "arch": False,
       "skare3_branch": "speedy-build",
       "python_version": "3.10.8",
       "channel_in": "flight",
       "channel_out": "test",
       "upload": False,
   }
)

repo.dispatch_event(
   "build-package",
   client_payload={
       "package": "sot/cxotime",
       "tag": '3.8.0',
       "arch": False,
       "skare3_branch": "speedy-build",
       "python_version": "3.11",
       "channel_in": "speedy",
       "channel_out": "speedy",
       "upload": False,
   }
)
```

and these are the corresponding workflows:
- https://github.com/sot/test-actions/actions/runs/7935314705
- https://github.com/sot/test-actions/actions/runs/7935311003