### PR TITLE
2024.10

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2024.7
+  version: 2024.10
 
 requirements:
   run:
@@ -196,11 +196,13 @@ requirements:
     - libexpat ==2.6.2
     - libffi ==3.4.2
     - libflac ==1.4.3  # [linux]
-    - libgcc-ng ==13.2.0  # [linux]
+    - libgcc ==14.1.0  # [linux]
+    - libgcc-ng ==14.1.0  # [linux]
     - libgcrypt ==1.10.3  # [linux]
     - libgfortran ==5.0.0  # [osx]
-    - libgfortran-ng ==13.2.0  # [linux]
-    - libgfortran5 ==13.2.0  # [linux or osx]
+    - libgfortran ==14.1.0  # [linux]
+    - libgfortran-ng ==14.1.0  # [linux]
+    - libgfortran5 ==14.1.0  # [linux or osx]
     - libglib ==2.78.4
     - libgpg-error ==1.48  # [linux]
     - libhwloc ==2.9.3
@@ -390,7 +392,7 @@ requirements:
     - ruamel.yaml.clib ==0.2.8
     - ruff ==0.2.2
     - scikit-learn ==1.4.1.post1
-    - scipy ==1.12.0
+    - scipy ==1.14.1
     - secretstorage ==3.3.3  # [linux]
     - send2trash ==1.8.2
     - setuptools ==69.1.1

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2024.10
+  version: "2024.10"
 
 requirements:
   run:

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,34 +1,32 @@
 ---
 package:
   name: ska3-matlab
-  version: 2024.8
+  version: "2024.10"
 
 build:
   noarch: generic
 
 requirements:
   run:
-    - aca_view ==0.14.1
+    - aca_view ==0.14.2
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.1.1
-    - acispy ==2.6.0
-    - agasc ==4.21.0
+    - acispy ==2.7.0
+    - agasc ==4.21.2
     - backstop_history ==3.2.1
-    - chandra_aca ==4.45.1
-    - chandra_cmd_states ==4.1.0
-    - chandra_limits ==0.9.1
-    - chandra_maneuver ==4.2.0
+    - chandra_aca ==4.46.0
+    - chandra_limits ==0.9.2
+    - chandra_maneuver ==4.3.0
     - chandra_time ==4.1.2
     - cheta ==4.62.0
     - cxotime ==3.8.0
-    - find_attitude ==3.4.4
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
-    - kadi ==7.11.0
+    - kadi ==7.12.0
     - maude ==3.11.1
-    - mica ==4.35.2
-    - parse_cm ==3.15.0
-    - proseco ==5.13.2
+    - mica ==4.36.0
+    - parse_cm ==3.16.0
+    - proseco ==5.15.0
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -37,19 +35,19 @@ requirements:
     - ska_dbi ==5.1.0
     - ska_file ==4.0.0
     - ska_ftp ==4.0.1
-    - ska_helpers ==0.16.0
+    - ska_helpers ==0.17.0
     - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.1
     - ska_path ==3.1.2
     - ska_quatutil ==4.0.0
     - ska_shell ==4.0.1
-    - ska_sun ==3.14.0
+    - ska_sun ==3.15.0
     - ska_sync ==4.13.0
-    - ska_tdb ==4.0.0
-    - ska3-core ==2024.7
+    - ska_tdb ==4.1.0
+    - ska3-core ==2024.10
     - ska3-template ==2022.06.02
-    - sparkles ==4.26.1
-    - starcheck ==14.11.0
+    - sparkles ==4.27.0
+    - starcheck ==14.12.0
     - testr ==4.12.0
     - xija ==4.32.0


### PR DESCRIPTION
# ska3-matlab 2024.10

This PR includes:
- starcheck: Update starcheck IR zone to (-5, +35)
- ska_tdb: Updates to support remote access from Windows
- ska_sun: Add functions `get_att_for_sun_pitch_yaw` and `get_nsm_attitude`
- proseco: COLOR1=0.7 stars are now excluded from guide selection
- chandra_aca: New routine for modern dark scaling

## Interface Impacts:

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.10rc1-HEAD).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.10rc1-GRETA).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2024.10rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2024.10rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2024.10 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-core changes (2024.7 -> 2024.10rc1)

ska3-core changes are motivated by an update to scipy.

### New Packages

- **libgcc: 14.1.0**
- **libgfortran: 14.1.0**

### Updated Packages

- **libgcc-ng:** 13.2.0 -> 14.1.0
- **libgfortran-ng:** 13.2.0 -> 14.1.0
- **libgfortran5:** 13.2.0 -> 14.1.0
- **scipy:** 1.12.0 -> 1.14.1



## ska3-matlab changes (2024.8 -> 2024.10rc1)

### Removed Packages

- **chandra_cmd_states**
- **find_attitude**

### Updated Packages

- **aca_view:** 0.14.1 -> 0.14.2 (0.14.1 -> 0.14.2)
  - [PR 188](https://github.com/sot/aca_view/pull/188) (Javier Gonzalez): Handle modern format 6
- **acispy:** 2.6.0 -> 2.7.0 (2.6.0 -> 2.7.0)
  - [PR 14](https://github.com/acisops/acispy/pull/14) (John ZuHone): Updates to thermal model support
  - [PR 13](https://github.com/acisops/acispy/pull/13) (John ZuHone): Improve handling of vehicle loads in SimulateECSRun, other small changes
- **agasc:** 4.21.0 -> 4.21.2 (4.21.0 -> 4.21.1 -> 4.21.2)
  - [PR 187](https://github.com/sot/agasc/pull/187) (Jean Connelly): Add a link to the old 1p7 readme from the docs index
  - [PR 182](https://github.com/sot/agasc/pull/182) (Javier Gonzalez): Update readme for 1p8
  - [PR 184](https://github.com/sot/agasc/pull/184) (Tom Aldcroft): Add type annotations and use numpydoc for key modules and functions
  - [PR 191](https://github.com/sot/agasc/pull/191) (Jean Connelly): Handle bad stars from supplement in one test
  - [PR 188](https://github.com/sot/agasc/pull/188) (Jean Connelly): Reduce number of bad stars in test
- **chandra_aca:** 4.45.1 -> 4.46.0 (4.45.1 -> 4.46.0)
  - [PR 172](https://github.com/sot/chandra_aca/pull/172) (Jean Connelly): Add routine for modern dark scaling
  - [PR 171](https://github.com/sot/chandra_aca/pull/171) (Javier Gonzalez): Binomial uncertainty
  - [PR 170](https://github.com/sot/chandra_aca/pull/170) (Tom Aldcroft): Use proseco acq candidate mask for ACA plot (bad_acq_stars)
- **chandra_limits:** 0.9.1 -> 0.9.2 (0.9.1 -> 0.9.2)
  - [PR 17](https://github.com/sot/chandra_limits/pull/17) (John ZuHone): Fix for when long ECS measurements are not in the obscat
- **chandra_maneuver:** 4.2.0 -> 4.3.0 (4.2.0 -> 4.3.0)
  - [PR 29](https://github.com/sot/chandra_maneuver/pull/29) (Tom Aldcroft): Make NSM_attitude() a wrapper for ska_sun.get_nsm_attitude()
- **kadi:** 7.11.0 -> 7.12.0 (7.11.0 -> 7.12.0)
  - [PR 333](https://github.com/sot/kadi/pull/333) (Javier Gonzalez): Use single date for agasc1p8 promotion
  - [PR 336](https://github.com/sot/kadi/pull/336) (Jean Connelly): Update to use get_nsm_attitude
  - [PR 335](https://github.com/sot/kadi/pull/335) (Tom Aldcroft): Squelch logging warning message in one test
- **mica:** 4.35.2 -> 4.36.0 (4.35.2 -> 4.36.0)
  - [PR 300](https://github.com/sot/mica/pull/300) (Jean Connelly): Ruff
  - [PR 299](https://github.com/sot/mica/pull/299) (Jean Connelly): Use full agasc for lookups for guide/acq stats
- **parse_cm:** 3.15.0 -> 3.16.0 (3.15.0 -> 3.16.0)
  - [PR 54](https://github.com/sot/parse_cm/pull/54) (Jean Connelly): Update backstop quaternion printed format and corresponding regress data
- **proseco:** 5.13.2 -> 5.15.0 (5.13.2 -> 5.14.0 -> 5.15.0)
  - [PR 402](https://github.com/sot/proseco/pull/402) (Tom Aldcroft): Update README.md
  - [PR 400](https://github.com/sot/proseco/pull/400) (Jean Connelly): Remove some agasc supplement bad star tests
  - [PR 399](https://github.com/sot/proseco/pull/399) (Tom Aldcroft): Factor out guide and acq candidates mask
  - [PR 401](https://github.com/sot/proseco/pull/401) (Jean Connelly): Exclude COLOR1=0.7 stars from guide selection
- **ska3-core:** 2024.7 -> 2024.10rc1
- **ska_helpers:** 0.16.0 -> 0.17.0 (0.16.0 -> 0.17.0)
  - [PR 58](https://github.com/sot/ska_helpers/pull/58) (Tom Aldcroft): New utils: logger context manager and random RA and Decs
- **ska_sun:** 3.14.0 -> 3.15.0 (3.14.0 -> 3.15.0)
  - [PR 38](https://github.com/sot/ska_sun/pull/38) (Tom Aldcroft): Add functions get_att_for_sun_pitch_yaw() and get_nsm_attitude()
- **ska_tdb:** 4.0.0 -> 4.1.0 (4.0.0 -> 4.1.0)
  - [PR 19](https://github.com/sot/ska_tdb/pull/19) (James Kristoff): Updates to support remote access from Windows
- **sparkles:** 4.26.1 -> 4.27.0 (4.26.1 -> 4.26.2 -> 4.27.0)
  - [PR 211](https://github.com/sot/sparkles/pull/211) (Jean Connelly): Use a different bad star for bad star test
  - [PR 212](https://github.com/sot/sparkles/pull/212) (Jean Connelly): Update sparkles tests for proseco no-color1 guide star change
- **starcheck:** 14.11.0 -> 14.12.0 (14.11.0 -> 14.12.0)
  - [PR 447](https://github.com/sot/starcheck/pull/447) (Jean Connelly): Update starcheck IR zone to (-5, +35)
  - [PR 426](https://github.com/sot/starcheck/pull/426) (Jean Connelly): Update acq model range warning for current grid model

# Related Issues

Fixes #1422