### PR TITLE
Remove pyrightconfig.json file from templates

### DIFF
--- a/templates/pyrightconfig.json
+++ b/templates/pyrightconfig.json
@@ -1,8 +1,0 @@
-{
-    "ignore": [
-        "**/node_modules",
-        "**/__pycache__",
-        "**/*.ipynb",
-        ".git"
-    ]
-}


### PR DESCRIPTION
It turns out that adding a `pyrightconfig.json` file is a bad idea: https://github.com/microsoft/pylance-release/issues/6446

Basically adding even an empty `pyrightconfig.json` file ends up turning on type checking (it sets `python.analysis.TypeCheckingMode` to `standard`. Then simple code like this gets a warning:
```
x = {"b": "c"}
x["d"] = 1  # it thinks x is dict[str, str]
```

So we should remove this config file from our repos and individual users will need to configure VS code:
```
    "python.analysis.ignore": [
        "**/*.ipynb"
    ],
```
I think the other `ignore` values are not really needed in practice, but pylance really doesn't deal well with notebooks. 