### PR TITLE
2024.6

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2024.3
+  version: 2024.6
 
 build:
   noarch: generic
@@ -10,13 +10,13 @@ requirements:
   run:
     - aca_view ==0.14.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==4.8.1
-    - acispy ==2.5.0
-    - agasc ==4.18.3
+    - acis_thermal_check ==5.1.1
+    - acispy ==2.6.0
+    - agasc ==4.19.0
     - backstop_history ==3.2.1
     - chandra_aca ==4.45.1
     - chandra_cmd_states ==4.1.0
-    - chandra_limits ==0.7.2
+    - chandra_limits ==0.9.1
     - chandra_maneuver ==4.2.0
     - chandra_time ==4.1.2
     - cheta ==4.62.0
@@ -24,11 +24,11 @@ requirements:
     - find_attitude ==3.4.4
     - fot-matlab ==2.4.0
     - hopper ==4.6.0
-    - kadi ==7.10.0
+    - kadi ==7.10.1
     - maude ==3.11.1
     - mica ==4.35.2
-    - parse_cm ==3.14.3
-    - proseco ==5.13.0
+    - parse_cm ==3.15.0
+    - proseco ==5.13.1
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -40,16 +40,16 @@ requirements:
     - ska_helpers ==0.16.0
     - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
-    - ska_parsecm ==4.0.0
+    - ska_parsecm ==4.0.1
     - ska_path ==3.1.2
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
     - ska_sun ==3.14.0
     - ska_sync ==4.11.0
     - ska_tdb ==4.0.0
-    - ska3-core ==2024.2
+    - ska3-core ==2024.5
     - ska3-template ==2022.06.02
     - sparkles ==4.26.1
-    - starcheck ==14.8.1
+    - starcheck ==14.9.0
     - testr ==4.12.0
-    - xija ==4.31.3
+    - xija ==4.32.0


### PR DESCRIPTION
# ska3-matlab 2024.6

This PR includes:
- **acis_thermal_check**
  -  now uses chandra_limits package (acis_thermal_check [PR 71](https://github.com/acisops/acis_thermal_check/pull/71))
  - first version of 1DPAMYT model (acis_thermal_check [PR 72](https://github.com/acisops/acis_thermal_check/pull/72))

- updates to **chandra_limits** to support new ACIS FP limits
- update to the time range used for High IR Zone checking in **starcheck**
- Fixes proseco bug, noticed on prelim review of obsid 26719, which caused `include_ids_guide` to be ignored when guide stars were close.



## Interface Impacts:

## Testing:

- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.6rc1-GRETA/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2024.6rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2024.6rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2024.6 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2024.3 -> 2024.6rc1)

### Updated Packages

- **acis_thermal_check:** 4.8.1 -> 5.1.1 (4.8.1 -> 5.0.0 -> 5.1.0 -> 5.1.1)
  - [PR 71](https://github.com/acisops/acis_thermal_check/pull/71) (John ZuHone): Use chandra limits
  - [PR 72](https://github.com/acisops/acis_thermal_check/pull/72) (None): First version of the 1DPAMYT model and setup.py mods
  - [PR 74](https://github.com/acisops/acis_thermal_check/pull/74) (John ZuHone): Support new FP limits
- **acispy:** 2.5.0 -> 2.6.0 (2.5.0 -> 2.6.0)
  - [PR 12](https://github.com/acisops/acispy/pull/12) (John ZuHone): Use chandra_limits to obtain limits, fix failing tests due to other ska updates
- **agasc:** 4.18.3 -> 4.19.0 (4.18.3 -> 4.19.0)
  - [PR 177](https://github.com/sot/agasc/pull/177) (Jean Connelly): Don't use file_args if args_file not supplied
  - [PR 173](https://github.com/sot/agasc/pull/173) (Javier Gonzalez): generate a diff file with differences between supplements
  - [PR 175](https://github.com/sot/agasc/pull/175) (Javier Gonzalez): add sot-mp to promotion email
- **chandra_limits:** 0.7.2 -> 0.9.1 (0.7.2 -> 0.8.0 -> 0.9.0 -> 0.9.1)
  - [PR 14](https://github.com/sot/chandra_limits/pull/14) (None):  Adding the new Chandra Limits capability to 1DPAMYT model; fixing .p…
  - [PR 15](https://github.com/sot/chandra_limits/pull/15) (John ZuHone): Support updated ACIS FP limits, add in ACIS characteristics file
  - [PR 16](https://github.com/sot/chandra_limits/pull/16) (Jean Connelly): Install new characteristics data
- **kadi:** 7.10.0 -> 7.10.1 (7.10.0 -> 7.10.1)
  - [PR 331](https://github.com/sot/kadi/pull/331) (Tom Aldcroft): Fix state-dependent callbacks
- **parse_cm:** 3.14.3 -> 3.15.0 (3.14.3 -> 3.15.0)
  - [PR 52](https://github.com/sot/parse_cm/pull/52) (Tom Aldcroft): Add `required_sequenced_duration` OR list parameter
- **proseco:** 5.13.0 -> 5.13.1 (5.13.0 -> 5.13.1)
  - [PR 397](https://github.com/sot/proseco/pull/397) (Tom Aldcroft): Respect include_ids_guide in combination optimization (alternate implementation)
- **ska3-core:** 2024.2 -> 2024.5
- **ska_parsecm:** 4.0.0 -> 4.0.1 (4.0.0 -> 4.0.1)
  - [PR 14](https://github.com/sot/ska_parsecm/pull/14) (Tom Aldcroft): Discontinue package
- **starcheck:** 14.8.1 -> 14.9.0 (14.8.1 -> 14.9.0)
  - [PR 441](https://github.com/sot/starcheck/pull/441) (Jean Connelly): Use Python to make text report from html
  - [PR 442](https://github.com/sot/starcheck/pull/442) (Jean Connelly): Update starcheck IR zone to (-10, +35)
- **xija:** 4.31.3 -> 4.32.0 (4.31.3 -> 4.32.0)
  - [PR 139](https://github.com/sot/xija/pull/139) (John ZuHone): Add new ACIS FP limit colors
  - [PR 138](https://github.com/sot/xija/pull/138) (Javier Gonzalez): fix docs workflow


# Related Issues

Fixes #1362