### PR TITLE
2024.12

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,32 +1,32 @@
 ---
 package:
   name: ska3-flight
-  version: 2024.11
+  version: 2024.12
 
 build:
   noarch: generic
 
 requirements:
   run:
-    - aca_view ==0.15.0
+    - aca_view ==0.16.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==5.1.1
+    - acis_thermal_check ==5.2.0
     - acispy ==2.7.0
-    - agasc ==4.21.2
+    - agasc ==4.22.0
     - backstop_history ==3.2.1
-    - chandra_aca ==4.47.0
+    - chandra_aca ==4.48.0
     - chandra_limits ==0.10.0
     - chandra_maneuver ==4.3.0
     - chandra_time ==4.1.2
-    - cheta ==4.62.1
-    - cxotime ==3.9.0
+    - cheta ==4.62.2
+    - cxotime ==3.9.1
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
-    - kadi ==7.13.0
-    - maude ==3.11.1
-    - mica ==4.37.0
-    - parse_cm ==3.16.0
-    - proseco ==5.15.0
+    - kadi ==7.14.0
+    - maude ==3.12.0
+    - mica ==4.38.0
+    - parse_cm ==3.16.1
+    - proseco ==5.16.0
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -47,7 +47,7 @@ requirements:
     - ska_tdb ==4.1.0
     - ska3-core ==2024.11
     - ska3-template ==2022.06.02
-    - sparkles ==4.27.1
+    - sparkles ==4.28.0
     - starcheck ==14.12.0
     - testr ==4.12.0
     - xija ==4.32.0


### PR DESCRIPTION
# ska3-flight 2024.12

This PR includes:
- acisfp_check: Update to allow for HRC dependence in the ACIS FP model.
- chandra_aca: Add some routines to get background subtracted images (relevant only for ACA).
- maude: Add `get_last_backorbit_date` function  to return the last available backorbit (SSR-dump) data for a list of MSIDs. This is useful to avoid accidentally getting realtime data that may have gaps or corruptions.

## Interface Impacts:

- chandra_aca:
  - dtype of return value in `get_aca_images` changed. 
  - `get_aca_images` now allows fetching data over time ranges larger than 3 hours
- maude: Adds a new function `get_last_backorbit_date`
- mica: columns in return value of `get_aca_images` are unmasked, except images.

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.12rc1-HEAD).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.12rc1-GRETA).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2024.12rc1-OSX)

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2024.12rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2024.12rc1
```

If this release includes an update to ska3-perl, the install process for Aspect will include that. Note: ska3-perl is generally not needed for non-Aspect users.

```
conda create -n ska3-flight-2024.12rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2024.12rc1 ska3-perl==2024.12rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2024.12 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-flight changes (2024.11 -> 2024.12rc1)

### Updated Packages

- **aca_view:** 0.15.0 -> 0.16.0 (0.15.0 -> 0.16.0)
  - [PR 200](https://github.com/sot/aca_view/pull/200) (Javier Gonzalez): fix edge case of AcaTelemetryTraverser.set_time
  - [PR 203](https://github.com/sot/aca_view/pull/203) (Javier Gonzalez): Fix issue #202
  - [PR 201](https://github.com/sot/aca_view/pull/201) (Javier Gonzalez): fix crash in general info widget when one slot has no data
- **acis_thermal_check:** 5.1.1 -> 5.2.0 (5.1.1 -> 5.2.0)
  - [PR 75](https://github.com/acisops/acis_thermal_check/pull/75) (John ZuHone): Update acisfp_check to allow for HRC dependence in the ACIS FP model
- **agasc:** 4.21.2 -> 4.22.0 (4.21.2 -> 4.22.0)
  - [PR 195](https://github.com/sot/agasc/pull/195) (Jean Connelly): Update for public use.
  - [PR 193](https://github.com/sot/agasc/pull/193) (Javier Gonzalez): add add_pmcorr_columns to agasc.__all__
- **chandra_aca:** 4.47.0 -> 4.48.0 (4.47.0 -> 4.48.0)
  - [PR 184](https://github.com/sot/chandra_aca/pull/184) (Jean Connelly): Ruff
  - [PR 174](https://github.com/sot/chandra_aca/pull/174) (Jean Connelly): Add some routines to get background subtracted images
  - [PR 182](https://github.com/sot/chandra_aca/pull/182) (Tom Aldcroft): `get_aca_images()` returns MaskedColumns only for data with masked values (except IMG)
  - [PR 183](https://github.com/sot/chandra_aca/pull/183) (Tom Aldcroft): Migrate maude_decom to CxoTime
  - [PR 181](https://github.com/sot/chandra_aca/pull/181) (Jean Connelly): Use CxoTime.linspace on get_aca_images for > 3hour range
- **cheta:** 4.62.1 -> 4.62.2 (4.62.1 -> 4.62.2)
  - [PR 265](https://github.com/sot/cheta/pull/265) (Tom Aldcroft): Refresh regression testing and fix ruff / improve variable naming
- **cxotime:** 3.9.0 -> 3.9.1 (3.9.0 -> 3.9.1)
  - [PR 47](https://github.com/sot/cxotime/pull/47) (Jean Connelly): Update linspace step_max docs
- **kadi:** 7.13.0 -> 7.14.0 (7.13.0 -> 7.14.0)
  - [PR 342](https://github.com/sot/kadi/pull/342) (Tom Aldcroft): Modernize ruff
  - [PR 338](https://github.com/sot/kadi/pull/338) (Jean Connelly): Set min_violation_duration to 180s for pcad validation
  - [PR 340](https://github.com/sot/kadi/pull/340) (Tom Aldcroft): Improve command states with better transition infrastructure
- **maude:** 3.11.1 -> 3.12.0 (3.11.1 -> 3.12.0)
  - [PR 46](https://github.com/sot/maude/pull/46) (Tom Aldcroft): Add get_last_backorbit_date function
- **mica:** 4.37.0 -> 4.38.0 (4.37.0 -> 4.38.0)
  - [PR 311](https://github.com/sot/mica/pull/311) (Jean Connelly): Unmask aca image data columns (from get_aca_images) except for IMG
- **parse_cm:** 3.16.0 -> 3.16.1 (3.16.0 -> 3.16.1)
  - [PR 55](https://github.com/sot/parse_cm/pull/55) (Tom Aldcroft): Stop showing source code in public docs
- **proseco:** 5.15.0 -> 5.16.0 (5.15.0 -> 5.16.0)
  - [PR 403](https://github.com/sot/proseco/pull/403) (Jean Connelly): Change dyn_bgd_n_faint default to 2 and fix faint force-include bug
- **sparkles:** 4.27.1 -> 4.28.0 (4.27.1 -> 4.28.0)
  - [PR 219](https://github.com/sot/sparkles/pull/219) (Jean Connelly): Update dec98_9 roll tests with new guide counts
  - [PR 217](https://github.com/sot/sparkles/pull/217) (Jean Connelly): Ruff: noqa an instance of PLC0206 in a yoshi test
  - [PR 215](https://github.com/sot/sparkles/pull/215) (Jean Connelly): Apply dynamic background bonus to rolled "n_stars"
  - [PR 214](https://github.com/sot/sparkles/pull/214) (Jean Connelly): Update a few tests to use old dyn_bgd_n_faint=0 default

# Related Issues

Fixes #1437
Fixes #1438
Fixes #1439
Fixes #1440
Fixes #1441
Fixes #1442
Fixes #1443
Fixes #1444
Fixes #1445
Fixes #1446
Fixes #1447
Fixes #1448
Fixes #1449
