### PR TITLE
add recipes for acq_stat_reports  and guide_stat_reports

### DIFF
--- a/environment-non-fsds.yml
+++ b/environment-non-fsds.yml
@@ -4,11 +4,13 @@ dependencies:
   - attitude_error_mon
   - aca_hi_bgd
   - aca_weekly_report
+  - acq_stat_reports
   - acdc
   - aimpoint_mon
   - astromon
   - annie
   - fid_drift_mon
+  - guide_stat_reports
   - fss_check
   - jobwatch
   - kalman_watch

--- a/pkg_defs/acq_stat_reports/meta.yaml
+++ b/pkg_defs/acq_stat_reports/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: acq_stat_reports
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  script: pip install .
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/acq_stat_reports
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - python
+    - setuptools
+    - setuptools_scm
+    - setuptools_scm_git_archive
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - setuptools_scm
+
+about:
+  home: https://github.com/sot/acq_stat_reports
+  summary: Display star acquisition statistics trends
+  dev_url: https://github.com/sot/acq_stat_reports

--- a/pkg_defs/guide_stat_reports/meta.yaml
+++ b/pkg_defs/guide_stat_reports/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: guide_stat_reports
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  script: pip install .
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/guide_stat_reports
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - python
+    - setuptools
+    - setuptools_scm
+    - setuptools_scm_git_archive
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - setuptools_scm
+
+about:
+  home: https://github.com/sot/guide_stat_reports
+  summary: Display guide star statistics trends
+  dev_url: https://github.com/sot/guide_stat_reports


### PR DESCRIPTION
This PR add recipes for acq_stat_reports  and guide_stat_reports.

I Verified that these build locally and that they installed the scripts:

```
./ska_builder.py acq_stat_reports --tag master
./ska_builder.py guide_stat_reports --tag v3
conda install -c file://`pwd`/builds acq_stat_reports
conda install -c file://`pwd`/builds -y guide_stat_reports
mamba install -c flight -y ska_report_ranges
mamba update -c masters chandra_aca
acq-stat-reports -h
acq-stat-reports-summary -h
acq-stat-reports-toc -h
guide-stat-reports -h
guide-stat-reports-summary -h
guide-stat-reports-toc -h
```