### PR TITLE
2024.8

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,18 +1,18 @@
 ---
 package:
   name: ska3-matlab
-  version: 2024.6
+  version: 2024.8
 
 build:
   noarch: generic
 
 requirements:
   run:
-    - aca_view ==0.14.0
+    - aca_view ==0.14.1
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.1.1
     - acispy ==2.6.0
-    - agasc ==4.19.0
+    - agasc ==4.21.0
     - backstop_history ==3.2.1
     - chandra_aca ==4.45.1
     - chandra_cmd_states ==4.1.0
@@ -24,11 +24,11 @@ requirements:
     - find_attitude ==3.4.4
     - fot-matlab ==2.4.0
     - hopper ==4.6.0
-    - kadi ==7.10.1
+    - kadi ==7.11.0
     - maude ==3.11.1
     - mica ==4.35.2
     - parse_cm ==3.15.0
-    - proseco ==5.13.1
+    - proseco ==5.13.2
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -45,11 +45,11 @@ requirements:
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
     - ska_sun ==3.14.0
-    - ska_sync ==4.11.0
+    - ska_sync ==4.13.0
     - ska_tdb ==4.0.0
-    - ska3-core ==2024.5
+    - ska3-core ==2024.7
     - ska3-template ==2022.06.02
     - sparkles ==4.26.1
-    - starcheck ==14.9.0
+    - starcheck ==14.11.0
     - testr ==4.12.0
     - xija ==4.32.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cheta ==4.62.0
     - cxotime ==3.8.0
     - find_attitude ==3.4.4
-    - fot-matlab ==2.4.0
+    - fot-matlab ==2.4.1
     - hopper ==4.6.0
     - kadi ==7.11.0
     - maude ==3.11.1


### PR DESCRIPTION
# ska3-matlab 2024.8

This PR includes the following changes to bring ska3-matlab in sync with ska3-flight 2024.7 and an update to fot-matlab:
- starcheck:
  - changes to use the default AGASC file (so when 1p8 is promoted starcheck uses it without any change)
- kadi
  - changes to support the AGASC 1.8 promotion
- agasc
  - fix test and ancillary script to work with AGASC 1.8
- ska_sync
  - Update to support AGASC 1.8 promotion

- fot-matlab
  - MATLAB-12089 - Updates to the structure of the model data
 
[Diffs from last ska3-matlab release](https://github.com/sot/skare3/compare/2024.6...2024.8-branch)

## Interface Impacts:

- agasc
  - Added new argument `full_agasc` to `agasc.write_agasc()`. If true (default), require exactly the standard AGASC column names and dtypes. If false, ensure that the output columns are a strict subset of the standard AGASC columns.
  - New keyword `columns` in `agasc.get_agasc_cone`
- ska_sync will not sync the following files anymore:
  - kadi/cmds.h5
  - kadi/cmds.pkl
  - cmd_states/cmd_states.db3
- starcheck. Changed starcheck notes format to add a 3-digit output of the max CCD temperature for diagnostics.

## Testing:

Testing results:
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.8rc2-GRETA)

NOTE: some intermittent failures in find_attitude unit tests have been observed. There is a fix for intermittent test failures in find_attitude when using AGASC 1.8 and the 1.7 version of the distances file (https://github.com/sot/find_attitude/pull/30). The issue is of no concern for operations, and the fix will be included in a future release.

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2024.8rc2 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2024.8rc2
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2024.8 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2024.6 -> 2024.8rc2)

### Updated Packages

- **aca_view:** 0.14.0 -> 0.14.1 (0.14.0 -> 0.14.1)
  - [PR 186](https://github.com/sot/aca_view/pull/186) (Jean Connelly): Handle agasc file not found in is_agasc_available
- **agasc:** 4.19.0 -> 4.21.0 (4.19.0 -> 4.20.0 -> 4.21.0)
  - [PR 181](https://github.com/sot/agasc/pull/181) (Javier Gonzalez): Do not update supplement magnitudes if d_mag is small
  - [PR 180](https://github.com/sot/agasc/pull/180) (Javier Gonzalez): use default agasc file when updating magnitudes in supplement
  - [PR 179](https://github.com/sot/agasc/pull/179) (Tom Aldcroft): Fix tests to work with AGASC 1.8
  - [PR 178](https://github.com/sot/agasc/pull/178) (Tom Aldcroft): Fix create_derived_agasc_h5 to work for proseco_agasc
  - [PR 183](https://github.com/sot/agasc/pull/183) (Tom Aldcroft): Support `columns` key in `get_agasc_cone` and improve caching
- **fot-matlab:** 2.4.0 -> 2.4.1 (2.4.0 -> 2.4.1)
  - [PR 27](https://github.com/sot/fot-matlab/pull/27) (James Kristoff): MATLAB-12089 - Updates to the structure of the model data
- **kadi:** 7.10.1 -> 7.11.0 (7.10.1 -> 7.11.0)
  - [PR 332](https://github.com/sot/kadi/pull/332) (Tom Aldcroft): Support AGASC 1.8 in `get_starcats`, refactor get_agasc_cone_fast()
- **proseco:** 5.13.1 -> 5.13.2 (5.13.1 -> 5.13.2)
  - [PR 398](https://github.com/sot/proseco/pull/398) (Jean Connelly): Pin proseco agasc to 1p7 for mag clip test
- **ska3-core:** 2024.5 -> 2024.7
- **ska_sync:** 4.11.0 -> 4.13.0 (4.11.0 -> 4.12.0 -> 4.13.0)
  - [PR 33](https://github.com/sot/ska_sync/pull/33) (Jean Connelly): Stop syncing cmds_states and kadi cmds v1
  - [PR 34](https://github.com/sot/ska_sync/pull/34) (Jean Connelly): Update to support AGASC 1.8 promotion.
- **starcheck:** 14.9.0 -> 14.11.0 (14.9.0 -> 14.10.0 -> 14.11.0)
  - [PR 444](https://github.com/sot/starcheck/pull/444) (Jean Connelly): Set starcheck to use agasc module default agasc file
  - [PR 445](https://github.com/sot/starcheck/pull/445) (Tom Aldcroft): Round CCD temperature for check and add 3-digit max T_CCD output

## ska3-core changes (2024.5 -> 2024.7)

### Updated Packages (Linux)

- **expat:** 2.5.0 -> 2.6.2
- **libcurl:** 8.5.0 -> 8.8.0
- **libexpat:** 2.5.0 -> 2.6.2
- **openssl:** 3.2.1 -> 3.3.1
- **xorg-libx11:** 1.8.7 -> 1.8.9
- **zstandard:** 0.22.0 -> 0.19.0
- **zstd:** 1.5.5 -> 1.5.6

# Related Issues

Fixes #1382
Fixes #1379 


