### PR TITLE
Update ruff-base.toml for Python 3.11

### DIFF
--- a/templates/ruff-base.toml
+++ b/templates/ruff-base.toml
@@ -1,5 +1,5 @@
 # Copied originally from pandas. This config requires ruff >= 0.2.
-target-version = "py310"
+target-version = "py311"
 
 # fix = true
 lint.unfixable = []


### PR DESCRIPTION
This is a trivial update to target Python 3.11 in ruff.