### PR TITLE
Update compiled recipes to use compiler directive

### DIFF
--- a/pkg_defs/chandra_time/meta.yaml
+++ b/pkg_defs/chandra_time/meta.yaml
@@ -14,16 +14,15 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - gxx_linux-64 # [linux]
-    - libgcc-ng  # [linux]
-    - clangxx_osx-64 # [osx]
+    - {{ compiler('cxx') }}
+  host:
     - python
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
     - cython
-    - ska_helpers
-    - testr
+    - ska_helpers # needed for duplicate_package_info
+    - testr # needed for ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/ska_numpy/meta.yaml
+++ b/pkg_defs/ska_numpy/meta.yaml
@@ -15,17 +15,16 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - gcc_linux-64 # [linux]
-    - libgcc-ng  # [linux]
-    - clang_osx-64 # [osx]
+    - {{ compiler('cxx') }}
+  host:
     - python
     - numpy
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
     - cython
-    - ska_helpers
-    - testr
+    - ska_helpers # needed for duplicate_package_info
+    - testr # needed for ska_helpers
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -15,9 +15,8 @@ requirements:
   # Packages required to build the package. python and numpy must be
   # listed explicitly if they are required.
   build:
-    - gcc_linux-64 # [linux]
-    - libgcc-ng  # [linux]
-    - clang_osx-64 # [osx]
+    - {{ compiler('cxx') }}
+  host:
     - python
     - setuptools
     - setuptools_scm


### PR DESCRIPTION
Update compiled recipes to use compiler directive.

I confirmed that these updated recipes resulted in build packages on linux and on osx-arm64 .  I didn't not test the packages.

I did not test on windows.

These don't work to build osx-64 packages on m1-m3 macs. AFAIK the current recipes in master also don't allow for osx-64 builds from m1-m3 macs -- this update to use the compiler directive doesn't fix that lack of cross-compile support.
