### PR TITLE
2024.3

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2024.2
+  version: 2024.3
 
 build:
   noarch: generic
@@ -12,23 +12,23 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==4.8.1
     - acispy ==2.5.0
-    - agasc ==4.18.2
+    - agasc ==4.18.3
     - backstop_history ==3.2.1
     - chandra_aca ==4.45.1
     - chandra_cmd_states ==4.1.0
-    - chandra_limits ==0.5.0
+    - chandra_limits ==0.7.2
     - chandra_maneuver ==4.2.0
     - chandra_time ==4.1.2
-    - cheta ==4.61.2
+    - cheta ==4.62.0
     - cxotime ==3.8.0
-    - find_attitude ==3.4.3
+    - find_attitude ==3.4.4
     - fot-matlab ==2.4.0
     - hopper ==4.6.0
-    - kadi ==7.9.0
+    - kadi ==7.10.0
     - maude ==3.11.1
-    - mica ==4.35.1
-    - parse_cm ==3.14.2
-    - proseco ==5.12.0
+    - mica ==4.35.2
+    - parse_cm ==3.14.3
+    - proseco ==5.13.0
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -49,7 +49,7 @@ requirements:
     - ska_tdb ==4.0.0
     - ska3-core ==2024.2
     - ska3-template ==2022.06.02
-    - sparkles ==4.26.0
-    - starcheck ==14.8.0
+    - sparkles ==4.26.1
+    - starcheck ==14.8.1
     - testr ==4.12.0
-    - xija ==4.31.2
+    - xija ==4.31.3


### PR DESCRIPTION
# ska3-matlab 2024.3

This PR includes:
- **cheta**.
  - Updated HRMA OHRTHR data to use WIDE mode.
  - Fix `Computed_Quat` MSID in cases when there are bad data in the fetch range.
- **kadi**. Remove commands v1.
- **proseco**. Implement acquisition box overlap penalty.

## Interface Impacts:

- Commands v1 has been deprecated for a long time and now it is fully removed. The configuration setting commands_version is removed and the environment variable KADI_COMMANDS_VERSION no longer has any effect.
- Not an API change, but Proseco will change which stars are selected in cases where an overlapping box would have been chosen.

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.3-GRETA/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2024.3rc2 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2024.3rc2
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2024.3 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2024.2 -> 2024.3rc2)

### Updated Packages

- **agasc:** 4.18.2 -> 4.18.3 (4.18.2 -> 4.18.3)
  - [PR 172](https://github.com/sot/agasc/pull/172) (Javier Gonzalez): remove statements forcing kadi commands v1
- **chandra_limits:** 0.5.0 -> 0.7.2 (0.5.0 -> 0.6.0 -> 0.7.0 -> 0.7.1 -> 0.7.2)
  - [PR 8](https://github.com/sot/chandra_limits/pull/8) (John ZuHone): Chandra models chars
  - [PR 6](https://github.com/sot/chandra_limits/pull/6) (John ZuHone): Black ruff
  - [PR 11](https://github.com/sot/chandra_limits/pull/11) (John ZuHone): Plotting nits
  - [PR 10](https://github.com/sot/chandra_limits/pull/10) (John ZuHone): Tests update
  - [PR 12](https://github.com/sot/chandra_limits/pull/12) (John ZuHone): start_time bug fix
  - [PR 13](https://github.com/sot/chandra_limits/pull/13) (John ZuHone): Catch ValueError in case local obscat has not been updated
- **cheta:** 4.61.2 -> 4.62.0 (4.61.2 -> 4.62.0)
  - [PR 261](https://github.com/sot/cheta/pull/261) (Jean Connelly): Update HRMA OHRTHR data to use WIDE mode values PR-575
  - [PR 259](https://github.com/sot/cheta/pull/259) (Tom Aldcroft): Modernize
  - [PR 260](https://github.com/sot/cheta/pull/260) (Tom Aldcroft): Fix computed Comp_Quat class and close pickle files
  - [PR 258](https://github.com/sot/cheta/pull/258) (Tom Aldcroft): Convert remaining np.bool to bool
- **find_attitude:** 3.4.3 -> 3.4.4 (3.4.3 -> 3.4.4)
  - [PR 27](https://github.com/sot/find_attitude/pull/27) (Tom Aldcroft): Ruff and modernize
- **kadi:** 7.9.0 -> 7.10.0 (7.9.0 -> 7.10.0)
  - [PR 328](https://github.com/sot/kadi/pull/328) (Tom Aldcroft): Remove commands v1 from kadi
- **mica:** 4.35.1 -> 4.35.2 (4.35.1 -> 4.35.2)
  - [PR 298](https://github.com/sot/mica/pull/298) (Jean Connelly): Don't warn if kadi user can't access db
  - [PR 297](https://github.com/sot/mica/pull/297) (Jean Connelly): Handle filling aca image array differently
  - [PR 295](https://github.com/sot/mica/pull/295) (Jean Connelly): Update one remaining sybase call to use sqsh
  - [PR 296](https://github.com/sot/mica/pull/296) (Jean Connelly): Remove np.str calls
- **parse_cm:** 3.14.2 -> 3.14.3 (3.14.2 -> 3.14.3)
  - [PR 51](https://github.com/sot/parse_cm/pull/51) (Tom Aldcroft): Change np.bool to bool and add test
- **proseco:** 5.12.0 -> 5.13.0 (5.12.0 -> 5.13.0)
  - [PR 394](https://github.com/sot/proseco/pull/394) (Tom Aldcroft): Implement acquisition box overlap penalty
  - [PR 395](https://github.com/sot/proseco/pull/395) (Tom Aldcroft): Ruff format and linting
- **sparkles:** 4.26.0 -> 4.26.1 (4.26.0 -> 4.26.1)
  - [PR 210](https://github.com/sot/sparkles/pull/210) (Tom Aldcroft): ruff formatting fixes
  - [PR 209](https://github.com/sot/sparkles/pull/209) (Jean Connelly): Update tests for proseco p2 overlap change
- **starcheck:** 14.8.0 -> 14.8.1 (14.8.0 -> 14.8.1)
  - [PR 440](https://github.com/sot/starcheck/pull/440) (Jean Connelly): Add notebook to make quick regress scripts
- **xija:** 4.31.2 -> 4.31.3 (4.31.2 -> 4.31.3)
  - [PR 137](https://github.com/sot/xija/pull/137) (Tom Aldcroft): Change np.float to float

# Related Issues

Fixes #1321 