### PR TITLE
2024.4

### DIFF
--- a/patch_instructions/noarch/patch_instructions.json
+++ b/patch_instructions/noarch/patch_instructions.json
@@ -1,10 +1,64 @@
 {
   "packages": {
-    "appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2": {
-      "license_family": "MIT"
-    },
     "astroquery-0.4.6-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
+    },
+    "colorama-0.4.6-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "decorator-5.1.1-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "django-3.1.7-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "entrypoints-0.4-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "MOZILLA"
+    },
+    "imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "pickleshare-0.7.5-py_1003.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "pycparser-2.21-pyhd8ed1ab_0.tar.bz2": {
+      "depends": [
+        "python ==2.7.*|>=3.4"
+      ],
+      "license_family": "BSD"
+    },
+    "python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "APACHE"
+    },
+    "rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "smmap-5.0.0-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "tomli-2.0.1-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "APACHE"
+    },
+    "appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2": {
+      "license_family": "MIT"
     },
     "babel-2.11.0-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
@@ -18,29 +72,14 @@
     "charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "MIT"
     },
-    "colorama-0.4.6-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
     "cycler-0.11.0-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
-    },
-    "decorator-5.1.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "django-3.1.7-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "entrypoints-0.4-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
     },
     "glob2-0.7-py_0.tar.bz2": {
       "license_family": "BSD"
     },
     "idna-3.4-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
-    },
-    "imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
     },
     "jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2": {
       "license_family": "BSD"
@@ -66,23 +105,8 @@
     "numpydoc-1.5.0-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
     },
-    "pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "pickleshare-0.7.5-py_1003.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "pycparser-2.21-pyhd8ed1ab_0.tar.bz2": {
-      "depends": [
-        "python ==2.7.*|>=3.4"
-      ],
-      "license_family": "BSD"
-    },
     "pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "MIT"
-    },
-    "python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "APACHE"
     },
     "python-docx-0.8.11-pyhd8ed1ab_0.tar.bz2": {
       "depends": [
@@ -103,16 +127,7 @@
     "requests-toolbelt-0.10.1-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "APACHE"
     },
-    "rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2": {
-      "license_family": "MIT"
-    },
     "smmap-3.0.5-pyh44b312d_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
     },
     "soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2": {
@@ -135,9 +150,6 @@
     "terminado-0.17.0-pyh08f2357_0.tar.bz2": {
       "license_family": "BSD"
     },
-    "tomli-2.0.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
     "toolz-0.12.0-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
     },
@@ -146,18 +158,6 @@
     },
     "wheel-0.38.4-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "MIT"
-    },
-    "fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MOZILLA"
-    },
-    "isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "smmap-5.0.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "APACHE"
     },
     "packages": {
       "packages": {

--- a/patch_instructions/osx-arm64/patch_instructions.json
+++ b/patch_instructions/osx-arm64/patch_instructions.json
@@ -1,0 +1,296 @@
+{
+  "packages": {
+    "libedit-3.1.20191231-hc8eb9b7_2.tar.bz2": {
+      "depends": [
+        "ncurses >=6.2,<7.0.0a0"
+      ]
+    },
+    "libffi-3.4.2-h3422bc3_5.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "libogg-1.3.4-h27ca646_1.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "libopus-1.3.1-h27ca646_1.tar.bz2": {
+      "license_family": "BSD"
+    },
+    "patch-2.7.6-h27ca646_1002.tar.bz2": {
+      "license_family": "GPL"
+    },
+    "sigtool-0.1.3-h44b9a77_0.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "yaml-0.2.5-h3422bc3_2.tar.bz2": {
+      "license_family": "MIT"
+    }
+  },
+  "packages.conda": {
+    "astropy-6.0.0-py311h9ea6feb_0.conda": {
+      "license_family": "BSD"
+    },
+    "blosc-1.21.5-hc338f07_0.conda": {
+      "depends": [
+        "libcxx >=15.0.7",
+        "libzlib >=1.2.13,<1.3.0a0",
+        "lz4-c >=1.9.3,<1.10.0a0",
+        "snappy >=1.1.10,<1.2.0a0",
+        "zstd >=1.5.5,<1.6.0a0"
+      ],
+      "license_family": "BSD"
+    },
+    "brotli-1.1.0-hb547adb_1.conda": {
+      "license_family": "MIT"
+    },
+    "brotli-bin-1.1.0-hb547adb_1.conda": {
+      "license_family": "MIT"
+    },
+    "brotli-python-1.1.0-py311ha891d26_1.conda": {
+      "license_family": "MIT"
+    },
+    "cffi-1.16.0-py311h4a08483_0.conda": {
+      "license_family": "MIT"
+    },
+    "conda-23.11.0-py311h267d04e_1.conda": {
+      "license_family": "BSD"
+    },
+    "conda-build-24.1.2-py311h267d04e_0.conda": {
+      "depends": [
+        "beautifulsoup4",
+        "cctools",
+        "chardet",
+        "conda >=22.11.0,<24.3.0a0",
+        "conda-index >=0.4.0",
+        "conda-package-handling >=1.3",
+        "filelock",
+        "jinja2",
+        "jsonschema >=4.19",
+        "menuinst >=2",
+        "packaging",
+        "patch >=2.6",
+        "pkginfo",
+        "psutil",
+        "py-lief <0.14.0a0",
+        "python >=3.11,<3.12.0a0",
+        "python >=3.11,<3.12.0a0 *_cpython",
+        "python-libarchive-c",
+        "python_abi 3.11.* *_cp311",
+        "pytz",
+        "pyyaml",
+        "requests",
+        "ripgrep",
+        "tqdm"
+      ]
+    },
+    "contourpy-1.2.0-py311hcc98501_1.conda": {
+      "license_family": "BSD"
+    },
+    "coverage-7.4.3-py311h05b510d_1.conda": {
+      "license_family": "APACHE"
+    },
+    "cython-3.0.8-py311h92babd0_0.conda": {
+      "license_family": "APACHE"
+    },
+    "giflib-5.2.1-h1a8c8d9_3.conda": {
+      "license_family": "MIT"
+    },
+    "gst-plugins-base-1.22.9-h09b4b5e_0.conda": {
+      "license_family": "LGPL"
+    },
+    "gstreamer-1.22.9-h551c6ff_0.conda": {
+      "license_family": "LGPL"
+    },
+    "h5py-3.10.0-nompi_py311hd00467f_101.conda": {
+      "license_family": "BSD"
+    },
+    "icu-73.2-hc8870d7_0.conda": {
+      "license_family": "MIT"
+    },
+    "jsonpointer-2.4-py311h267d04e_3.conda": {
+      "license_family": "BSD"
+    },
+    "krb5-1.21.2-h92f50d5_0.conda": {
+      "license_family": "MIT"
+    },
+    "libarchive-3.7.2-hcacb583_1.conda": {
+      "depends": [
+        "bzip2 >=1.0.8,<2.0a0",
+        "libiconv >=1.17,<2.0a0",
+        "libxml2 >=2.12.2,<3.0.0a0",
+        "libzlib >=1.2.13,<1.3.0a0",
+        "lz4-c >=1.9.3,<1.10.0a0",
+        "lzo >=2.10,<3.0a0",
+        "openssl >=3.2.0,<4.0a0",
+        "xz >=5.2.6,<6.0a0",
+        "zstd >=1.5.5,<1.6.0a0"
+      ]
+    },
+    "libblas-3.9.0-22_osxarm64_openblas.conda": {
+      "license_family": "BSD"
+    },
+    "libbrotlicommon-1.1.0-hb547adb_1.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlidec-1.1.0-hb547adb_1.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlienc-1.1.0-hb547adb_1.conda": {
+      "license_family": "MIT"
+    },
+    "libcblas-3.9.0-22_osxarm64_openblas.conda": {
+      "license_family": "BSD"
+    },
+    "libdeflate-1.19-hb547adb_0.conda": {
+      "license_family": "MIT"
+    },
+    "libhwloc-2.9.3-default_h4394839_1009.conda": {
+      "depends": [
+        "__osx >=10.9",
+        "libcxx >=16.0.6",
+        "libxml2 >=2.11.5,<3.0.0a0"
+      ],
+      "license_family": "BSD"
+    },
+    "liblapack-3.9.0-22_osxarm64_openblas.conda": {
+      "license_family": "BSD"
+    },
+    "libllvm15-15.0.7-h2621b3d_4.conda": {
+      "depends": [
+        "libcxx >=16",
+        "libxml2 >=2.12.1,<3.0.0a0",
+        "libzlib >=1.2.13,<1.3.0a0"
+      ]
+    },
+    "libllvm16-16.0.6-haab561b_3.conda": {
+      "depends": [
+        "libcxx >=16",
+        "libxml2 >=2.12.1,<3.0.0a0",
+        "libzlib >=1.2.13,<1.3.0a0",
+        "zstd >=1.5.5,<1.6.0a0"
+      ]
+    },
+    "libopenblas-0.3.27-openmp_h6c19121_0.conda": {
+      "license_family": "BSD"
+    },
+    "libwebp-1.3.2-hf30222e_1.conda": {
+      "license_family": "BSD"
+    },
+    "libwebp-base-1.3.2-h93a5062_1.conda": {
+      "license_family": "BSD"
+    },
+    "libxslt-1.1.39-h223e5b9_0.conda": {
+      "depends": [
+        "libxml2 >=2.12.1,<3.0.0a0"
+      ],
+      "license_family": "MIT"
+    },
+    "llvm-openmp-17.0.6-hcd81f8e_0.conda": {
+      "license_family": "APACHE"
+    },
+    "llvmlite-0.42.0-py311hf5d242d_1.conda": {
+      "license_family": "BSD"
+    },
+    "lxml-5.1.0-py311h85df328_0.conda": {
+      "depends": [
+        "libxml2 >=2.12.3,<3.0.0a0",
+        "libxslt >=1.1.39,<2.0a0",
+        "libzlib >=1.2.13,<1.3.0a0",
+        "python >=3.11,<3.12.0a0",
+        "python >=3.11,<3.12.0a0 *_cpython",
+        "python_abi 3.11.* *_cp311"
+      ]
+    },
+    "lz4-c-1.9.4-hb7217d7_0.conda": {
+      "license_family": "BSD"
+    },
+    "nodejs-20.9.0-h0950e01_0.conda": {
+      "license_family": "MIT"
+    },
+    "nspr-4.35-hb7217d7_0.conda": {
+      "license_family": "MOZILLA"
+    },
+    "nss-3.98-h5ce2875_0.conda": {
+      "license_family": "MOZILLA"
+    },
+    "numexpr-2.8.4-py311h9e438b8_1.conda": {
+      "license_family": "MIT"
+    },
+    "numpy-1.26.4-py311h7125741_0.conda": {
+      "license_family": "BSD"
+    },
+    "openjpeg-2.5.1-h9f1df11_0.conda": {
+      "license_family": "BSD"
+    },
+    "pandas-2.2.1-py311hfbe21a1_0.conda": {
+      "license_family": "BSD"
+    },
+    "pycosat-0.6.6-py311heffc1b2_0.conda": {
+      "license_family": "MIT"
+    },
+    "pyobjc-framework-cocoa-10.1-py311h665608e_0.conda": {
+      "license_family": "MIT"
+    },
+    "pytables-3.8.0-py311h5f09214_4.conda": {
+      "depends": [
+        "blosc >=1.21.5,<2.0a0",
+        "bzip2 >=1.0.8,<2.0a0",
+        "c-blosc2 >=2.10.4,<2.13.0a0",
+        "hdf5 >=1.14.2,<1.14.4.0a0",
+        "libcxx >=15.0.7",
+        "libzlib >=1.2.13,<1.3.0a0",
+        "numexpr",
+        "numpy >=1.23.5,<2.0a0",
+        "packaging",
+        "py-cpuinfo",
+        "python >=3.11,<3.12.0a0",
+        "python >=3.11,<3.12.0a0 *_cpython",
+        "python_abi 3.11.* *_cp311"
+      ],
+      "license_family": "BSD"
+    },
+    "qt-5.15.8-h13919d0_0.conda": {
+      "license_family": "LGPL"
+    },
+    "qt-main-5.15.8-h6bf1bb6_19.conda": {
+      "license_family": "LGPL"
+    },
+    "qt-webengine-5.15.8-h850e111_4.conda": {
+      "license_family": "LGPL"
+    },
+    "readline-8.2-h92ec313_1.conda": {
+      "license_family": "GPL"
+    },
+    "reproc-14.2.4.post0-h93a5062_1.conda": {
+      "license_family": "MIT"
+    },
+    "reproc-cpp-14.2.4.post0-h965bd2d_1.conda": {
+      "license_family": "MIT"
+    },
+    "rpds-py-0.18.0-py311ha958965_0.conda": {
+      "license_family": "MIT"
+    },
+    "ruamel.yaml-0.18.6-py311h05b510d_0.conda": {
+      "license_family": "MIT"
+    },
+    "scikit-learn-1.4.1.post1-py311h696fe38_0.conda": {
+      "license_family": "BSD"
+    },
+    "scipy-1.12.0-py311h4f9446f_2.conda": {
+      "license_family": "BSD"
+    },
+    "tbb-2021.11.0-h2ffa867_1.conda": {
+      "license_family": "APACHE"
+    },
+    "zeromq-4.3.5-h5119023_3.conda": {
+      "license_family": "MOZILLA"
+    },
+    "zstandard-0.22.0-py311h67b91a1_0.conda": {
+      "license_family": "BSD"
+    },
+    "zstd-1.5.5-h4f39d0f_0.conda": {
+      "license_family": "BSD"
+    }
+  },
+  "remove": [],
+  "revoke": [],
+  "patch_instructions_version": 1
+}

--- a/patch_instructions/osx-arm64/patch_instructions.json
+++ b/patch_instructions/osx-arm64/patch_instructions.json
@@ -17,6 +17,12 @@
     "patch-2.7.6-h27ca646_1002.tar.bz2": {
       "license_family": "GPL"
     },
+    "pkg-config-0.29.2-hab62308_1008.tar.bz2": {
+      "depends": [
+        "libglib >=2.70.2,<3.0a0",
+        "libiconv >=1.16,<2.0.0a0"
+      ]
+    },
     "sigtool-0.1.3-h44b9a77_0.tar.bz2": {
       "license_family": "MIT"
     },

--- a/pkg_defs/chandra_time/meta.yaml
+++ b/pkg_defs/chandra_time/meta.yaml
@@ -17,10 +17,10 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
+    - cython
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
-    - cython
     - ska_helpers # needed for duplicate_package_info
     - testr # needed for ska_helpers
   # Packages required to run the package. These are the dependencies that

--- a/pkg_defs/ska3-core-latest/install_from_scratch.py
+++ b/pkg_defs/ska3-core-latest/install_from_scratch.py
@@ -47,10 +47,11 @@ def get_package_list():
             "packages": ["notebook==6.5.6"],
         },
         {  # this is not in defaults or conda-forge (for now?)
-            "channels": ["sherpa"] + CHANNELS,
+            # "channels": ["sherpa"] + CHANNELS,
+            "channels": ["https://cxc.cfa.harvard.edu/conda/ciao"] + CHANNELS,
             "options": [],
             "packages": ["sherpa"],
-            "platform": ["linux-64", "osx-64"],
+            "platform": ["linux-64", "osx-64", "osx-arm64"],
         },
     ]
 
@@ -58,9 +59,10 @@ def get_package_list():
 # These options are passed to conda_build.metadata.select_lines after reading meta.yaml.
 # This causes, for example, the lines that read " # [win]" to be read only on win-64.
 PLATFORM_OPTIONS = {
-    "linux-64": {"linux": True, "linux64": True},
-    "osx-64": {"osx": True, "osx64": True},
-    "win-64": {"win": True, "win64": True},
+    "linux-64": {"linux": True, "linux64": True, "arm64":   False},
+    "osx-64": {"osx": True, "osx64": True, "arm64": False},
+    "osx-arm64": {"osx": True, "osx64": True, "arm64":  True},
+    "win-64": {"win": True, "win64": True, "arm64": False},
 }
 
 

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -43,7 +43,8 @@ requirements:
     - brotli-python ==1.1.0
     - bzip2 ==1.0.8
     - c-ares ==1.27.0  # [linux or osx]
-    - c-blosc2 ==2.13.2
+    - c-blosc2 ==2.13.2  # [not arm64]
+    - c-blosc2 ==2.12.0  # [arm64]
     - ca-certificates ==2024.2.2
     - cached-property ==1.5.2
     - cached_property ==1.5.2
@@ -95,7 +96,8 @@ requirements:
     - fontconfig ==2.14.2  # [linux]
     - fonts-conda-ecosystem ==1  # [linux]
     - fonts-conda-forge ==1  # [linux]
-    - fonttools ==4.49.0
+    - fonttools ==4.49.0  # [not arm64]
+    - fonttools ==4.51.0  # [arm64]
     - fqdn ==1.5.1
     - freetype ==2.12.1
     - future ==1.0.0
@@ -394,7 +396,7 @@ requirements:
     - setuptools ==69.1.1
     - setuptools-scm ==8.0.4
     - setuptools_scm ==8.0.4
-    - sherpa ==4.15.1  # [linux or osx]
+    - sherpa ==4.15.1  # [(linux or osx) and not arm64]
     - sigtool ==0.1.3  # [osx]
     - sip ==6.7.12
     - six ==1.16.0

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -396,7 +396,7 @@ requirements:
     - setuptools ==69.1.1
     - setuptools-scm ==8.0.4
     - setuptools_scm ==8.0.4
-    - sherpa ==4.15.1  # [(linux or osx) and not arm64]
+    - sherpa ==4.16  # [linux or osx]
     - sigtool ==0.1.3  # [osx]
     - sip ==6.7.12
     - six ==1.16.0

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -396,7 +396,7 @@ requirements:
     - setuptools ==69.1.1
     - setuptools-scm ==8.0.4
     - setuptools_scm ==8.0.4
-    - sherpa ==4.16  # [linux or osx]
+    - sherpa ==4.16  # [not win and not arm64]
     - sigtool ==0.1.3  # [osx]
     - sip ==6.7.12
     - six ==1.16.0

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -396,7 +396,7 @@ requirements:
     - setuptools ==69.1.1
     - setuptools-scm ==8.0.4
     - setuptools_scm ==8.0.4
-    - sherpa ==4.16  # [not win and not arm64]
+    - sherpa ==4.16  # [not win]
     - sigtool ==0.1.3  # [osx]
     - sip ==6.7.12
     - six ==1.16.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - pkg-config ==0.29.2
     - sysroot_linux-64 ==2.17  # [linux]
     - task_schedule ==4.3.0
-    - watch_cron_logs ==4.2.1
+    - watch_cron_logs ==4.2.2
     - xorg-libxft ==2.3.8  # [linux]
     - xtime ==1.2.2  # [linux]
     - zip ==3.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-perl
-  version: 2024.2
+  version: 2024.4
 
 build:
   skip: True  # [win]
@@ -19,15 +19,15 @@ requirements:
     - libx11-devel-cos7-x86_64 ==1.6.7  # [linux]
     - mkl-service ==2.4.0  # [linux]
     - mkl_fft ==1.3.8  # [linux]
-    - perl ==5.26.2
-    - perl-app-cpanminus ==1.7044
+    - perl ==5.32.1
+    - perl-app-cpanminus ==1.7047
     - perl-app-env-ascds ==0.04  # [linux]
     - perl-chandra-time ==0.9.2  # [linux]
     - perl-core-deps ==0.3.1
     - perl-cxc-sysarch ==1.00  # [linux]
     - perl-dbd-sybase ==1.15  # [linux]
     - perl-extended-deps ==0.3.1  # [linux]
-    - perl-io-tty ==1.12
+    - perl-io-tty ==1.20
     - perl-ska-agasc ==3.5.0  # [linux]
     - perl-ska-classic ==0.6
     - perl-ska-convert ==4.3  # [linux]

--- a/pkg_defs/ska_numpy/meta.yaml
+++ b/pkg_defs/ska_numpy/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
+    - cython
     - numpy
     - setuptools
     - setuptools_scm

--- a/pkg_defs/xija/meta.yaml
+++ b/pkg_defs/xija/meta.yaml
@@ -21,6 +21,8 @@ requirements:
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
+    - ska_helpers
+    - testr
   # Packages required to run the package. These are the dependencies that
   # will be installed automatically whenever the package is installed.
   run:

--- a/ska3_flight_build_order.txt
+++ b/ska3_flight_build_order.txt
@@ -38,6 +38,12 @@ dea_check
 dpa_check
 proseco
 sparkles
+aca_view
+acispy
+skare3_tools
+chandra_limits
+aca_weekly_report
+astromon
 annie
 acdc
 find_attitude
@@ -51,5 +57,6 @@ ska3-core
 ska3-flight
 ska3-matlab
 ska3-perl
+ska3-perl-latest
 ska3-flight-latest
 ska3-core-latest


### PR DESCRIPTION
# ska3-flight 2024.4alpha9

This PR is not to be merged. I made it so we can see the changes, and to be able to tag pre-releases (the workflows make a sanity check that requires the existence of a pull request).

This branch should build an osx-arm64 package. For all other platforms this should make no difference.

**NOTES:**
- Workflows have not been updated at all. This is just building the packages
- this ska3-core does not include sherpa


## Testing:

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2024.4alpha9 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2024.4alpha9 ska3-perl==2024.4alpha9
```

**Note that you will need an ARM miniconda installation.**



