### PR TITLE
Add recipe for fotmp package

### DIFF
--- a/pkg_defs/fotmp/meta.yaml
+++ b/pkg_defs/fotmp/meta.yaml
@@ -1,0 +1,34 @@
+
+package:
+  name: fotmp  # lower case name of package, may contain '-' but no spaces
+  version: {{ SKA_PKG_VERSION }}
+
+
+build:
+  script: pip install .
+  noarch: python
+
+source:
+  path: {{ SKA_TOP_SRC_DIR }}/fotmp
+
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - setuptools_scm
+    - setuptools_scm_git_archive
+    - ska_helpers
+    - testr
+  run:
+    - python
+    - ska_helpers
+    - testr
+
+test:
+  imports:
+    - fotmp
+
+about:
+  home: https://github.com/sot/fotmp


### PR DESCRIPTION
Add recipe for fotmp package.

I tested this locally with 
```
python ska_builder.py fotmp --tag 614d40b --override-channels -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight -c conda-forge
```
and confirmed it made a package.
