### PR TITLE
2024.2

### DIFF
--- a/pkg_defs/ska3-core-latest/base_environment.yml
+++ b/pkg_defs/ska3-core-latest/base_environment.yml
@@ -1,7 +1,8 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.11
+  - numexpr<2.8.5
   - libblas=*=*mkl  # on conda-forge, libblas uses open_blas by default
   - conda-forge::libarchive  # libarchive from defaults is not good for mamba
   - mamba

--- a/pkg_defs/ska3-core-latest/install_from_scratch.py
+++ b/pkg_defs/ska3-core-latest/install_from_scratch.py
@@ -8,9 +8,9 @@ import logging
 assert "CONDA_PASSWORD" in os.environ, "CONDA_PASSWORD environmental variable is not defined"
 
 CHANNELS = [
-    'defaults',
+    # 'defaults',
     'conda-forge',
-    f'https://ska:{os.environ["CONDA_PASSWORD"]}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight'
+    # f'https://ska:{os.environ["CONDA_PASSWORD"]}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight'
 ]
 
 
@@ -18,7 +18,7 @@ CHANNELS = [
 PACKAGES = [
     {
         'channels': CHANNELS,
-        'options': ['--no-channel-priority'],
+        'options': [],
         'packages': ['numpy', 'matplotlib', 'scipy', 'pandas', 'astropy', 'pyyaml', 'conda-build',
                      'pyqt']
     },
@@ -27,10 +27,15 @@ PACKAGES = [
         'options': [],
         'packages': ['django==3.1.7']
     },
-    {  # this is not in defaults or conda-forge (for now?)
-        'channels': ['astropy'],
+    {  # later versions cause a conflict with nb_conda
+        'channels': CHANNELS,
         'options': [],
-        'packages': ['regions']
+        'packages': ['notebook==6.5.6']
+    },
+    {  # this is not in defaults or conda-forge (for now?)
+        'channels': ['sherpa'] + CHANNELS,
+        'options': [],
+        'packages': ['sherpa']
     },
 ]
 
@@ -46,7 +51,7 @@ PLATFORM_OPTIONS = {
 
 def install_pkgs(pkgs):
     channels = sum([['-c', c] for c in pkgs['channels']], [])
-    cmd = ['mamba', 'install', '-y'] + pkgs['options'] + channels + pkgs['packages']
+    cmd = ['mamba', 'install', '-y', '--override-channels'] + pkgs['options'] + channels + pkgs['packages']
     logging.info(' '.join(cmd))
     subprocess.run(cmd)
 

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core-latest
-  version: "2023.10"
+  version: 2024.1
 
 requirements:
   run:

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -51,7 +51,6 @@ requirements:
    - pillow
    - pip
    - flake8
-   - pycrypto
    - pylint
    - plotly
    - ply

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,240 +1,238 @@
 ---
 package:
   name: ska3-core
-  version: "2023.10"
+  version: 2024.1
 
 requirements:
   run:
     - _libgcc_mutex ==0.1  # [linux]
     - _openmp_mutex ==4.5  # [linux]
-    - alabaster ==0.7.13
-    - alsa-lib ==1.2.8  # [linux]
-    - anyio ==3.6.2
-    - appdirs ==1.4.4
+    - alabaster ==0.7.16
+    - alsa-lib ==1.2.10  # [linux]
+    - anyio ==4.2.0
     - appnope ==0.1.3  # [osx]
-    - argon2-cffi ==21.3.0
+    - archspec ==0.2.2
+    - argon2-cffi ==23.1.0
     - argon2-cffi-bindings ==21.2.0
+    - arrow ==1.3.0
     - asgiref ==3.3.4
-    - astroid ==2.13.2
-    - astropy ==5.3.1
-    - astropy-healpix ==0.7
-    - astropy-iers-data==0.2024.1.8.0.30.55
+    - astroid ==3.0.2
+    - astropy ==6.0.0
+    - astropy-healpix ==1.0.2
+    - astropy-iers-data ==0.2024.1.8.0.30.55
     - astropy-sphinx-theme ==1.1
     - astroquery ==0.4.6
-    - asttokens ==2.2.1
+    - asttokens ==2.4.1
+    - async-lru ==2.0.4
     - attr ==2.5.1  # [linux]
-    - attrs ==22.2.0
-    - autopep8 ==2.0.1
-    - babel ==2.11.0
-    - backcall ==0.2.0
+    - attrs ==23.2.0
+    - autopep8 ==2.0.4
+    - babel ==2.14.0
     - backports ==1.0
-    - backports.functools_lru_cache ==1.6.4
     - backports.zoneinfo ==0.2.1
-    - bcrypt ==3.2.0  # [linux or osx]
-    - bcrypt ==3.2.2  # [win]
-    - beautifulsoup4 ==4.11.1
-    - black ==23.1.0
-    - bleach ==5.0.1
-    - blinker ==1.5
-    - blosc ==1.21.1  # [linux or osx]
-    - blosc ==1.21.3  # [win]
-    - bokeh ==3.0.3
-    - brotli ==1.0.9
-    - brotli-bin ==1.0.9
-    - brotlipy ==0.7.0
+    - bcrypt ==4.1.2
+    - beautifulsoup4 ==4.12.2
+    - black ==23.12.1
+    - bleach ==6.1.0
+    - blinker ==1.7.0
+    - blosc ==1.21.5
+    - bokeh ==3.3.3
+    - boltons ==23.1.1
+    - brotli ==1.1.0
+    - brotli-bin ==1.1.0
+    - brotli-python ==1.1.0
     - bzip2 ==1.0.8
-    - c-ares ==1.18.1  # [linux or osx]
-    - ca-certificates ==2022.12.7
+    - c-ares ==1.25.0  # [linux or osx]
+    - c-blosc2 ==2.12.0
+    - ca-certificates ==2023.11.17
     - cached-property ==1.5.2
     - cached_property ==1.5.2
+    - cairo ==1.18.0  # [linux]
     - cctools ==973.0.1  # [osx]
     - cctools_osx-64 ==973.0.1  # [osx]
-    - certifi ==2022.12.7
-    - cffi ==1.15.1
-    - chardet ==5.1.0
-    - charset-normalizer ==2.1.1
-    - click ==8.1.3
-    - cloudpickle ==2.2.1  # [win]
+    - certifi ==2023.11.17
+    - cffi ==1.16.0
+    - chardet ==5.2.0
+    - charset-normalizer ==3.3.2
+    - click ==8.1.7
+    - cloudpickle ==3.0.0  # [win]
     - colorama ==0.4.6
-    - comm ==0.1.2
+    - comm ==0.2.1
     - commonmark ==0.9.1
-    - conda ==22.11.1
-    - conda-build ==3.23.3
-    - conda-package-handling ==2.0.2
-    - conda-package-streaming ==0.7.0
-    - coverage ==7.2.1
-    - configobj ==5.0.6  # [linux or osx]
-    - configobj ==5.0.7  # [win]
-    - contourpy ==1.0.7
-    - cryptography ==39.0.0
-    - cycler ==0.11.0
-    - cython ==0.29.33
+    - conda ==23.11.0
+    - conda-build ==3.28.3
+    - conda-index ==0.3.0
+    - conda-libmamba-solver ==23.12.0
+    - conda-package-handling ==2.2.0
+    - conda-package-streaming ==0.9.0
+    - configobj ==5.0.8
+    - contourpy ==1.2.0
+    - coverage ==7.4.0
+    - cryptography ==41.0.7
+    - cycler ==0.12.1
+    - cython ==3.0.7
     - dbus ==1.13.6  # [linux]
-    - debugpy ==1.6.5
+    - debugpy ==1.8.0
     - decorator ==5.1.1
     - defusedxml ==0.7.1
-    - dill ==0.3.6
+    - dill ==0.3.7
+    - distro ==1.9.0
     - django ==3.1.7
-    - docutils ==0.19
+    - docutils ==0.20.1
     - docxtpl ==0.11.5
     - entrypoints ==0.4
-    - et_xmlfile ==1.0.1
-    - exceptiongroup ==1.0.4  # [win]
-    - exceptiongroup ==1.1.0  # [linux or osx]
-    - executing ==1.2.0
+    - et_xmlfile ==1.1.0
+    - exceptiongroup ==1.2.0
+    - executing ==2.0.1
     - expat ==2.5.0  # [linux]
-    - fftw ==3.3.10  # [linux]
-    - filelock ==3.9.0
-    - flake8 ==6.0.0
-    - flit-core ==3.8.0
-    - fmt ==9.1.0
+    - filelock ==3.13.1
+    - flake8 ==7.0.0
+    - fmt ==10.1.1
     - font-ttf-dejavu-sans-mono ==2.37  # [linux]
     - font-ttf-inconsolata ==3.000  # [linux]
     - font-ttf-source-code-pro ==2.038  # [linux]
     - font-ttf-ubuntu ==0.83  # [linux]
-    - fontconfig ==2.14.1  # [linux]
+    - fontconfig ==2.14.2  # [linux]
     - fonts-conda-ecosystem ==1  # [linux]
     - fonts-conda-forge ==1  # [linux]
-    - fonttools ==4.38.0
+    - fonttools ==4.47.0
+    - fqdn ==1.5.1
     - freetype ==2.12.1
     - future ==0.18.3
     - gettext ==0.21.1
     - giflib ==5.2.1  # [linux or osx]
-    - git ==2.39.1  # [win]
-    - gitdb ==4.0.10
-    - gitpython ==3.1.30
-    - glib ==2.74.1
-    - glib-tools ==2.74.1
-    - glob2 ==0.7
-    - greenlet ==2.0.1  # [win]
-    - gst-plugins-base ==1.21.3
-    - gstreamer ==1.21.3
-    - gstreamer-orc ==0.4.33  # [linux]
-    - h5py ==3.7.0
-    - hdf5 ==1.12.2
+    - git ==2.43.0  # [win]
+    - gitdb ==4.0.11
+    - gitpython ==3.1.40
+    - glib ==2.78.3
+    - glib-tools ==2.78.3
+    - gmp ==6.3.0  # [linux]
+    - graphite2 ==1.3.13  # [linux]
+    - greenlet ==3.0.3  # [win]
+    - gst-plugins-base ==1.22.8
+    - gstreamer ==1.22.8
+    - h5py ==3.10.0
+    - harfbuzz ==8.3.0  # [linux]
+    - hdf5 ==1.14.3
     - html5lib ==1.1
-    - icu ==70.1
-    - idna ==3.4
+    - icu ==73.2
+    - idna ==3.6
     - imagesize ==1.4.1
-    - importlib-metadata ==6.0.0
-    - importlib_metadata ==6.0.0
-    - importlib_resources ==5.10.2
-    - iniconfig ==1.1.1  # [win]
-    - iniconfig ==2.0.0  # [linux or osx]
-    - intel-openmp ==2023.0.0  # [win]
-    - ipykernel ==6.20.2
-    - ipympl ==0.9.2
-    - ipyparallel ==6.3.0  # [linux or osx]
-    - ipyparallel ==8.4.1  # [win]
-    - ipython ==8.8.0
+    - importlib-metadata ==7.0.1
+    - importlib_metadata ==7.0.1
+    - importlib_resources ==6.1.1
+    - iniconfig ==2.0.0
+    - intel-openmp ==2024.0.0  # [win]
+    - ipykernel ==6.28.0
+    - ipympl ==0.9.3
+    - ipyparallel ==8.6.1
+    - ipython ==8.20.0
     - ipython_genutils ==0.2.0
-    - ipywidgets ==8.0.4
-    - isort ==5.12.0
-    - jack ==1.9.21  # [linux]
-    - jaraco.classes ==3.2.3
-    - jedi ==0.18.2
+    - ipywidgets ==8.1.1
+    - isoduration ==20.11.0
+    - isort ==5.13.2
+    - jaraco.classes ==3.3.0
+    - jedi ==0.19.1
     - jeepney ==0.8.0  # [linux]
     - jinja2 ==3.1.2
-    - jira ==3.4.1
-    - joblib ==1.2.0
-    - jpeg ==9e
-    - jplephem ==2.18
-    - json5 ==0.9.5
-    - jsonschema ==4.17.3
+    - jira ==3.6.0
+    - joblib ==1.3.2
+    - jplephem ==2.21
+    - json5 ==0.9.14
+    - jsonpatch ==1.33
+    - jsonpointer ==2.4
+    - jsonschema ==4.20.0
+    - jsonschema-specifications ==2023.12.1
+    - jsonschema-with-format-nongpl ==4.20.0
     - jupyter ==1.0.0
+    - jupyter-lsp ==2.2.1
     - jupyter_client ==7.4.9
-    - jupyter_console ==6.4.4
-    - jupyter_core ==5.1.3
-    - jupyter_events ==0.6.3
-    - jupyter_server ==2.1.0
-    - jupyter_server_terminals ==0.4.4
-    - jupyterlab ==3.5.2
-    - jupyterlab_pygments ==0.2.2
-    - jupyterlab_server ==2.19.0
-    - jupyterlab_widgets ==3.0.5
+    - jupyter_console ==6.6.3
+    - jupyter_core ==5.7.1
+    - jupyter_events ==0.9.0
+    - jupyter_server ==2.12.3
+    - jupyter_server_terminals ==0.5.1
+    - jupyterlab ==4.0.10
+    - jupyterlab_pygments ==0.3.0
+    - jupyterlab_server ==2.25.2
+    - jupyterlab_widgets ==3.0.9
     - kaleido-core ==0.2.1
-    - keyring ==23.13.1
+    - keyring ==24.3.0
     - keyutils ==1.6.1  # [linux]
-    - kiwisolver ==1.4.4
-    - krb5 ==1.20.1
+    - kiwisolver ==1.4.5
+    - krb5 ==1.21.2
     - lame ==3.100  # [linux]
-    - lazy-object-proxy ==1.9.0
-    - lcms2 ==2.14
+    - lcms2 ==2.16
     - ld64 ==609  # [osx]
     - ld64_osx-64 ==609  # [osx]
-    - ld_impl_linux-64 ==2.39  # [linux]
+    - ld_impl_linux-64 ==2.40  # [linux]
     - lerc ==4.0.0
-    - libaec ==1.0.6
-    - libarchive ==3.6.2
+    - libaec ==1.1.2
+    - libarchive ==3.7.2
     - libblas ==3.9.0
-    - libbrotlicommon ==1.0.9
-    - libbrotlidec ==1.0.9
-    - libbrotlienc ==1.0.9
-    - libcap ==2.66  # [linux]
+    - libbrotlicommon ==1.1.0
+    - libbrotlidec ==1.1.0
+    - libbrotlienc ==1.1.0
+    - libcap ==2.69  # [linux]
     - libcblas ==3.9.0
-    - libclang ==13.0.1  # [osx]
-    - libclang ==15.0.7  # [linux or win]
-    - libclang13 ==15.0.7  # [linux or win]
+    - libclang ==15.0.7
+    - libclang13 ==15.0.7
     - libcups ==2.3.3  # [linux]
-    - libcurl ==7.88.1
-    - libcxx ==16.0.4  # [osx]
-    - libdb ==6.2.32  # [linux]
-    - libdeflate ==1.17
+    - libcurl ==8.5.0
+    - libcxx ==16.0.6  # [osx]
+    - libdeflate ==1.19
     - libedit ==3.1.20191231  # [linux or osx]
     - libev ==4.33  # [linux or osx]
-    - libevent ==2.1.10  # [linux]
+    - libevent ==2.1.12  # [linux]
+    - libexpat ==2.5.0
     - libffi ==3.4.2
-    - libflac ==1.4.2  # [linux]
-    - libgcc-ng ==12.2.0  # [linux]
-    - libgcrypt ==1.10.1  # [linux]
+    - libflac ==1.4.3  # [linux]
+    - libgcc-ng ==13.2.0  # [linux]
+    - libgcrypt ==1.10.3  # [linux]
     - libgfortran ==5.0.0  # [osx]
-    - libgfortran-ng ==12.2.0  # [linux]
-    - libgfortran5 ==11.3.0  # [osx]
-    - libgfortran5 ==12.2.0  # [linux]
-    - libglib ==2.74.1
-    - libgpg-error ==1.46  # [linux]
-    - libhwloc ==2.8.0  # [linux or win]
+    - libgfortran-ng ==13.2.0  # [linux]
+    - libgfortran5 ==13.2.0  # [linux or osx]
+    - libglib ==2.78.3
+    - libgpg-error ==1.47  # [linux]
     - libiconv ==1.17
-    - libjpeg-turbo ==2.1.4
+    - libjpeg-turbo ==3.0.0
     - liblapack ==3.9.0
     - liblief ==0.12.3
-    - libllvm11 ==11.1.0  # [linux or osx]
-    - libllvm13 ==13.0.1  # [osx]
-    - libllvm14 ==14.0.6  # [osx]
-    - libllvm15 ==15.0.7  # [linux]
-    - libmamba ==1.3.1
-    - libmambapy ==1.3.1
-    - libnghttp2 ==1.51.0  # [linux or osx]
-    - libnsl ==2.0.0  # [linux]
+    - libllvm14 ==14.0.6  # [linux or osx]
+    - libllvm15 ==15.0.7  # [linux or osx]
+    - libllvm16 ==16.0.6  # [osx]
+    - libmamba ==1.5.6
+    - libmambapy ==1.5.6
+    - libnghttp2 ==1.58.0  # [linux or osx]
+    - libnsl ==2.0.1  # [linux]
     - libogg ==1.3.4
     - libopus ==1.3.1  # [linux or osx]
     - libpng ==1.6.39
-    - libpq ==15.1  # [linux or osx]
-    - libsndfile ==1.2.0  # [linux]
+    - libpq ==16.1  # [linux or osx]
+    - libsndfile ==1.2.2  # [linux]
     - libsodium ==1.0.18
-    - libsolv ==0.7.23
-    - libsqlite ==3.40.0
-    - libssh2 ==1.10.0
-    - libstdcxx-ng ==12.2.0  # [linux]
-    - libsystemd0 ==252  # [linux]
-    - libtiff ==4.5.0
-    - libtool ==2.4.7  # [linux]
-    - libudev1 ==252  # [linux]
-    - libuuid ==2.32.1  # [linux]
-    - libuv ==1.44.2  # [linux or osx]
+    - libsolv ==0.7.27
+    - libsqlite ==3.44.2
+    - libssh2 ==1.11.0
+    - libstdcxx-ng ==13.2.0  # [linux]
+    - libsystemd0 ==255  # [linux]
+    - libtiff ==4.6.0
+    - libuuid ==2.38.1  # [linux]
+    - libuv ==1.46.0  # [linux or osx]
     - libvorbis ==1.3.7
-    - libwebp ==1.2.4
-    - libwebp-base ==1.2.4
-    - libxcb ==1.13
-    - libxkbcommon ==1.0.3  # [linux]
-    - libxml2 ==2.10.3
-    - libxslt ==1.1.37
+    - libwebp ==1.3.2
+    - libwebp-base ==1.3.2
+    - libxcb ==1.15
+    - libxcrypt ==4.4.36  # [linux]
+    - libxkbcommon ==1.6.0  # [linux]
+    - libxml2 ==2.12.3
+    - libxslt ==1.1.39
     - libzlib ==1.2.13
-    - line_profiler ==4.0.2
-    - llvm-openmp ==15.0.7  # [linux or osx]
-    - llvmlite ==0.39.1
-    - lxml ==4.9.2
-    - lz4-c ==1.9.3
+    - line_profiler ==4.1.1
+    - llvm-openmp ==17.0.6  # [linux or osx]
+    - llvmlite ==0.41.1
+    - lxml ==5.1.0
+    - lz4-c ==1.9.4
     - lzo ==2.10
     - m2-msys2-runtime ==2.5.0.17080.65c939c  # [win]
     - m2-patch ==2.7.5  # [win]
@@ -243,217 +241,244 @@ requirements:
     - m2w64-gcc-libs-core ==5.3.0  # [win]
     - m2w64-gmp ==6.1.0  # [win]
     - m2w64-libwinpthread-git ==5.0.0.4634.697f757  # [win]
-    - mamba ==1.3.1
-    - markupsafe ==2.1.2
+    - mamba ==1.5.6
+    - markupsafe ==2.1.3
     - mathjax ==2.7.7
-    - matplotlib ==3.6.3
-    - matplotlib-base ==3.6.3
+    - matplotlib ==3.8.2
+    - matplotlib-base ==3.8.2
     - matplotlib-inline ==0.1.6
     - mccabe ==0.7.0
-    - menuinst ==1.4.19  # [win]
-    - mistune ==2.0.4
+    - menuinst ==2.0.1
+    - mistune ==3.0.2
     - mkl ==2022.1.0  # [win]
-    - mkl ==2022.2.1  # [linux or osx]
-    - more-itertools ==9.0.0
-    - mpg123 ==1.31.2  # [linux]
-    - mpld3 ==0.5.9
+    - mkl ==2022.2.1  # [linux]
+    - mkl ==2023.2.0  # [osx]
+    - more-itertools ==10.2.0
+    - mpg123 ==1.32.3  # [linux]
+    - mpld3 ==0.5.10
     - msys2-conda-epoch ==20160418  # [win]
     - munkres ==1.1.4
-    - mypy_extensions ==0.4.3
-    - mysql-common ==8.0.31  # [osx]
-    - mysql-common ==8.0.32  # [linux]
-    - mysql-libs ==8.0.31  # [osx]
-    - mysql-libs ==8.0.32  # [linux]
+    - mypy_extensions ==1.0.0
+    - mysql-common ==8.0.33  # [linux or osx]
+    - mysql-libs ==8.0.33  # [linux or osx]
     - nb_conda ==2.2.1
     - nb_conda_kernels ==2.3.1
-    - nbclassic ==0.4.8
-    - nbclient ==0.7.2
-    - nbconvert ==7.2.8
-    - nbconvert-core ==7.2.8
-    - nbconvert-pandoc ==7.2.8
-    - nbformat ==5.7.3
-    - ncurses ==6.3  # [linux or osx]
-    - nest-asyncio ==1.5.6
-    - networkx ==3.0
-    - nodejs ==18.12.1
+    - nbclassic ==1.0.0
+    - nbclient ==0.8.0
+    - nbconvert ==7.14.0
+    - nbconvert-core ==7.14.0
+    - nbconvert-pandoc ==7.14.0
+    - nbformat ==5.9.2
+    - ncurses ==6.4  # [linux or osx]
+    - nest-asyncio ==1.5.8
+    - networkx ==3.2.1
+    - nodejs ==20.9.0
     - nose ==1.3.7
-    - notebook ==6.5.2
-    - notebook-shim ==0.2.2
+    - notebook ==6.5.6
+    - notebook-shim ==0.2.3
     - nspr ==4.35  # [linux or osx]
-    - nss ==3.78  # [osx]
-    - nss ==3.82  # [linux]
-    - numba ==0.56.4
-    - numexpr ==2.7.3  # [linux or win]
-    - numexpr ==2.8.3  # [osx]
-    - numpy ==1.23.5
-    - numpydoc ==1.5.0
+    - nss ==3.96  # [linux or osx]
+    - numba ==0.58.1
+    - numexpr ==2.8.4
+    - numpy ==1.26.3
+    - numpydoc ==1.6.0
     - oauthlib ==3.2.2
     - openjpeg ==2.5.0
-    - openpyxl ==3.0.10
-    - openssl ==3.0.8
-    - packaging ==23.0
-    - pandas ==1.5.3
-    - pandoc ==2.19.2
+    - openpyxl ==3.1.2
+    - openssl ==3.2.0
+    - overrides ==7.4.0
+    - packaging ==23.2
+    - pandas ==2.1.4
+    - pandoc ==3.1.3
     - pandocfilters ==1.5.0
-    - paramiko ==2.8.1
+    - paramiko ==3.4.0
     - parso ==0.8.3
     - patch ==2.7.6  # [linux or osx]
     - patchelf ==0.17.2  # [linux]
-    - pathspec ==0.10.3
-    - pcre2 ==10.40
+    - pathspec ==0.12.1
+    - pcre2 ==10.42
     - pexpect ==4.8.0
     - pickleshare ==0.7.5
-    - pillow ==9.4.0
-    - pip ==22.3.1
+    - pillow ==10.2.0
+    - pip ==23.3.2
+    - pixman ==0.43.0  # [linux]
     - pkginfo ==1.9.6
     - pkgutil-resolve-name ==1.3.10
-    - platformdirs ==2.6.2
-    - plotly ==5.12.0
-    - pluggy ==1.0.0
+    - platformdirs ==4.1.0
+    - plotly ==5.18.0
+    - pluggy ==1.3.0
     - ply ==3.11
-    - pooch ==1.6.0
-    - prometheus_client ==0.15.0
-    - prompt-toolkit ==3.0.36
-    - prompt_toolkit ==3.0.36
-    - psutil ==5.9.4
+    - prometheus_client ==0.19.0
+    - prompt-toolkit ==3.0.42
+    - prompt_toolkit ==3.0.42
+    - psutil ==5.9.7
     - pthread-stubs ==0.4
-    - pthreads-win32 ==2.9.1  # [win]
     - ptyprocess ==0.7.0
-    - pulseaudio ==16.1  # [linux]
+    - pulseaudio-client ==16.1  # [linux]
     - pure_eval ==0.2.2
+    - py-cpuinfo ==9.0.0
     - py-lief ==0.12.3
     - pybind11-abi ==4
-    - pycodestyle ==2.10.0
-    - pycosat ==0.6.4
+    - pycodestyle ==2.11.1
+    - pycosat ==0.6.6
     - pycparser ==2.21
-    - pycrypto ==2.6.1
-    - pyerfa ==2.0.0.1
-    - pyflakes ==3.0.1
-    - pygments ==2.14.0
-    - pyjwt ==2.6.0
-    - pylint ==2.15.10
+    - pyerfa ==2.0.1.1
+    - pyflakes ==3.2.0
+    - pygments ==2.17.2
+    - pyjwt ==2.8.0
+    - pylint ==3.0.3
     - pynacl ==1.5.0
-    - pyopenssl ==23.0.0
-    - pyparsing ==3.0.9
-    - pyqt ==5.15.7
-    - pyqt5-sip ==12.11.0
-    - pyqtgraph ==0.13.1
-    - pyrsistent ==0.19.3
+    - pyobjc-core ==10.1  # [osx]
+    - pyobjc-framework-cocoa ==10.1  # [osx]
+    - pyparsing ==3.1.1
+    - pyqt ==5.15.9
+    - pyqt5-sip ==12.12.2
+    - pyqtgraph ==0.13.3
     - pysocks ==1.7.1
-    - pytables ==3.7.0
-    - pytest ==7.2.0  # [win]
-    - pytest ==7.2.1  # [linux or osx]
-    - pytest-timeout ==2.1.0
-    - python ==3.10.8
+    - pytables ==3.9.2
+    - pytest ==7.4.4
+    - pytest-timeout ==2.2.0
+    - python ==3.11.7
     - python-dateutil ==2.8.2
-    - python-docx ==0.8.11
-    - python-fastjsonschema ==2.16.2
-    - python-json-logger ==2.0.4
+    - python-docx ==1.1.0
+    - python-fastjsonschema ==2.19.1
+    - python-json-logger ==2.0.7
     - python-kaleido ==0.2.1
-    - python-libarchive-c ==4.0
-    - python_abi ==3.10
-    - pytoolconfig ==1.2.4
-    - pytz ==2022.7.1
-    - pyvo ==1.4
-    - pywin32 ==304  # [win]
-    - pywin32-ctypes ==0.2.0  # [win]
-    - pywinpty ==2.0.10  # [win]
-    - pyyaml ==6.0
-    - pyzmq ==25.0.0
-    - qt ==5.15.6
-    - qt-main ==5.15.6
-    - qt-webengine ==5.15.4
-    - qtconsole ==5.4.0
-    - qtconsole-base ==5.4.0
-    - qtpy ==2.3.0
-    - readline ==8.1.2  # [linux or osx]
-    - regions ==0.6
-    - reproc ==14.2.4
-    - reproc-cpp ==14.2.4
-    - requests ==2.28.2
+    - python-libarchive-c ==5.0
+    - python-tzdata ==2023.4
+    - python_abi ==3.11
+    - pytoolconfig ==1.2.5
+    - pytz ==2023.3.post1
+    - pyvo ==1.5
+    - pywin32 ==306  # [win]
+    - pywin32-ctypes ==0.2.2  # [win]
+    - pywinpty ==2.0.12  # [win]
+    - pyyaml ==6.0.1
+    - pyzmq ==24.0.1
+    - qt ==5.15.8
+    - qt-main ==5.15.8
+    - qt-webengine ==5.15.8
+    - qtconsole ==5.5.1
+    - qtconsole-base ==5.5.1
+    - qtpy ==2.4.1
+    - readline ==8.2  # [linux or osx]
+    - referencing ==0.32.1
+    - regions ==0.8
+    - reproc ==14.2.4.post0
+    - reproc-cpp ==14.2.4.post0
+    - requests ==2.31.0
     - requests-oauthlib ==1.3.1
-    - requests-toolbelt ==0.10.1
+    - requests-toolbelt ==1.0.0
     - rfc3339-validator ==0.1.4
     - rfc3986-validator ==0.1.1
-    - ripgrep ==13.0.0
-    - rope ==1.6.0
-    - ruamel.yaml ==0.17.21
+    - ripgrep ==14.0.3
+    - rope ==1.11.0
+    - rpds-py ==0.16.2
+    - ruamel.yaml ==0.18.5
     - ruamel.yaml.clib ==0.2.7
-    - ruff ==0.0.220
-    - scikit-learn ==1.2.0
-    - scipy ==1.10.0
+    - ruff ==0.1.11
+    - scikit-learn ==1.3.2
+    - scipy ==1.11.4
     - secretstorage ==3.3.3  # [linux]
-    - send2trash ==1.8.0
-    - setuptools ==65.6.3
-    - setuptools-scm ==7.1.0
-    - setuptools_scm ==7.1.0
-    - sherpa ==4.15.0  # [linux or osx]
+    - send2trash ==1.8.2
+    - setuptools ==69.0.3
+    - setuptools-scm ==8.0.4
+    - setuptools_scm ==8.0.4
+    - sherpa ==4.15.1  # [linux or osx]
     - sigtool ==0.1.3  # [osx]
-    - sip ==6.7.5
+    - sip ==6.7.12
     - six ==1.16.0
-    - smmap ==3.0.5
-    - snappy ==1.1.9
+    - smmap ==5.0.0
+    - snappy ==1.1.10
     - sniffio ==1.3.0
     - snowballstemmer ==2.2.0
-    - soupsieve ==2.3.2.post1
-    - sphinx ==6.1.3
-    - sphinx-argparse ==0.3.1
-    - sphinxcontrib-applehelp ==1.0.2
-    - sphinxcontrib-devhelp ==1.0.2
-    - sphinxcontrib-htmlhelp ==2.0.0
+    - soupsieve ==2.5
+    - sphinx ==7.2.6
+    - sphinx-argparse ==0.4.0
+    - sphinxcontrib-applehelp ==1.0.7
+    - sphinxcontrib-devhelp ==1.0.5
+    - sphinxcontrib-htmlhelp ==2.0.4
     - sphinxcontrib-jsmath ==1.0.1
-    - sphinxcontrib-qthelp ==1.0.3
-    - sphinxcontrib-serializinghtml ==1.1.5
-    - sqlalchemy ==1.4.46  # [win]
-    - sqlite ==3.40.0
-    - sqlparse ==0.4.3
+    - sphinxcontrib-qthelp ==1.0.6
+    - sphinxcontrib-serializinghtml ==1.1.9
+    - sqlalchemy ==2.0.25  # [win]
+    - sqlite ==3.44.2
+    - sqlparse ==0.4.4
     - stack_data ==0.6.2
+    - tabulate ==0.9.0
     - tapi ==1100.0.11  # [osx]
-    - tbb ==2021.7.0
-    - tenacity ==8.1.0
-    - terminado ==0.17.0  # [win]
-    - terminado ==0.17.1  # [linux or osx]
-    - threadpoolctl ==3.1.0
+    - tbb ==2021.10.0  # [osx]
+    - tbb ==2021.7.0  # [linux or win]
+    - tenacity ==8.2.3
+    - terminado ==0.18.0
+    - threadpoolctl ==3.2.0
     - tinycss2 ==1.2.1
-    - tk ==8.6.12
+    - tk ==8.6.13
     - toml ==0.10.2
     - tomli ==2.0.1
-    - tomlkit ==0.11.6
-    - toolz ==0.12.0
-    - tornado ==6.2
-    - tqdm ==4.64.1
-    - traitlets ==5.8.1
-    - typing ==3.10.0.0
-    - typing-extensions ==4.4.0
-    - typing_extensions ==4.4.0
-    - tzdata ==2022g
+    - tomlkit ==0.12.3
+    - tornado ==6.3.3
+    - tqdm ==4.66.1
+    - traitlets ==5.14.1
+    - truststore ==0.8.0
+    - types-python-dateutil ==2.8.19.20240106
+    - typing-extensions ==4.9.0
+    - typing_extensions ==4.9.0
+    - typing_utils ==0.1.0
+    - tzdata ==2023d
     - ucrt ==10.0.22621.0  # [win]
-    - unicodedata2 ==15.0.0
-    - urllib3 ==1.26.14
+    - uri-template ==1.3.0
+    - urllib3 ==2.1.0
     - vc ==14.3  # [win]
-    - vc14_runtime ==14.34.31931  # [win]
-    - vs2015_runtime ==14.34.31931  # [win]
-    - wcwidth ==0.2.6
+    - vc14_runtime ==14.38.33130  # [win]
+    - vs2015_runtime ==14.38.33130  # [win]
+    - wcwidth ==0.2.13
+    - webcolors ==1.13
     - webencodings ==0.5.1
-    - websocket-client ==1.4.2
-    - wheel ==0.38.4
-    - widgetsnbextension ==4.0.5
+    - websocket-client ==1.7.0
+    - wheel ==0.42.0
+    - widgetsnbextension ==4.0.9
     - win_inet_pton ==1.1.0  # [win]
     - winpty ==0.4.3  # [win]
-    - wrapt ==1.14.1
     - xcb-util ==0.4.0  # [linux]
     - xcb-util-image ==0.4.0  # [linux]
     - xcb-util-keysyms ==0.4.0  # [linux]
     - xcb-util-renderutil ==0.3.9  # [linux]
     - xcb-util-wm ==0.4.1  # [linux]
-    - xorg-libxau ==1.0.9
+    - xkeyboard-config ==2.40  # [linux]
+    - xorg-compositeproto ==0.4.2  # [linux]
+    - xorg-damageproto ==1.2.1  # [linux]
+    - xorg-fixesproto ==5.0  # [linux]
+    - xorg-inputproto ==2.3.2  # [linux]
+    - xorg-kbproto ==1.0.7  # [linux]
+    - xorg-libice ==1.1.1  # [linux]
+    - xorg-libsm ==1.2.4  # [linux]
+    - xorg-libx11 ==1.8.7  # [linux]
+    - xorg-libxau ==1.0.11
+    - xorg-libxcomposite ==0.4.6  # [linux]
+    - xorg-libxdamage ==1.1.5  # [linux]
     - xorg-libxdmcp ==1.1.3
-    - xyzservices ==2022.9.0
+    - xorg-libxext ==1.3.4  # [linux]
+    - xorg-libxfixes ==5.0.3  # [linux]
+    - xorg-libxi ==1.7.10  # [linux]
+    - xorg-libxrandr ==1.5.2  # [linux]
+    - xorg-libxrender ==0.9.11  # [linux]
+    - xorg-libxtst ==1.2.3  # [linux]
+    - xorg-randrproto ==1.5.0  # [linux]
+    - xorg-recordproto ==1.14.2  # [linux]
+    - xorg-renderproto ==0.11.1  # [linux]
+    - xorg-util-macros ==1.19.3  # [linux]
+    - xorg-xextproto ==7.3.0  # [linux]
+    - xorg-xf86vidmodeproto ==2.3.1  # [linux]
+    - xorg-xproto ==7.0.31  # [linux]
+    - xyzservices ==2023.10.1
     - xz ==5.2.6
     - yaml ==0.2.5
-    - yaml-cpp ==0.7.0
-    - zeromq ==4.3.4
-    - zipp ==3.11.0
+    - yaml-cpp ==0.8.0
+    - zeromq ==4.3.4  # [win]
+    - zeromq ==4.3.5  # [linux or osx]
+    - zipp ==3.17.0
     - zlib ==1.2.13  # [linux or osx]
-    - zstandard ==0.19.0
-    - zstd ==1.5.2
+    - zlib-ng ==2.0.7
+    - zstandard ==0.22.0
+    - zstd ==1.5.5

--- a/pkg_defs/ska3-flight-latest/install_from_scratch.py
+++ b/pkg_defs/ska3-flight-latest/install_from_scratch.py
@@ -8,9 +8,8 @@ import logging
 assert "CONDA_PASSWORD" in os.environ, "CONDA_PASSWORD environmental variable is not defined"
 
 CHANNELS = [
-    'defaults',
     'conda-forge',
-    f'https://ska:{os.environ["CONDA_PASSWORD"]}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight'
+    f'https://ska:{os.environ["CONDA_PASSWORD"]}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/test'
 ]
 
 
@@ -19,7 +18,7 @@ PACKAGES = [
     {
         'channels': [
             f'https://ska:{os.environ["CONDA_PASSWORD"]}@cxc.cfa.harvard.edu'
-            '/mta/ASPECT/ska3-conda/flight'],
+            '/mta/ASPECT/ska3-conda/test'],
         'options': [],
         'packages': ['quaternion']
     },
@@ -37,7 +36,7 @@ PLATFORM_OPTIONS = {
 
 def install_pkgs(pkgs):
     channels = sum([['-c', c] for c in pkgs['channels']], [])
-    cmd = ['mamba', 'install', '-y'] + pkgs['options'] + channels + pkgs['packages']
+    cmd = ['mamba', 'install', '-y', '--override-channels'] + pkgs['options'] + channels + pkgs['packages']
     logging.info(' '.join(cmd))
     subprocess.run(cmd)
 

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: "2023.10"
+  version: 2024.1
 
 build:
   noarch: generic
@@ -12,44 +12,44 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==4.8.0
     - acispy ==2.5.0
-    - agasc ==4.18.0
+    - agasc ==4.18.2
     - backstop_history ==3.2.1
+    - chandra_aca ==4.45.1
     - chandra_cmd_states ==4.1.0
     - chandra_limits ==0.5.0
     - chandra_maneuver ==4.2.0
     - chandra_time ==4.1.2
-    - chandra_aca ==4.45.0
-    - cheta ==4.61.0
+    - cheta ==4.61.2
     - cxotime ==3.8.0
     - find_attitude ==3.4.3
     - fot-matlab ==2.3.0
     - hopper ==4.6.0
-    - kadi ==7.8.1
+    - kadi ==7.9.0
     - maude ==3.11.1
-    - mica ==4.34.1
-    - parse_cm ==3.14.1
+    - mica ==4.35.1
+    - parse_cm ==3.14.2
     - proseco ==5.12.0
     - pyyaks ==4.5.0
-    - quaternion ==4.3.0
+    - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
-    - ska_dbi ==5.0.0
+    - ska_dbi ==5.1.0
     - ska_file ==4.0.0
-    - ska_ftp ==4.0.0
+    - ska_ftp ==4.0.1
+    - ska_helpers ==0.16.0
     - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.0
+    - ska_path ==3.1.2
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
-    - ska_sun ==3.13.0
-    - ska_tdb ==4.0.0
-    - ska3-core ==2023.10
-    - ska3-template ==2022.06.02
-    - ska_helpers ==0.14.0
-    - ska_path ==3.1.2
+    - ska_sun ==3.14.0
     - ska_sync ==4.11.0
-    - sparkles ==4.25.0
-    - starcheck ==14.7.0
+    - ska_tdb ==4.0.0
+    - ska3-core ==2024.1
+    - ska3-template ==2022.06.02
+    - sparkles ==4.26.0
+    - starcheck ==14.8.0
     - testr ==4.12.0
-    - xija ==4.31.1
+    - xija ==4.31.2

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,56 +1,55 @@
 ---
 package:
   name: ska3-matlab
-  version: 2023.8
+  version: 2024.2
 
 build:
   noarch: generic
 
 requirements:
   run:
-    - aca_view ==0.13.0
+    - aca_view ==0.14.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==4.7.0
+    - acis_thermal_check ==4.8.0
     - acispy ==2.5.0
-    - agasc ==4.17.0
+    - agasc ==4.18.2
     - backstop_history ==3.2.1
-    - chandra_cmd_states ==4.0.0
+    - chandra_aca ==4.45.1
+    - chandra_cmd_states ==4.1.0
     - chandra_limits ==0.5.0
-    - chandra_maneuver ==4.0.0
+    - chandra_maneuver ==4.2.0
     - chandra_time ==4.1.2
-    - chandra_aca ==4.42.0
-    - cheta ==4.60.0
-    - cxotime ==3.6.1
+    - cheta ==4.61.2
+    - cxotime ==3.8.0
     - find_attitude ==3.4.3
     - fot-matlab ==2.3.0
     - hopper ==4.6.0
-    - kadi ==7.6.0
+    - kadi ==7.9.0
     - maude ==3.11.1
-    - mica ==4.33.2
-    - parse_cm ==3.13.0
-    - proseco ==5.11.0
+    - mica ==4.35.1
+    - parse_cm ==3.14.2
+    - proseco ==5.12.0
     - pyyaks ==4.5.0
-    - quaternion ==4.1.1
+    - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
-    - ska_dbi ==5.0.0
+    - ska_dbi ==5.1.0
     - ska_file ==4.0.0
-    - ska_ftp ==4.0.0
+    - ska_ftp ==4.0.1
+    - ska_helpers ==0.16.0
     - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.0
+    - ska_path ==3.1.2
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
-    - ska_sun ==3.11.0
-    - ska_tdb ==4.0.0
-    - ska3-core ==2023.3
-    - ska3-template ==2022.06.02
-    - ska_helpers ==0.12.0
-    - ska_path ==3.1.2
+    - ska_sun ==3.14.0
     - ska_sync ==4.11.0
-    - skare3_tools ==1.1.0
-    - sparkles ==4.24.0
-    - starcheck ==14.5.0
+    - ska_tdb ==4.0.0
+    - ska3-core ==2024.1
+    - ska3-template ==2022.06.02
+    - sparkles ==4.26.0
+    - starcheck ==14.8.0
     - testr ==4.12.0
-    - xija ==4.31.0
+    - xija ==4.31.2

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-perl
-  version: 2023.1
+  version: 2024.1
 
 build:
   skip: True  # [win]
@@ -10,6 +10,8 @@ requirements:
   run:
     - _sysroot_linux-64_curr_repodata_hack ==3  # [linux]
     - blas ==1.0  # [linux]
+    - ca-certificates ==2023.11.17
+    - certifi ==2023.11.17
     - cfitsio ==4.2.0  # [linux]
     - expat ==2.5.0  # [osx]
     - gsl ==2.7  # [linux]
@@ -17,7 +19,8 @@ requirements:
     - libx11-common-cos7-x86_64 ==1.6.7  # [linux]
     - libx11-cos7-x86_64 ==1.6.7  # [linux]
     - libx11-devel-cos7-x86_64 ==1.6.7  # [linux]
-    - mkl_fft ==1.3.1  # [linux]
+    - mkl-service ==2.4.0  # [linux]
+    - mkl_fft ==1.3.8  # [linux]
     - perl ==5.26.2
     - perl-app-cpanminus ==1.7044
     - perl-app-env-ascds ==0.04  # [linux]
@@ -36,11 +39,6 @@ requirements:
     - sysroot_linux-64 ==2.17  # [linux]
     - task_schedule ==4.3.0
     - watch_cron_logs ==4.2.1
-    - xorg-kbproto ==1.0.7  # [linux]
-    - xorg-libx11 ==1.6.12  # [linux]
-    - xorg-libxft ==2.3.4  # [linux]
-    - xorg-libxrender ==0.9.10  # [linux]
-    - xorg-renderproto ==0.11.1  # [linux]
-    - xorg-xproto ==7.0.31  # [linux]
+    - xorg-libxft ==2.3.8  # [linux]
     - xtime ==1.2.2  # [linux]
     - zip ==3.0


### PR DESCRIPTION
# ska3-matlab 2024.2

This PR includes:
- 

## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.2/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2024.2rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2024.2rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2024.2 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

# Related Issues
