### PR TITLE
2024.9

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -196,11 +196,11 @@ requirements:
     - libexpat ==2.6.2
     - libffi ==3.4.2
     - libflac ==1.4.3  # [linux]
-    - libgcc-ng ==13.2.0  # [linux]
+    - libgcc-ng ==14.1.0  # [linux]
     - libgcrypt ==1.10.3  # [linux]
     - libgfortran ==5.0.0  # [osx]
-    - libgfortran-ng ==13.2.0  # [linux]
-    - libgfortran5 ==13.2.0  # [linux or osx]
+    - libgfortran-ng ==14.1.0  # [linux]
+    - libgfortran5 ==14.1.0  # [linux or osx]
     - libglib ==2.78.4
     - libgpg-error ==1.48  # [linux]
     - libhwloc ==2.9.3

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2024.7
+  version: 2024.9
 
 requirements:
   run:
@@ -390,7 +390,7 @@ requirements:
     - ruamel.yaml.clib ==0.2.8
     - ruff ==0.2.2
     - scikit-learn ==1.4.1.post1
-    - scipy ==1.12.0
+    - scipy ==1.14.1
     - secretstorage ==3.3.3  # [linux]
     - send2trash ==1.8.2
     - setuptools ==69.1.1

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -196,9 +196,11 @@ requirements:
     - libexpat ==2.6.2
     - libffi ==3.4.2
     - libflac ==1.4.3  # [linux]
+    - libgcc ==14.1.0  # [linux]
     - libgcc-ng ==14.1.0  # [linux]
     - libgcrypt ==1.10.3  # [linux]
     - libgfortran ==5.0.0  # [osx]
+    - libgfortran ==14.1.0  # [linux]
     - libgfortran-ng ==14.1.0  # [linux]
     - libgfortran5 ==14.1.0  # [linux or osx]
     - libglib ==2.78.4

--- a/pkg_defs/ska3-flight-latest/meta.yaml
+++ b/pkg_defs/ska3-flight-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight-latest
-  version: "2023.10"
+  version: 2023.9
 
 build:
   noarch: generic
@@ -16,13 +16,11 @@ requirements:
     - agasc
     - backstop_history
     - chandra_aca
-    - chandra_cmd_states
     - chandra_limits
     - chandra_maneuver
     - chandra_time
     - cheta
     - cxotime
-    - find_attitude
     - fot-matlab
     - hopper
     - kadi

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -8,27 +8,25 @@ build:
 
 requirements:
   run:
-    - aca_view ==0.14.1
+    - aca_view ==0.14.2
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.1.1
-    - acispy ==2.6.0
-    - agasc ==4.21.0
+    - acispy ==2.7.0
+    - agasc ==4.21.2
     - backstop_history ==3.2.1
-    - chandra_aca ==4.45.1
-    - chandra_cmd_states ==4.1.0
-    - chandra_limits ==0.9.1
-    - chandra_maneuver ==4.2.0
+    - chandra_aca ==4.46.0
+    - chandra_limits ==0.9.2
+    - chandra_maneuver ==4.3.0
     - chandra_time ==4.1.2
     - cheta ==4.62.0
     - cxotime ==3.8.0
-    - find_attitude ==3.4.4
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
-    - kadi ==7.11.0
+    - kadi ==7.12.0
     - maude ==3.11.1
-    - mica ==4.35.2
-    - parse_cm ==3.15.0
-    - proseco ==5.13.2
+    - mica ==4.36.0
+    - parse_cm ==3.16.0
+    - proseco ==5.14.0
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -37,19 +35,19 @@ requirements:
     - ska_dbi ==5.1.0
     - ska_file ==4.0.0
     - ska_ftp ==4.0.1
-    - ska_helpers ==0.16.0
+    - ska_helpers ==0.17.0
     - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.1
     - ska_path ==3.1.2
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
-    - ska_sun ==3.14.0
+    - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.0.0
     - ska3-core ==2024.9
     - ska3-template ==2022.06.02
-    - sparkles ==4.26.1
-    - starcheck ==14.11.0
+    - sparkles ==4.26.2
+    - starcheck ==14.12.0
     - testr ==4.12.0
     - xija ==4.32.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - maude ==3.11.1
     - mica ==4.36.0
     - parse_cm ==3.16.0
-    - proseco ==5.14.0
+    - proseco ==5.15.0
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -44,10 +44,10 @@ requirements:
     - ska_shell ==4.0.1
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
-    - ska_tdb ==4.0.0
+    - ska_tdb ==4.1.0
     - ska3-core ==2024.9
     - ska3-template ==2022.06.02
-    - sparkles ==4.26.2
+    - sparkles ==4.27.0
     - starcheck ==14.12.0
     - testr ==4.12.0
     - xija ==4.32.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2024.7
+  version: 2024.9
 
 build:
   noarch: generic
@@ -22,7 +22,7 @@ requirements:
     - cheta ==4.62.0
     - cxotime ==3.8.0
     - find_attitude ==3.4.4
-    - fot-matlab ==2.4.0
+    - fot-matlab ==2.4.1
     - hopper ==4.6.0
     - kadi ==7.11.0
     - maude ==3.11.1
@@ -47,7 +47,7 @@ requirements:
     - ska_sun ==3.14.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.0.0
-    - ska3-core ==2024.7
+    - ska3-core ==2024.9
     - ska3-template ==2022.06.02
     - sparkles ==4.26.1
     - starcheck ==14.11.0


### PR DESCRIPTION
# ska3-flight 2024.9

This PR includes:
-

## Interface Impacts:

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.9rc3-HEAD/).
- [just kadi on HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.9rc3-kadi-HEAD/). (failed on first run with a connection timeout
- 
skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2024.9rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2024.9rc#
```

If this release includes an update to ska3-perl, the install process for Aspect will include that. Note: ska3-perl is generally not needed for non-Aspect users.

```
conda create -n ska3-flight-2024.9rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2024.9rc# ska3-perl==2024.9rc#
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2024.9 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

# Related Issues
