### PR TITLE
2024.7

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -97,7 +97,9 @@ jobs:
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         python-version: "3.11"
         activate-environment: conda-build
-        channels: https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight
+        channels: conda-forge
+    - name: Add flight channel
+      run: conda config --env --add channels https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/flight
     - name: Update Conda Environment
       run: conda env update -n conda-build -f ./skare3/build-environment.yml
     - name: Build Package
@@ -116,6 +118,8 @@ jobs:
         GIT_USERNAME: chandra-xray
         GIT_ASKPASS: ${{ github.workspace }}/skare3_tools/actions/build/files/git_pass.py
         GIT_PASSWORD: ${{ secrets.CHANDRA_XRAY_TOKEN }}
+    - name: Review built packages
+      run: ls -l builds/*
     - name: Save package
       uses: actions/upload-artifact@v4
       with:
@@ -138,9 +142,12 @@ jobs:
         with:
           pattern: conda-package-*
           path: package
+      - name: Show files
+        run: tree package
       - name: Update channel
         run: |
-          rsync -a package/ ${CONDA_CHANNEL_DIR}
+          echo ${CONDA_CHANNEL_DIR}
+          rsync -av package/conda-package-*/* ${CONDA_CHANNEL_DIR}
           conda index ${CONDA_CHANNEL_DIR}
         env:
           CONDA_CHANNEL_DIR: /proj/sot/ska/www/ASPECT/ska3-conda/test
@@ -177,7 +184,7 @@ jobs:
           ln -s /proj/sot/ska3/test/data $CONDA_PREFIX/data
           export SKA=$CONDA_PREFIX
           run_testr --root ./ska_testr --outputs-dir /export/kadi/ska_testr/release_tests
-          skare3-test-results --stream releases --tag /export/kadi/ska_testr/release_tests/logs/last
+          skare3-test-results --stream releases --tag head /export/kadi/ska_testr/release_tests/logs/last
           # add test result report to PR description
         env:
           CONDA_PASSWORD: ${{ secrets.CONDA_PASSWORD }}

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2024.5
+  version: 2024.7
 
 requirements:
   run:
@@ -85,7 +85,7 @@ requirements:
     - et_xmlfile ==1.1.0
     - exceptiongroup ==1.2.0
     - executing ==2.0.1
-    - expat ==2.5.0  # [linux]
+    - expat ==2.6.2
     - filelock ==3.13.1
     - flake8 ==7.0.0
     - fmt ==10.2.1
@@ -186,14 +186,14 @@ requirements:
     - libclang ==15.0.7
     - libclang13 ==15.0.7
     - libcups ==2.3.3  # [linux]
-    - libcurl ==8.5.0
-    - libcxx ==16.0.6  # [osx]
+    - libcurl ==8.8.0
+    - libcxx ==17.0.6 # [osx]
     - libdeflate ==1.18  # [win]
     - libdeflate ==1.19  # [linux or osx]
     - libedit ==3.1.20191231  # [linux or osx]
     - libev ==4.33  # [linux or osx]
     - libevent ==2.1.12  # [linux]
-    - libexpat ==2.5.0
+    - libexpat ==2.6.2
     - libffi ==3.4.2
     - libflac ==1.4.3  # [linux]
     - libgcc-ng ==13.2.0  # [linux]
@@ -294,7 +294,7 @@ requirements:
     - openjpeg ==2.5.0  # [win]
     - openjpeg ==2.5.1  # [linux or osx]
     - openpyxl ==3.1.2
-    - openssl ==3.2.1
+    - openssl ==3.3.1
     - overrides ==7.7.0
     - packaging ==23.2
     - pandas ==2.2.1
@@ -494,5 +494,5 @@ requirements:
     - zipp ==3.17.0
     - zlib ==1.2.13  # [linux or osx]
     - zlib-ng ==2.0.7
-    - zstandard ==0.22.0
-    - zstd ==1.5.5
+    - zstandard ==0.19.0
+    - zstd ==1.5.6

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -465,7 +465,7 @@ requirements:
     - xorg-kbproto ==1.0.7  # [linux]
     - xorg-libice ==1.1.1  # [linux]
     - xorg-libsm ==1.2.4  # [linux]
-    - xorg-libx11 ==1.8.7  # [linux]
+    - xorg-libx11 ==1.8.9  # [linux]
     - xorg-libxau ==1.0.11  # [linux or osx]
     - xorg-libxau ==1.0.8  # [win]
     - xorg-libxcomposite ==0.4.6  # [linux]

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2024.5
+  version: 2024.7
 
 build:
   noarch: generic
@@ -47,7 +47,7 @@ requirements:
     - ska_sun ==3.14.0
     - ska_sync ==4.11.0
     - ska_tdb ==4.0.0
-    - ska3-core ==2024.5
+    - ska3-core ==2024.7
     - ska3-template ==2022.06.02
     - sparkles ==4.26.1
     - starcheck ==14.9.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -12,7 +12,7 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.1.1
     - acispy ==2.6.0
-    - agasc ==4.20.0
+    - agasc ==4.21.0
     - backstop_history ==3.2.1
     - chandra_aca ==4.45.1
     - chandra_cmd_states ==4.1.0
@@ -24,7 +24,7 @@ requirements:
     - find_attitude ==3.4.4
     - fot-matlab ==2.4.0
     - hopper ==4.6.0
-    - kadi ==7.10.1
+    - kadi ==7.11.0
     - maude ==3.11.1
     - mica ==4.35.2
     - parse_cm ==3.15.0
@@ -45,11 +45,11 @@ requirements:
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
     - ska_sun ==3.14.0
-    - ska_sync ==4.12.0
+    - ska_sync ==4.13.0
     - ska_tdb ==4.0.0
     - ska3-core ==2024.7
     - ska3-template ==2022.06.02
     - sparkles ==4.26.1
-    - starcheck ==14.10.0
+    - starcheck ==14.11.0
     - testr ==4.12.0
     - xija ==4.32.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -8,11 +8,11 @@ build:
 
 requirements:
   run:
-    - aca_view ==0.14.0
+    - aca_view ==0.14.1
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.1.1
     - acispy ==2.6.0
-    - agasc ==4.19.0
+    - agasc ==4.20.0
     - backstop_history ==3.2.1
     - chandra_aca ==4.45.1
     - chandra_cmd_states ==4.1.0
@@ -28,7 +28,7 @@ requirements:
     - maude ==3.11.1
     - mica ==4.35.2
     - parse_cm ==3.15.0
-    - proseco ==5.13.1
+    - proseco ==5.13.2
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -45,11 +45,11 @@ requirements:
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
     - ska_sun ==3.14.0
-    - ska_sync ==4.11.0
+    - ska_sync ==4.12.0
     - ska_tdb ==4.0.0
     - ska3-core ==2024.7
     - ska3-template ==2022.06.02
     - sparkles ==4.26.1
-    - starcheck ==14.9.0
+    - starcheck ==14.10.0
     - testr ==4.12.0
     - xija ==4.32.0

--- a/pkg_defs/ska3-perl-latest/meta.yaml
+++ b/pkg_defs/ska3-perl-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-perl-latest
-  version: 2023.1
+  version: 2024.7
 
 build:
   skip: True  # [win]
@@ -13,6 +13,8 @@ requirements:
     - perl-ska-classic
     - xtime # [linux]
     - perl-extended-deps # [linux]
+    - perl-pdl # [linux]
+    - perl-astro-fits-cfitsio-simple # [linux]
     - perl-chandra-time # [linux]
     - perl-cxc-sysarch # [linux]
     - perl-ska-convert # [linux]

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - perl-extended-deps ==0.4.0  # [linux]
     - perl-io-tty ==1.16 # [osx and x86_64]
     - perl-io-tty ==1.20 # [linux or arm64]
-    - perl-ska-agasc =3.5.0=pl5321h3fd9d12_0  # [linux]
+    - perl-ska-agasc =3.5.0=pl5321_2# [linux]
     - perl-ska-classic ==0.6
     - perl-ska-convert ==4.3  # [linux]
     - perl-ska-web ==4.0  # [linux]

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,42 +1,46 @@
 ---
 package:
   name: ska3-perl
-  version: 2024.2
+  version: 2024.7
 
 build:
   skip: True  # [win]
+  number: 1
 
 requirements:
   run:
     - _sysroot_linux-64_curr_repodata_hack ==3  # [linux]
     - blas ==1.0  # [linux]
-    - cfitsio ==4.2.0  # [linux]
-    - expat ==2.5.0  # [osx]
+    - cfitsio ==4.4.0  # [linux]
+    - expat ==2.6.2
     - gsl ==2.7  # [linux]
     - kernel-headers_linux-64 ==3.10.0  # [linux]
     - libx11-common-cos7-x86_64 ==1.6.7  # [linux]
     - libx11-cos7-x86_64 ==1.6.7  # [linux]
     - libx11-devel-cos7-x86_64 ==1.6.7  # [linux]
     - mkl-service ==2.4.0  # [linux]
-    - mkl_fft ==1.3.8  # [linux]
-    - perl ==5.26.2
-    - perl-app-cpanminus ==1.7044
+    - mkl_fft ==1.3.1  # [linux]
+    - perl ==5.32.1
+    - perl-app-cpanminus ==1.7047
     - perl-app-env-ascds ==0.04  # [linux]
+    - perl-astro-fits-cfitsio-simple ==0.20 # [linux]
     - perl-chandra-time ==0.9.2  # [linux]
-    - perl-core-deps ==0.3.1
+    - perl-core-deps ==0.4.0
     - perl-cxc-sysarch ==1.00  # [linux]
-    - perl-dbd-sybase ==1.15  # [linux]
-    - perl-extended-deps ==0.3.1  # [linux]
-    - perl-io-tty ==1.12
-    - perl-ska-agasc ==3.5.0  # [linux]
+    - perl-dbd-sybase ==1.24  # [linux]
+    - perl-extended-deps ==0.4.0  # [linux]
+    - perl-io-tty ==1.16 # [osx and x86_64]
+    - perl-io-tty ==1.20 # [linux or arm64]
+    - perl-ska-agasc =3.5.0=pl5321h3fd9d12_0  # [linux]
     - perl-ska-classic ==0.6
     - perl-ska-convert ==4.3  # [linux]
     - perl-ska-web ==4.0  # [linux]
-    - perl-tk ==804.035  # [linux]
+    - perl-tk =804.035=pl5321h3fd9d12_1 # [linux]
     - pkg-config ==0.29.2
     - sysroot_linux-64 ==2.17  # [linux]
     - task_schedule ==4.3.0
     - watch_cron_logs ==4.2.1
     - xorg-libxft ==2.3.8  # [linux]
+    - xorg-libx11 ==1.8.9  #[linux]
     - xtime ==1.2.2  # [linux]
     - zip ==3.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -22,19 +22,19 @@ requirements:
     - mkl_fft ==1.3.1  # [linux]
     - perl ==5.32.1
     - perl-app-cpanminus ==1.7047
-    - perl-app-env-ascds ==0.04  # [linux]
+    - perl-app-env-ascds =0.04=pl5321_1  # [linux]
     - perl-astro-fits-cfitsio-simple ==0.20 # [linux]
-    - perl-chandra-time ==0.9.2  # [linux]
+    - perl-chandra-time =0.9.2=pl5321h2bc3f7f_1  # [linux]
     - perl-core-deps ==0.4.0
-    - perl-cxc-sysarch ==1.00  # [linux]
+    - perl-cxc-sysarch =1.00=pl5321_1  # [linux]
     - perl-dbd-sybase ==1.24  # [linux]
     - perl-extended-deps ==0.4.0  # [linux]
     - perl-io-tty ==1.16 # [osx and x86_64]
     - perl-io-tty ==1.20 # [linux or arm64]
     - perl-ska-agasc =3.5.0=pl5321_2# [linux]
-    - perl-ska-classic ==0.6
-    - perl-ska-convert ==4.3  # [linux]
-    - perl-ska-web ==4.0  # [linux]
+    - perl-ska-classic =0.6=pl5321_1
+    - perl-ska-convert =4.3=pl5321_2  # [linux]
+    - perl-ska-web =4.0=pl5321_1  # [linux]
     - perl-tk =804.035=pl5321h3fd9d12_1 # [linux]
     - pkg-config ==0.29.2
     - sysroot_linux-64 ==2.17  # [linux]

--- a/ska_builder.py
+++ b/ska_builder.py
@@ -48,10 +48,10 @@ def get_opt():
                         help="Build only architecture-specific packages")
     parser.add_argument("--python",
                         default="3.11",
-                        help="Target version of Python (default=3.10)")
+                        help="Target version of Python (default=3.11)")
     parser.add_argument("--perl",
-                        default="5.26.2",
-                        help="Target version of Perl (default=5.26.2)")
+                        default="5.32.1",
+                        help="Target version of Perl (default=5.32.1)")
     parser.add_argument("--numpy",
                         default="1.26.3",
                         help="Build version of NumPy")


### PR DESCRIPTION
# ska3-flight 2024.7

This PR includes:
- starcheck:
  - changes to use the default AGASC file (so when 1p8 is promoted starcheck uses it without any change)
- kadi
  - changes to support the AGASC 1.8 promotion
- agasc
  - fix test and ancillary script to work with AGASC 1.8
- ska_sync
  - Update to support AGASC 1.8 promotion

This is the first release where all packages (including starcheck) are expected to work in the osx-arm64 build. A number of core packages and the ska3-perl meta-package were updated to that effect.

## Interface Impacts:

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.7rc6-HEAD/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.7rc6-GRETA/).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.7rc6-OSX/).


skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2024.7rc6 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2024.7rc6
```

## Additional Testing

As the perl version and accompanying packages have been updated - Replan Central (which is a controlled package that includes Perl code) was functionally tested and an on-the-side cron job set up with output at https://cxc.cfa.harvard.edu/mta/ASPECT/arc3_prime_test/ .

Review of the processing logs and the output shows no issues.

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2024.7 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-core changes (2024.5 -> 2024.7rc4)

### Updated Packages

- **expat:** 2.5.0 -> 2.6.2
- **libcurl:** 8.5.0 -> 8.8.0
- **libexpat:** 2.5.0 -> 2.6.2
- **openssl:** 3.2.1 -> 3.3.1
- **xorg-libx11:** 1.8.7 -> 1.8.9
- **zstandard:** 0.22.0 -> 0.19.0
- **zstd:** 1.5.5 -> 1.5.6

## ska3-perl changes

- **perl:** 5.26.2 -> 5.32.1
(with small changes in accompanying perl packages, these changes differ by OS)

## ska3-flight changes (2024.5 -> 2024.7rc6)

### Updated Packages

- **aca_view:** 0.14.0 -> 0.14.1 (0.14.0 -> 0.14.1)
  - [PR 186](https://github.com/sot/aca_view/pull/186) (Jean Connelly): Handle agasc file not found in is_agasc_available
- **agasc:** 4.19.0 -> 4.21.0 (4.19.0 -> 4.20.0 -> 4.21.0)
  - [PR 181](https://github.com/sot/agasc/pull/181) (Javier Gonzalez): Do not update supplement magnitudes if d_mag is small
  - [PR 180](https://github.com/sot/agasc/pull/180) (Javier Gonzalez): use default agasc file when updating magnitudes in supplement
  - [PR 179](https://github.com/sot/agasc/pull/179) (Tom Aldcroft): Fix tests to work with AGASC 1.8
  - [PR 178](https://github.com/sot/agasc/pull/178) (Tom Aldcroft): Fix create_derived_agasc_h5 to work for proseco_agasc
  - [PR 183](https://github.com/sot/agasc/pull/183) (Tom Aldcroft): Support `columns` key in `get_agasc_cone` and improve caching
- **kadi:** 7.10.1 -> 7.11.0
  - [PR 332](https://github.com/sot/kadi/pull/332) (Tom Aldcroft): Support AGASC 1.8 in `get_starcats`, refactor get_agasc_cone_fast()
- **proseco:** 5.13.1 -> 5.13.2 (5.13.1 -> 5.13.2)
  - [PR 398](https://github.com/sot/proseco/pull/398) (Jean Connelly): Pin proseco agasc to 1p7 for mag clip test
- **ska3-core:** 2024.5 -> 2024.7rc4
- **ska_sync:** 4.11.0 -> 4.13.0 (4.11.0 -> 4.12.0 -> 4.13.0)
  - [PR 33](https://github.com/sot/ska_sync/pull/33) (Jean Connelly): Stop syncing cmds_states and kadi cmds v1
  - [PR 34](https://github.com/sot/ska_sync/pull/34) (Jean Connelly): Update to support AGASC 1.8 promotion.
- **starcheck:** 14.9.0 -> 14.11.0 (14.9.0 -> 14.10.0 -> 14.11.0)
  - [PR 444](https://github.com/sot/starcheck/pull/444) (Jean Connelly): Set starcheck to use agasc module default agasc file
  -  [PR 445](https://github.com/sot/starcheck/pull/445): Round CCD temperature for check and add 3-digit max T_CCD output



# Related Issues

Fixes #1319
Fixes #1367
Fixes #1368
Fixes #1369
Fixes #1370
Fixes #1371
Fixes #1372
Fixes #1375
Fixes #1374
Fixes #1376
