### PR TITLE
Make kadi-apps build recipe arch-dependent

### DIFF
--- a/pkg_defs/kadi-apps/meta.yaml
+++ b/pkg_defs/kadi-apps/meta.yaml
@@ -4,7 +4,6 @@ package:
 
 build:
   script: pip install .
-  noarch: python
 
 source:
   path: {{ SKA_TOP_SRC_DIR }}/kadi-apps


### PR DESCRIPTION
Now that I am adding a kadi-apps executable, I need the package to be arch-dependent.