### PR TITLE
add build recipe for sherpa

### DIFF
--- a/pkg_defs/sherpa/build.sh
+++ b/pkg_defs/sherpa/build.sh
@@ -1,0 +1,16 @@
+# if [ "$(uname -s)" == "Darwin" ]
+# then
+#   CONDA_BUILD_SYSROOT=/opt/MacOSX11.0.sdk
+# fi
+
+# #Apply patches
+# git apply -v --whitespace=nowarn ${RECIPE_DIR}/patches/*.patch
+# #Ignore the changes when setting the version
+# # We only ignore files that were CHANGED by the patches, not any CREATED by the patches
+# for CIAO_IGNORE in "setup.cfg conda_build_config.yaml"
+# do
+#   git update-index --assume-unchanged ${CIAO_IGNORE}
+# done
+
+
+$PYTHON -m pip install --prefix=$PREFIX -vv .

--- a/pkg_defs/sherpa/conda_build_config.yaml
+++ b/pkg_defs/sherpa/conda_build_config.yaml
@@ -1,0 +1,27 @@
+CONDA_BUILD_SYSROOT: /opt/MacOSX11.0.sdk
+c_compiler: clang
+cpu_optimization_target: nocona
+cran_mirror: https://cran.r-project.org
+cxx_compiler: clangxx
+extend_keys:
+- pin_run_as_build
+- ignore_build_only_deps
+- extend_keys
+- ignore_version
+fortran_compiler: gfortran
+ignore_build_only_deps:
+- python
+- numpy
+lua: '5'
+numpy: '1.23'
+perl: 5.26.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+python: '3.11'
+r_base: '3.5'
+target_platform: osx-arm64

--- a/pkg_defs/sherpa/meta.yaml
+++ b/pkg_defs/sherpa/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: sherpa
+  version: {{ environ.get('SHERPA_TAG') }}
+
+source:
+  git_rev: {{ environ.get('SHERPA_TAG') }}
+  git_url: https://github.com/sherpa/sherpa.git
+
+requirements:
+  build:
+    - python=3.11
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - conda-build
+    - conda-verify
+    - bison
+    - setuptools <60.0.0
+
+  host:
+    - python 3.11
+    - setuptools <60.0.0
+    - pip
+    - numpy 1.21.* # [py<=310]
+    - numpy 1.23.* # [py>310]
+    - matplotlib >3.3.0
+
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+about:
+  home: https://github.com/sherpa/sherpa
+  license: GPL3
+  license_file: LICENSE
+


### PR DESCRIPTION
This adds a recipe for sherpa.

I did not use `ska_builder.py` to build the package. I just did
```
conda build --python 3.11 --output-folder /Users/aca/skare3/builds pkg_defs/sherpa
```

This is the recipe used to build the **current** package 4.15.1.