### PR TITLE
2024.4

### DIFF
--- a/pkg_defs/ska3-core-latest/base_environment.yml
+++ b/pkg_defs/ska3-core-latest/base_environment.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - python=3.11
   - numexpr<2.8.5
-  - libblas=*=*mkl  # on conda-forge, libblas uses open_blas by default
+  - libblas         # on conda-forge, libblas uses open_blas by default
   - libarchive      # libarchive from defaults is not good for mamba
   - mamba
   - setuptools_scm

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2024.2
+  version: 2024.4
 
 requirements:
   run:
@@ -214,6 +214,7 @@ requirements:
     - libmambapy ==1.5.6
     - libnghttp2 ==1.58.0  # [linux or osx]
     - libnsl ==2.0.1  # [linux]
+    - libopenblas ==0.3.27  # [osx]
     - libogg ==1.3.4
     - libopus ==1.3.1  # [linux or osx]
     - libpng ==1.6.43
@@ -258,7 +259,6 @@ requirements:
     - mistune ==3.0.2
     - mkl ==2022.1.0  # [win]
     - mkl ==2022.2.1  # [linux]
-    - mkl ==2023.2.0  # [osx]
     - more-itertools ==10.2.0
     - mpg123 ==1.32.4  # [linux]
     - mpld3 ==0.5.10

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -10,13 +10,13 @@ requirements:
   run:
     - aca_view ==0.14.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==5.0.0
+    - acis_thermal_check ==5.0.1
     - acispy ==2.5.0
     - agasc ==4.18.3
     - backstop_history ==3.2.1
     - chandra_aca ==4.45.1
     - chandra_cmd_states ==4.1.0
-    - chandra_limits ==0.7.2
+    - chandra_limits ==0.8.0
     - chandra_maneuver ==4.2.0
     - chandra_time ==4.1.2
     - cheta ==4.62.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2024.1
+  version: 2024.4
 
 build:
   noarch: generic
@@ -10,25 +10,25 @@ requirements:
   run:
     - aca_view ==0.14.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==4.8.1
+    - acis_thermal_check ==5.0.0
     - acispy ==2.5.0
-    - agasc ==4.18.2
+    - agasc ==4.18.3
     - backstop_history ==3.2.1
     - chandra_aca ==4.45.1
     - chandra_cmd_states ==4.1.0
-    - chandra_limits ==0.5.0
+    - chandra_limits ==0.7.2
     - chandra_maneuver ==4.2.0
     - chandra_time ==4.1.2
-    - cheta ==4.61.2
+    - cheta ==4.62.0
     - cxotime ==3.8.0
-    - find_attitude ==3.4.3
-    - fot-matlab ==2.3.0
+    - find_attitude ==3.4.4
+    - fot-matlab ==2.4.0
     - hopper ==4.6.0
-    - kadi ==7.9.0
+    - kadi ==7.10.0
     - maude ==3.11.1
-    - mica ==4.35.1
-    - parse_cm ==3.14.2
-    - proseco ==5.12.0
+    - mica ==4.35.2
+    - parse_cm ==3.14.3
+    - proseco ==5.13.0
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -47,9 +47,9 @@ requirements:
     - ska_sun ==3.14.0
     - ska_sync ==4.11.0
     - ska_tdb ==4.0.0
-    - ska3-core ==2024.1
+    - ska3-core ==2024.2
     - ska3-template ==2022.06.02
-    - sparkles ==4.26.0
-    - starcheck ==14.8.0
+    - sparkles ==4.26.1
+    - starcheck ==14.8.1
     - testr ==4.12.0
-    - xija ==4.31.2
+    - xija ==4.31.3

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -47,7 +47,7 @@ requirements:
     - ska_sun ==3.14.0
     - ska_sync ==4.11.0
     - ska_tdb ==4.0.0
-    - ska3-core ==2024.2
+    - ska3-core ==2024.4
     - ska3-template ==2022.06.02
     - sparkles ==4.26.1
     - starcheck ==14.8.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -10,7 +10,7 @@ requirements:
   run:
     - aca_view ==0.14.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==5.0.1
+    - acis_thermal_check ==5.1.0
     - acispy ==2.5.0
     - agasc ==4.18.3
     - backstop_history ==3.2.1


### PR DESCRIPTION
# ska3-flight 2024.4

This PR includes:
- **acis_thermal_check**
  -  now uses chandra_limits package (acis_thermal_check [PR 71](https://github.com/acisops/acis_thermal_check/pull/71))
  - first version of 1DPAMYT model (acis_thermal_check [PR 72](https://github.com/acisops/acis_thermal_check/pull/72))
- **cheta**.
  - updated HRMA OHRTHR data to use WIDE mode.
  - Fix `Computed_Quat` MSID in cases when there are bad data in the fetch range.
- **kadi**. Remove commands v1.
- **proseco**. Implement acquisition box overlap penalty

## Interface Impacts:

- Commands v1 has been deprecated for a long time and now it is fully removed. The configuration setting commands_version is removed and the environment variable KADI_COMMANDS_VERSION no longer has any effect.
- Proseco will change which acquisition stars are selected or modify box sizes in cases where an overlapping box would have been chosen. While this code will become operation for load checking, the corresponding changes that affect load creation will not become operational until Matlab 2024_030 is promoted. As a result, there might be some discrepancies between star selection and load checking until then.
- acis_thermal_check
  - The 1DPAMYT model will have a calling sequence similar to 1DPAMZT
  - The table reporting violations on the webpages has changed slightly, but is human-read. Plots show limit lines as a function of time instead of every limit line across the whole plot; also human-read.

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.4rc3-HEAD/).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.4rc3-OSX/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.4rc3-GRETA/).

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2024.4rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2024.4rc#
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2024.4 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-core changes (2024.2 -> 2024.4rc3)

On OSX, libblas uses libopenblas instead of MKL.

## ska3-flight changes (2024.1 -> 2024.4rc3)

### Updated Packages

- **acis_thermal_check:** 4.8.1 -> 5.1.0 (4.8.1 -> 5.0.0 -> 5.1.0)
  - [PR 71](https://github.com/acisops/acis_thermal_check/pull/71) (John ZuHone): Use chandra limits
  - [PR 72](https://github.com/acisops/acis_thermal_check/pull/72) (None): First version of the 1DPAMYT model and setup.py mods
- **agasc:** 4.18.2 -> 4.18.3 (4.18.2 -> 4.18.3)
  - [PR 172](https://github.com/sot/agasc/pull/172) (Javier Gonzalez): remove statements forcing kadi commands v1
- **chandra_limits:** 0.5.0 -> 0.8.0 (0.5.0 -> 0.6.0 -> 0.7.0 -> 0.7.1 -> 0.7.2 -> 0.8.0)
  - [PR 8](https://github.com/sot/chandra_limits/pull/8) (John ZuHone): Chandra models chars
  - [PR 6](https://github.com/sot/chandra_limits/pull/6) (John ZuHone): Black ruff
  - [PR 11](https://github.com/sot/chandra_limits/pull/11) (John ZuHone): Plotting nits
  - [PR 10](https://github.com/sot/chandra_limits/pull/10) (John ZuHone): Tests update
  - [PR 12](https://github.com/sot/chandra_limits/pull/12) (John ZuHone): start_time bug fix
  - [PR 13](https://github.com/sot/chandra_limits/pull/13) (John ZuHone): Catch ValueError in case local obscat has not been updated
  - [PR 14](https://github.com/sot/chandra_limits/pull/14) (None):  Adding the new Chandra Limits capability to 1DPAMYT model; fixing .p…
- **cheta:** 4.61.2 -> 4.62.0 (4.61.2 -> 4.62.0)
  - [PR 261](https://github.com/sot/cheta/pull/261) (Jean Connelly): Update HRMA OHRTHR data to use WIDE mode values PR-575
  - [PR 259](https://github.com/sot/cheta/pull/259) (Tom Aldcroft): Modernize
  - [PR 260](https://github.com/sot/cheta/pull/260) (Tom Aldcroft): Fix computed Comp_Quat class and close pickle files
  - [PR 258](https://github.com/sot/cheta/pull/258) (Tom Aldcroft): Convert remaining np.bool to bool
- **find_attitude:** 3.4.3 -> 3.4.4 (3.4.3 -> 3.4.4)
  - [PR 27](https://github.com/sot/find_attitude/pull/27) (Tom Aldcroft): Ruff and modernize
- **fot-matlab:** 2.3.0 -> 2.4.0 (2.3.0 -> 2.4.0)
  - [PR 26](https://github.com/sot/fot-matlab/pull/26) (James Kristoff): Support parsing YAML comments from file or as raw text
  - [PR 25](https://github.com/sot/fot-matlab/pull/25) (James Kristoff): Add support for parsing YAML text from OR List Comments
- **kadi:** 7.9.0 -> 7.10.0 (7.9.0 -> 7.10.0)
  - [PR 328](https://github.com/sot/kadi/pull/328) (Tom Aldcroft): Remove commands v1 from kadi
- **mica:** 4.35.1 -> 4.35.2 (4.35.1 -> 4.35.2)
  - [PR 298](https://github.com/sot/mica/pull/298) (Jean Connelly): Don't warn if kadi user can't access db
  - [PR 297](https://github.com/sot/mica/pull/297) (Jean Connelly): Handle filling aca image array differently
  - [PR 295](https://github.com/sot/mica/pull/295) (Jean Connelly): Update one remaining sybase call to use sqsh
  - [PR 296](https://github.com/sot/mica/pull/296) (Jean Connelly): Remove np.str calls
- **parse_cm:** 3.14.2 -> 3.14.3 (3.14.2 -> 3.14.3)
  - [PR 51](https://github.com/sot/parse_cm/pull/51) (Tom Aldcroft): Change np.bool to bool and add test
- **proseco:** 5.12.0 -> 5.13.0 (5.12.0 -> 5.13.0)
  - [PR 394](https://github.com/sot/proseco/pull/394) (Tom Aldcroft): Implement acquisition box overlap penalty
  - [PR 395](https://github.com/sot/proseco/pull/395) (Tom Aldcroft): Ruff format and linting
- **ska3-core:** 2024.1 -> 2024.4rc3
- **sparkles:** 4.26.0 -> 4.26.1 (4.26.0 -> 4.26.1)
  - [PR 210](https://github.com/sot/sparkles/pull/210) (Tom Aldcroft): ruff formatting fixes
  - [PR 209](https://github.com/sot/sparkles/pull/209) (Jean Connelly): Update tests for proseco p2 overlap change
- **starcheck:** 14.8.0 -> 14.8.1 (14.8.0 -> 14.8.1)
  - [PR 440](https://github.com/sot/starcheck/pull/440) (Jean Connelly): Add notebook to make quick regress scripts
- **xija:** 4.31.2 -> 4.31.3 (4.31.2 -> 4.31.3)
  - [PR 137](https://github.com/sot/xija/pull/137) (Tom Aldcroft): Change np.float to float

# Related Issues

Fixes #1308
Fixes #1323
Fixes #1324
Fixes #1325
Fixes #1326
Fixes #1327
Fixes #1328
Fixes #1329
Fixes #1330
Fixes #1331
Fixes #1332
Fixes #1333
Fixes #1340

