### PR TITLE
Set osx libblas to be openblas not mkl

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2024.2
+  version: 2024.3
 
 requirements:
   run:
@@ -175,7 +175,8 @@ requirements:
     - lerc ==4.0.0
     - libaec ==1.1.2
     - libarchive ==3.7.2
-    - libblas ==3.9.0
+    - libblas ==3.9.0=*openblas # [osx]
+    - libblas ==3.9.0 # [linux or win]
     - libbrotlicommon ==1.1.0
     - libbrotlidec ==1.1.0
     - libbrotlienc ==1.1.0


### PR DESCRIPTION
On my osx_x64 installation I installed this PR in a new environment with

```
conda install ska3-core --override-channels -c file://Users/jean/git/skare3/builds/ -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight -c conda-forge
``` 

and I end up with these packages from conda-forge

```
(new-core)skare3 jean$ conda list |grep conda-forge
libblas                   3.9.0           22_osx64_openblas    conda-forge
libcblas                  3.9.0           22_osx64_openblas    conda-forge
liblapack                 3.9.0           22_osx64_openblas    conda-forge
libopenblas               0.3.27          openmp_hfef2a42_0    conda-forge
```
And then I don't get the warning:

```
(new-core) JKRISTOFF-L1:skare3 jean$ ipython
Python 3.11.8 | packaged by conda-forge | (main, Feb 16 2024, 20:51:20) [Clang 16.0.6 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.22.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import numpy

In [2]: 
``` 

As compared to my old(er) flight installation
```
(ska3-flight-2024.1rc4) flame:~ jean$ ipython
Python 3.11.8 | packaged by conda-forge | (main, Feb 16 2024, 20:51:20) [Clang 16.0.6 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.22.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import numpy
Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) instructions.
Intel MKL WARNING: Support of Intel(R) Streaming SIMD Extensions 4.2 (Intel(R) SSE4.2) enabled only processors has been deprecated. Intel oneAPI Math Kernel Library 2025.0 will require Intel(R) Advanced Vector Extensions (Intel(R) AVX) 
```