### PR TITLE
add aperoll

### DIFF
--- a/environment-non-fsds.yml
+++ b/environment-non-fsds.yml
@@ -6,6 +6,7 @@ dependencies:
   - aca_weekly_report
   - acdc
   - aimpoint_mon
+  - aperoll
   - astromon
   - annie
   - fid_drift_mon

--- a/pkg_defs/aperoll/meta.yaml
+++ b/pkg_defs/aperoll/meta.yaml
@@ -25,15 +25,18 @@ requirements:
   run:
     - python
     - numpy
-    - scipy
     - pyqt
     - pyqtwebengine
-    - maude
+    - astropy
+    - agasc
     - chandra_aca
-    - mica
     - cxotime
     - kadi
+    - maude
+    - proseco
     - quaternion
+    - ska_helpers
+    - sparkles
 
 test:
   imports:

--- a/pkg_defs/aperoll/meta.yaml
+++ b/pkg_defs/aperoll/meta.yaml
@@ -1,0 +1,44 @@
+package:
+  name: aperoll
+  version:  {{ SKA_PKG_VERSION }}
+
+build:
+  script: pip install .
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/aperoll
+
+
+# the build and runtime requirements. Dependencies of these requirements
+# are included automatically.
+requirements:
+  # Packages required to build the package. python and numpy must be
+  # listed explicitly if they are required.
+  build:
+    - pip
+    - python
+    - setuptools
+    - setuptools_scm
+    - setuptools_scm_git_archive
+  # Packages required to run the package. These are the dependencies that
+  # will be installed automatically whenever the package is installed.
+  run:
+    - python
+    - numpy
+    - scipy
+    - pyqt
+    - pyqtwebengine
+    - maude
+    - chandra_aca
+    - mica
+    - cxotime
+    - kadi
+    - quaternion
+
+test:
+  imports:
+    - aperoll
+
+
+about:
+  home: https://github.com/sot/aperoll

--- a/pkg_defs/aperoll/run_test.py
+++ b/pkg_defs/aperoll/run_test.py
@@ -1,0 +1,3 @@
+import sys
+import aca_view
+sys.exit(aca_view.test())

--- a/pkg_defs/aperoll/run_test.py
+++ b/pkg_defs/aperoll/run_test.py
@@ -1,3 +1,0 @@
-import sys
-import aca_view
-sys.exit(aca_view.test())


### PR DESCRIPTION
This PR adds a recipe for aperoll and adds it to the non-fsds environment.

I used this branch to build the latest release of aperoll, installed it from the test conda channel, and it works as expected.