### PR TITLE
2025.0

### DIFF
--- a/.github/workflows/package_build.yml
+++ b/.github/workflows/package_build.yml
@@ -94,63 +94,20 @@ jobs:
         repository: sot/skare3_tools
         ref: master
         path: skare3_tools
-    - name: Cache Conda Packages
-      uses: actions/cache@v4
-      env:
-        # Increase this value to reset cache if etc/example-environment.yml has not changed
-        CACHE_NUMBER: 0
-      with:
-        path: ~/conda_pkgs_dir
-        key:
-          conda-build-pkgs-${{ runner.os }}-${{hashFiles('./skare3/build-environment.yml') }}-${{ env.CACHE_NUMBER }}
     - name: Setup Conda Environment
       if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
       uses: conda-incubator/setup-miniconda@v3.0.4
       with:
-        # mamba-version: "*"
-        auto-update-conda: true
-        use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+        miniforge-version: latest
         python-version: ${{ inputs.python_version }}
         activate-environment: conda-build
         channels: https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/${{ inputs.channel }},conda-forge
-    #- name: Debug
-    #  if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
-    #  run: |
-    #    env
-    #    echo $CONDA_EXE info --envs
-    #    $CONDA_EXE info --envs
-    - name: Cache Conda Environment
-      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
-      uses: actions/cache@v4
-      with:
-        # it seems that env.CONDA is not available, so I am caching the directories for windows and
-        # linux (only one will succeed)
-        # path: ${{ env.CONDA }}/envs
-        path: /c/Miniconda/envs
-        key:
-          conda-build-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('./skare3/build-environment.yml') }}-${{ env.CACHE_NUMBER }}
-      env:
-        # Increase this value to reset cache if etc/example-environment.yml has not changed
-        CACHE_NUMBER: 0
-      id: conda_cache
-    - name: Cache Conda Environment
-      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
-      uses: actions/cache@v4
-      with:
-        # path: ${{ env.CONDA }}/envs
-        path: /usr/share/miniconda/envs
-        key:
-          conda-build-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('./skare3/build-environment.yml') }}-${{ env.CACHE_NUMBER }}
-      env:
-        # Increase this value to reset cache if etc/example-environment.yml has not changed
-        CACHE_NUMBER: 0
-      id: conda_cache_win
     - name: Update Conda Environment
-      if: ${{ ((steps.conda_cache.outputs.cache-hit != 'true') && (steps.conda_cache_win.outputs.cache-hit != 'true')) && ((matrix.os == 'ubuntu-latest') || !inputs.noarch) }}
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
       run:
         conda env update -n conda-build -f ./skare3/build-environment.yml
     - name: Install ska_helpers
-      if: ${{ inputs.install_ska_helpers && ((steps.conda_cache.outputs.cache-hit != 'true') && (steps.conda_cache_win.outputs.cache-hit != 'true')) && ((matrix.os == 'ubuntu-latest') || !inputs.noarch) }}
+      if: ${{ inputs.install_ska_helpers && ((matrix.os == 'ubuntu-latest') || !inputs.noarch) }}
       run: |
         conda search ska_helpers
         err=$?

--- a/pkg_defs/ska3-core-latest/base_environment.yml
+++ b/pkg_defs/ska3-core-latest/base_environment.yml
@@ -1,8 +1,8 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
-  - numexpr<2.8.5
+  - python=3.12
+  - numexpr
   - libblas         # on conda-forge, libblas uses open_blas by default
   - libarchive      # libarchive from defaults is not good for mamba
   - mamba

--- a/pkg_defs/ska3-core-latest/install_from_scratch.py
+++ b/pkg_defs/ska3-core-latest/install_from_scratch.py
@@ -41,13 +41,13 @@ def get_package_list():
             "options": [],
             "packages": ["django==3.1.7"],
         },
-        {  # later versions cause a conflict with nb_conda
-            "channels": CHANNELS,
-            "options": [],
-            "packages": ["notebook==6.5.6"],
-        },
+        # {  # later versions cause a conflict with nb_conda
+        #     "channels": CHANNELS,
+        #     "options": [],
+        #     "packages": ["notebook==6.5.6"],
+        # },
         {  # this is not in defaults or conda-forge (for now?)
-            "channels": ["sherpa"] + CHANNELS,
+            "channels": ["https://cxc.cfa.harvard.edu/conda/sherpa"] + CHANNELS,
             "options": [],
             "packages": ["sherpa"],
             "platform": ["linux-64", "osx-64", "osx-arm64"],

--- a/pkg_defs/ska3-core-latest/install_from_scratch.py
+++ b/pkg_defs/ska3-core-latest/install_from_scratch.py
@@ -36,6 +36,11 @@ def get_package_list():
                 "pyqt",
             ],
         },
+        {  # 0.60 is incompatible with VS code debugger
+            "channels": CHANNELS,
+            "options": [],
+            "packages": ["numba==0.59.1"],
+        },
         {  # this version is set so it is not the latest
             "channels": CHANNELS,
             "options": [],

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -51,8 +51,6 @@ requirements:
    - openpyxl
    - pillow
    - pip
-   - flake8
-   - pylint
    - plotly
    - ply
    - pre-commit

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -55,17 +55,18 @@ requirements:
    - pylint
    - plotly
    - ply
+   - pre-commit
    - pytest-timeout
    - python-kaleido
    - python-docx
    - pyqt
    - pyqtgraph
+   - pyqtwebengine
    - pyyaml
    - qt
    - regions
    - requests
    - rope
-   - ruff
    - scikit-learn
    - scipy
    - setuptools

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core-latest
-  version: 2024.1
+  version: 2025.0
 
 requirements:
   run:
@@ -74,7 +74,7 @@ requirements:
    - sphinx-argparse
    - six
    - sphinx
-   - sqlalchemy # [win]
+   - sqlalchemy
    - sqlite
    - tk
    - tqdm

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -101,7 +101,7 @@ requirements:
     - cpython ==3.12.8  # [win]
     - cryptography ==44.0.0
     - cycler ==0.12.1
-    - cyrus-sasl ==2.1.27  # [linux or arm64]
+    - cyrus-sasl ==2.1.27  # [arm64]
     - cython ==3.0.11
     - dask-core ==2024.12.1
     - dbus ==1.13.6  # [linux]
@@ -113,7 +113,6 @@ requirements:
     - django ==3.1.7
     - docutils ==0.21.2
     - docxtpl ==0.11.5
-    - double-conversion ==3.3.0  # [linux]
     - entrypoints ==0.4
     - et_xmlfile ==2.0.0
     - exceptiongroup ==1.2.2
@@ -235,7 +234,6 @@ requirements:
     - libcblas ==3.9.0
     - libclang-cpp15 ==15.0.7  # [linux or osx]
     - libclang-cpp17 ==17.0.6  # [arm64]
-    - libclang-cpp19.1 ==19.1.6  # [linux]
     - libclang13 ==19.1.6
     - libcrc32c ==1.1.2
     - libcups ==2.3.3  # [linux]
@@ -263,7 +261,7 @@ requirements:
     - libglib ==2.82.2
     - libglvnd ==1.7.0  # [linux]
     - libglx ==1.7.0  # [linux]
-    - libgomp ==14.2.0  # [linux or win]
+    - libgomp ==14.2.0  # [win]
     - libgoogle-cloud ==2.33.0
     - libgoogle-cloud-storage ==2.33.0
     - libgpg-error ==1.51  # [linux]
@@ -283,10 +281,9 @@ requirements:
     - libmambapy ==2.0.5
     - libnghttp2 ==1.64.0  # [linux or osx]
     - libnsl ==2.0.1  # [linux]
-    - libntlm ==1.8  # [linux or arm64]
+    - libntlm ==1.8  # [arm64]
     - libogg ==1.3.5
-    - libopenblas ==0.3.28
-    - libopengl ==1.7.0  # [linux]
+    - libopenblas ==0.3.28  # [osx or win]
     - libopus ==1.3.1  # [linux or osx]
     - libparquet ==18.1.0
     - libpciaccess ==0.18  # [linux]
@@ -340,6 +337,7 @@ requirements:
     - mccabe ==0.7.0
     - menuinst ==2.2.0
     - mistune ==3.0.2
+    - mkl ==2024.2.2
     - more-itertools ==10.5.0
     - mpg123 ==1.32.9  # [linux]
     - mpld3 ==0.5.10
@@ -363,7 +361,7 @@ requirements:
     - networkx ==3.4.2
     - nlohmann_json ==3.11.3
     - nodejs ==22.12.0
-    - nomkl ==1.0  # [linux or win]
+    - nomkl ==1.0  # [win]
     - nose ==1.3.7
     - notebook ==6.5.7
     - notebook-shim ==0.2.4
@@ -375,7 +373,7 @@ requirements:
     - numpydoc ==1.8.0
     - oauthlib ==3.2.2
     - openjpeg ==2.5.3
-    - openldap ==2.6.9  # [linux or arm64]
+    - openldap ==2.6.9  # [arm64]
     - openpyxl ==3.1.5
     - openssl ==3.4.0
     - orc ==2.0.3
@@ -539,7 +537,6 @@ requirements:
     - vc ==14.3  # [win]
     - vc14_runtime ==14.42.34433  # [win]
     - vs2015_runtime ==14.42.34433  # [win]
-    - wayland ==1.23.1  # [linux]
     - wcwidth ==0.2.13
     - webcolors ==24.11.1
     - webencodings ==0.5.1
@@ -550,7 +547,6 @@ requirements:
     - winpty ==0.4.3  # [win]
     - wrapt ==1.17.0
     - xcb-util ==0.4.1  # [linux]
-    - xcb-util-cursor ==0.1.5  # [linux]
     - xcb-util-image ==0.4.0  # [linux]
     - xcb-util-keysyms ==0.4.1  # [linux]
     - xcb-util-renderutil ==0.3.10  # [linux]
@@ -561,7 +557,6 @@ requirements:
     - xorg-libx11 ==1.8.10  # [linux]
     - xorg-libxau ==1.0.12
     - xorg-libxcomposite ==0.4.6  # [linux]
-    - xorg-libxcursor ==1.2.3  # [linux]
     - xorg-libxdamage ==1.1.6  # [linux]
     - xorg-libxdmcp ==1.1.5
     - xorg-libxext ==1.3.6  # [linux]

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -102,7 +102,6 @@ requirements:
     - cpython ==3.12.8  # [win]
     - cryptography ==44.0.0
     - cycler ==0.12.1
-    - cyrus-sasl ==2.1.27  # [arm64]
     - cython ==3.0.11
     - dask-core ==2024.12.1
     - dbus ==1.13.6  # [linux]
@@ -236,7 +235,6 @@ requirements:
     - libcap ==2.71  # [linux]
     - libcblas ==3.9.0
     - libclang-cpp15 ==15.0.7  # [linux or osx]
-    - libclang-cpp17 ==17.0.6  # [arm64]
     - libclang13 ==19.1.6
     - libcrc32c ==1.1.2
     - libcups ==2.3.3  # [linux]
@@ -277,14 +275,12 @@ requirements:
     - liblief ==0.14.1
     - libllvm14 ==14.0.6  # [linux or osx]
     - libllvm15 ==15.0.7  # [linux or osx]
-    - libllvm17 ==17.0.6  # [arm64]
     - libllvm19 ==19.1.6  # [linux or osx]
     - liblzma ==5.6.3
     - libmamba ==2.0.5
     - libmambapy ==2.0.5
     - libnghttp2 ==1.64.0  # [linux or osx]
     - libnsl ==2.0.1  # [linux]
-    - libntlm ==1.8  # [arm64]
     - libogg ==1.3.5
     - libopenblas ==0.3.28  # [osx or win]
     - libopus ==1.3.1  # [linux or osx]
@@ -377,7 +373,6 @@ requirements:
     - numpydoc ==1.8.0
     - oauthlib ==3.2.2
     - openjpeg ==2.5.3
-    - openldap ==2.6.9  # [arm64]
     - openpyxl ==3.1.5
     - openssl ==3.4.0
     - orc ==2.0.3

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -321,7 +321,7 @@ requirements:
     - llvm-openmp ==19.1.6  # [osx]
     - llvm-tools ==19.1.6  # [osx]
     - llvm-tools-19 ==19.1.6  # [osx]
-    - llvmlite ==0.43.0
+    - llvmlite ==0.42.0
     - locket ==1.0.0
     - lxml ==5.3.0
     - lz4-c ==1.10.0
@@ -371,7 +371,7 @@ requirements:
     - notebook-shim ==0.2.4
     - nspr ==4.36  # [linux or osx]
     - nss ==3.107  # [linux or osx]
-    - numba ==0.60.0
+    - numba ==0.59.1
     - numexpr ==2.10.2
     - numpy ==1.26.4
     - numpydoc ==1.8.0

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -120,7 +120,6 @@ requirements:
     - executing ==2.1.0
     - expat ==2.6.4  # [linux]
     - filelock ==3.16.1
-    - flake8 ==7.1.1
     - fmt ==11.0.2
     - font-ttf-dejavu-sans-mono ==2.37  # [linux]
     - font-ttf-inconsolata ==3.000  # [linux]
@@ -419,10 +418,8 @@ requirements:
     - pycosat ==0.6.6
     - pycparser ==2.22
     - pyerfa ==2.0.1.5
-    - pyflakes ==3.2.0
     - pygments ==2.18.0
     - pyjwt ==2.10.1
-    - pylint ==3.3.3
     - pynacl ==1.5.0
     - pyobjc-core ==10.3.2  # [osx]
     - pyobjc-framework-cocoa ==10.3.2  # [osx]

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -337,7 +337,7 @@ requirements:
     - mccabe ==0.7.0
     - menuinst ==2.2.0
     - mistune ==3.0.2
-    - mkl ==2024.2.2
+    - mkl ==2024.2.2  # [linux]
     - more-itertools ==10.5.0
     - mpg123 ==1.32.9  # [linux]
     - mpld3 ==0.5.10

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -81,6 +81,7 @@ requirements:
     - cctools_osx-arm64 ==1010.6  # [arm64]
     - certifi ==2024.12.14
     - cffi ==1.17.1
+    - cfgv ==3.3.1
     - chardet ==5.2.0
     - charset-normalizer ==3.4.0
     - click ==8.1.8
@@ -109,6 +110,7 @@ requirements:
     - decorator ==5.1.1
     - defusedxml ==0.7.1
     - dill ==0.3.9
+    - distlib ==0.3.9
     - distro ==1.9.0
     - django ==3.1.7
     - docutils ==0.21.2
@@ -161,6 +163,7 @@ requirements:
     - httpx ==0.28.1
     - hyperframe ==6.0.1
     - icu ==75.1
+    - identify ==2.6.4
     - idna ==3.10
     - imagesize ==1.4.1
     - importlib-metadata ==8.5.0
@@ -363,6 +366,7 @@ requirements:
     - nodejs ==22.12.0
     - nomkl ==1.0  # [win]
     - nose ==1.3.7
+    - nodeenv ==1.9.1
     - notebook ==6.5.7
     - notebook-shim ==0.2.4
     - nspr ==4.36  # [linux or osx]
@@ -400,6 +404,7 @@ requirements:
     - plotly ==5.24.1
     - pluggy ==1.5.0
     - ply ==3.11
+    - pre-commit ==4.0.1
     - prometheus_client ==0.21.1
     - prompt-toolkit ==3.0.48
     - prompt_toolkit ==3.0.48
@@ -430,6 +435,7 @@ requirements:
     - pyqt ==5.15.9
     - pyqt5-sip ==12.12.2
     - pyqtgraph ==0.13.7
+    - pyqtwebengine ==5.15.9
     - pysocks ==1.7.1
     - pytables ==3.10.1
     - pytest ==8.3.4
@@ -474,7 +480,6 @@ requirements:
     - rpds-py ==0.22.3
     - ruamel.yaml ==0.18.6
     - ruamel.yaml.clib ==0.2.8
-    - ruff ==0.8.5
     - s2n ==1.5.10  # [linux]
     - s3fs ==2024.12.0
     - scikit-learn ==1.6.0
@@ -531,11 +536,13 @@ requirements:
     - typing_utils ==0.1.0
     - tzdata ==2024b
     - ucrt ==10.0.22621.0  # [win]
+    - ukkonen ==1.0.1
     - unicodedata2 ==15.1.0
     - uri-template ==1.3.0
     - urllib3 ==2.3.0
     - vc ==14.3  # [win]
     - vc14_runtime ==14.42.34433  # [win]
+    - virtualenv ==20.28.1
     - vs2015_runtime ==14.42.34433  # [win]
     - wcwidth ==0.2.13
     - webcolors ==24.11.1

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -77,7 +77,7 @@ requirements:
     - cached_property ==1.5.2
     - cairo ==1.18.2  # [linux]
     - cctools ==1010.6  # [osx]
-    - cctools_osx-64 ==1010.6  # [osx-64]
+    - cctools_osx-64 ==1010.6  # [osx and not arm64]
     - cctools_osx-arm64 ==1010.6  # [arm64]
     - certifi ==2024.12.14
     - cffi ==1.17.1
@@ -214,7 +214,7 @@ requirements:
     - lame ==3.100  # [linux]
     - lcms2 ==2.16
     - ld64 ==951.9  # [osx]
-    - ld64_osx-64 ==951.9  # [osx-64]
+    - ld64_osx-64 ==951.9  # [osx and not arm64]
     - ld64_osx-arm64 ==951.9  # [arm64]
     - ld_impl_linux-64 ==2.43  # [linux]
     - lerc ==4.0.0
@@ -489,7 +489,7 @@ requirements:
     - sherpa ==4.17.0  # [linux or osx]
     - sigtool ==0.1.3  # [osx]
     - simdjson ==3.11.3
-    - sip ==6.7.12  # [linux or osx-64 or win]
+    - sip ==6.7.12  # [not arm64]
     - sip ==6.8.6  # [arm64]
     - six ==1.17.0
     - smmap ==5.0.0

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,501 +1,584 @@
 ---
 package:
   name: ska3-core
-  version: 2024.11
+  version: 2025.0
 
 requirements:
   run:
     - _libgcc_mutex ==0.1  # [linux]
-    - _openmp_mutex ==4.5  # [linux]
-    - alabaster ==0.7.16
-    - alsa-lib ==1.2.10  # [linux]
-    - anyio ==4.3.0
+    - _openmp_mutex ==4.5  # [linux or win]
+    - aiobotocore ==2.16.1
+    - aiohappyeyeballs ==2.4.4
+    - aiohttp ==3.11.11
+    - aioitertools ==0.12.0
+    - aiosignal ==1.3.2
+    - alabaster ==1.0.0
+    - alsa-lib ==1.2.13  # [linux]
+    - anyio ==4.7.0
     - appnope ==0.1.4  # [osx]
     - archspec ==0.2.3
     - argon2-cffi ==23.1.0
     - argon2-cffi-bindings ==21.2.0
     - arrow ==1.3.0
     - asgiref ==3.3.4
-    - astroid ==3.1.0
-    - astropy ==6.0.0
-    - astropy-healpix ==1.0.2
-    - astropy-iers-data ==0.2024.2.26.0.28.55
+    - astroid ==3.3.8
+    - astropy ==7.0.0
+    - astropy-base ==7.0.0
+    - astropy-healpix ==1.0.3
+    - astropy-iers-data ==0.2024.12.30.0.33.36
     - astropy-sphinx-theme ==1.1
-    - astroquery ==0.4.6
-    - asttokens ==2.4.1
+    - astroquery ==0.4.7
+    - asttokens ==3.0.0
     - async-lru ==2.0.4
     - attr ==2.5.1  # [linux]
-    - attrs ==23.2.0
-    - autopep8 ==2.0.4
-    - babel ==2.14.0
+    - attrs ==24.3.0
+    - autopep8 ==2.3.1
+    - aws-c-auth ==0.8.0
+    - aws-c-cal ==0.8.1
+    - aws-c-common ==0.10.6
+    - aws-c-compression ==0.3.0
+    - aws-c-event-stream ==0.5.0
+    - aws-c-http ==0.9.2
+    - aws-c-io ==0.15.3
+    - aws-c-mqtt ==0.11.0
+    - aws-c-s3 ==0.7.7
+    - aws-c-sdkutils ==0.2.1
+    - aws-checksums ==0.2.2
+    - aws-crt-cpp ==0.29.7
+    - aws-sdk-cpp ==1.11.458
+    - azure-core-cpp ==1.14.0  # [linux or osx]
+    - azure-identity-cpp ==1.10.0  # [linux or osx]
+    - azure-storage-blobs-cpp ==12.13.0  # [linux or osx]
+    - azure-storage-common-cpp ==12.8.0  # [linux or osx]
+    - azure-storage-files-datalake-cpp ==12.12.0  # [linux or osx]
+    - babel ==2.16.0
     - backports ==1.0
+    - backports.tarfile ==1.2.0
     - backports.zoneinfo ==0.2.1
-    - bcrypt ==4.1.2
+    - bcrypt ==4.2.1
     - beautifulsoup4 ==4.12.3
-    - black ==24.2.0
-    - bleach ==6.1.0
-    - blinker ==1.7.0
-    - blosc ==1.21.5
-    - bokeh ==3.3.4
-    - boltons ==23.1.1
+    - black ==24.10.0
+    - bleach ==6.2.0
+    - blinker ==1.9.0
+    - blosc ==1.21.6
+    - bokeh ==3.6.2
+    - boltons ==24.0.0
+    - botocore ==1.35.88
+    - bottleneck ==1.4.2
+    - bqplot ==0.12.43
     - brotli ==1.1.0
     - brotli-bin ==1.1.0
     - brotli-python ==1.1.0
     - bzip2 ==1.0.8
-    - c-ares ==1.27.0  # [linux or osx]
-    - c-blosc2 ==2.13.2  # [not arm64]
-    - c-blosc2 ==2.12.0  # [arm64]
-    - ca-certificates ==2024.2.2
+    - c-ares ==1.34.4
+    - c-blosc2 ==2.15.2
+    - ca-certificates ==2024.12.14
     - cached-property ==1.5.2
     - cached_property ==1.5.2
-    - cairo ==1.18.0  # [linux]
-    - cctools ==973.0.1  # [osx]
-    - cctools_osx-64 ==973.0.1  # [osx]
-    - certifi ==2024.2.2
-    - cffi ==1.16.0
+    - cairo ==1.18.2  # [linux]
+    - cctools ==1010.6  # [osx]
+    - cctools_osx-64 ==1010.6  # [osx-64]
+    - cctools_osx-arm64 ==1010.6  # [arm64]
+    - certifi ==2024.12.14
+    - cffi ==1.17.1
     - chardet ==5.2.0
-    - charset-normalizer ==3.3.2
-    - click ==8.1.7
-    - cloudpickle ==3.0.0  # [win]
+    - charset-normalizer ==3.4.0
+    - click ==8.1.8
+    - cloudpickle ==3.1.0
     - colorama ==0.4.6
-    - comm ==0.2.1
+    - comm ==0.2.2
     - commonmark ==0.9.1
-    - conda ==23.11.0
-    - conda-build ==24.1.2
-    - conda-index ==0.4.0
-    - conda-libmamba-solver ==24.1.0
-    - conda-package-handling ==2.2.0
-    - conda-package-streaming ==0.9.0
-    - configobj ==5.0.8
-    - contourpy ==1.2.0
-    - coverage ==7.4.3
-    - cryptography ==42.0.5
+    - conda ==24.11.2
+    - conda-build ==24.11.2
+    - conda-index ==0.5.0
+    - conda-libmamba-solver ==24.11.1
+    - conda-package-handling ==2.4.0
+    - conda-package-streaming ==0.11.0
+    - configobj ==5.0.9
+    - contourpy ==1.3.1
+    - coverage ==7.6.10
+    - cpp-expected ==1.1.0
+    - cpython ==3.12.8  # [win]
+    - cryptography ==44.0.0
     - cycler ==0.12.1
-    - cython ==3.0.8
+    - cyrus-sasl ==2.1.27  # [linux or arm64]
+    - cython ==3.0.11
+    - dask-core ==2024.12.1
     - dbus ==1.13.6  # [linux]
-    - debugpy ==1.8.1
+    - debugpy ==1.8.11
     - decorator ==5.1.1
     - defusedxml ==0.7.1
-    - dill ==0.3.8
+    - dill ==0.3.9
     - distro ==1.9.0
     - django ==3.1.7
-    - docutils ==0.20.1
+    - docutils ==0.21.2
     - docxtpl ==0.11.5
+    - double-conversion ==3.3.0  # [linux]
     - entrypoints ==0.4
-    - et_xmlfile ==1.1.0
-    - exceptiongroup ==1.2.0
-    - executing ==2.0.1
-    - expat ==2.6.2
-    - filelock ==3.13.1
-    - flake8 ==7.0.0
-    - fmt ==10.2.1
+    - et_xmlfile ==2.0.0
+    - exceptiongroup ==1.2.2
+    - executing ==2.1.0
+    - expat ==2.6.4  # [linux]
+    - filelock ==3.16.1
+    - flake8 ==7.1.1
+    - fmt ==11.0.2
     - font-ttf-dejavu-sans-mono ==2.37  # [linux]
     - font-ttf-inconsolata ==3.000  # [linux]
     - font-ttf-source-code-pro ==2.038  # [linux]
     - font-ttf-ubuntu ==0.83  # [linux]
-    - fontconfig ==2.14.2  # [linux]
+    - fontconfig ==2.15.0  # [linux]
     - fonts-conda-ecosystem ==1  # [linux]
     - fonts-conda-forge ==1  # [linux]
-    - fonttools ==4.49.0  # [not arm64]
-    - fonttools ==4.51.0  # [arm64]
+    - fonttools ==4.55.3
     - fqdn ==1.5.1
     - freetype ==2.12.1
+    - frozendict ==2.4.6
+    - frozenlist ==1.5.0
+    - fsspec ==2024.12.0
     - future ==1.0.0
-    - gettext ==0.21.1
-    - giflib ==5.2.1  # [linux or osx]
-    - git ==2.44.0  # [win]
+    - gast ==0.4.0
+    - gettext ==0.22.5  # [linux]
+    - gettext-tools ==0.22.5  # [linux]
+    - gflags ==2.2.2  # [linux or osx]
+    - giflib ==5.2.2  # [linux or osx]
+    - git ==2.47.1  # [win]
     - gitdb ==4.0.11
-    - gitpython ==3.1.42
-    - glib ==2.78.4
-    - glib-tools ==2.78.4
+    - gitpython ==3.1.43
+    - glib ==2.82.2
+    - glib-tools ==2.82.2
+    - glog ==0.7.1  # [linux or osx]
     - graphite2 ==1.3.13  # [linux]
-    - greenlet ==3.0.3  # [win]
-    - gst-plugins-base ==1.22.9
-    - gstreamer ==1.22.9
+    - greenlet ==3.1.1
+    - gst-plugins-base ==1.24.7
+    - gstreamer ==1.24.7
     - h11 ==0.14.0
     - h2 ==4.1.0
-    - h5py ==3.10.0
-    - harfbuzz ==8.3.0  # [linux]
-    - hdf5 ==1.14.3
+    - h5py ==3.12.1
+    - harfbuzz ==9.0.0  # [linux]
+    - hdf5 ==1.14.4
     - hpack ==4.0.0
     - html5lib ==1.1
-    - httpcore ==1.0.4
-    - httpx ==0.27.0
+    - httpcore ==1.0.7
+    - httpx ==0.28.1
     - hyperframe ==6.0.1
-    - icu ==73.2
-    - idna ==3.6
+    - icu ==75.1
+    - idna ==3.10
     - imagesize ==1.4.1
-    - importlib-metadata ==7.0.1
-    - importlib_metadata ==7.0.1
-    - importlib_resources ==6.1.2
+    - importlib-metadata ==8.5.0
+    - importlib_resources ==6.4.5
     - iniconfig ==2.0.0
-    - intel-openmp ==2024.0.0  # [win]
-    - ipykernel ==6.29.3
-    - ipympl ==0.9.3
-    - ipyparallel ==8.6.1
-    - ipython ==8.29.0
+    - ipydatagrid ==1.4.0
+    - ipykernel ==6.29.5
+    - ipympl ==0.9.5
+    - ipyparallel ==9.0.0
+    - ipython ==8.31.0
     - ipython_genutils ==0.2.0
-    - ipywidgets ==8.1.2
+    - ipywidgets ==8.1.5
     - isoduration ==20.11.0
     - isort ==5.13.2
-    - jaraco.classes ==3.3.1
-    - jedi ==0.19.1
+    - jaraco.classes ==3.4.0
+    - jaraco.context ==6.0.1
+    - jaraco.functools ==4.1.0
+    - jedi ==0.19.2
     - jeepney ==0.8.0  # [linux]
-    - jinja2 ==3.1.3
-    - jira ==3.6.0
-    - joblib ==1.3.2
+    - jinja2 ==3.1.5
+    - jira ==3.8.0
+    - jira-base ==3.8.0
+    - jira-with-cli ==3.8.0
+    - jmespath ==1.0.1
+    - joblib ==1.4.2
     - jplephem ==2.21
-    - json5 ==0.9.17
+    - json5 ==0.10.0
     - jsonpatch ==1.33
-    - jsonpointer ==2.4
-    - jsonschema ==4.21.1
-    - jsonschema-specifications ==2023.12.1
-    - jsonschema-with-format-nongpl ==4.21.1
-    - jupyter ==1.0.0
-    - jupyter-lsp ==2.2.3
+    - jsonpointer ==3.0.0
+    - jsonschema ==4.23.0
+    - jsonschema-specifications ==2024.10.1
+    - jsonschema-with-format-nongpl ==4.23.0
+    - jupyter ==1.1.1
+    - jupyter-lsp ==2.2.5
     - jupyter_client ==7.4.9
     - jupyter_console ==6.6.3
-    - jupyter_core ==5.7.1
-    - jupyter_events ==0.9.0
-    - jupyter_server ==2.12.5
-    - jupyter_server_terminals ==0.5.2
-    - jupyterlab ==4.1.2
+    - jupyter_core ==5.7.2
+    - jupyter_events ==0.11.0
+    - jupyter_server ==2.15.0
+    - jupyter_server_terminals ==0.5.3
+    - jupyterlab ==4.3.4
     - jupyterlab_pygments ==0.3.0
-    - jupyterlab_server ==2.25.3
-    - jupyterlab_widgets ==3.0.10
+    - jupyterlab_server ==2.27.3
+    - jupyterlab_widgets ==3.0.13
     - kaleido-core ==0.2.1
-    - keyring ==24.3.1
+    - keyring ==25.6.0
     - keyutils ==1.6.1  # [linux]
-    - kiwisolver ==1.4.5
-    - krb5 ==1.21.2
+    - kiwisolver ==1.4.7
+    - krb5 ==1.21.3
     - lame ==3.100  # [linux]
-    - lcms2 ==2.15  # [win]
-    - lcms2 ==2.16  # [linux or osx]
-    - ld64 ==609  # [osx]
-    - ld64_osx-64 ==609  # [osx]
-    - ld_impl_linux-64 ==2.40  # [linux]
+    - lcms2 ==2.16
+    - ld64 ==951.9  # [osx]
+    - ld64_osx-64 ==951.9  # [osx-64]
+    - ld64_osx-arm64 ==951.9  # [arm64]
+    - ld_impl_linux-64 ==2.43  # [linux]
     - lerc ==4.0.0
-    - libaec ==1.1.2
-    - libarchive ==3.7.2
+    - libabseil ==20240722.0
+    - libaec ==1.1.3
+    - libarchive ==3.7.7
+    - libarrow ==18.1.0
+    - libarrow-acero ==18.1.0
+    - libarrow-dataset ==18.1.0
+    - libarrow-substrait ==18.1.0
+    - libasprintf ==0.22.5  # [linux]
+    - libasprintf-devel ==0.22.5  # [linux]
     - libblas ==3.9.0
     - libbrotlicommon ==1.1.0
     - libbrotlidec ==1.1.0
     - libbrotlienc ==1.1.0
-    - libcap ==2.69  # [linux]
+    - libcap ==2.71  # [linux]
     - libcblas ==3.9.0
-    - libclang ==15.0.7
-    - libclang13 ==15.0.7
+    - libclang-cpp15 ==15.0.7  # [linux or osx]
+    - libclang-cpp17 ==17.0.6  # [arm64]
+    - libclang-cpp19.1 ==19.1.6  # [linux]
+    - libclang13 ==19.1.6
+    - libcrc32c ==1.1.2
     - libcups ==2.3.3  # [linux]
-    - libcurl ==8.8.0
-    - libcxx ==17.0.6 # [osx]
-    - libdeflate ==1.18  # [win]
-    - libdeflate ==1.19  # [linux or osx]
+    - libcurl ==8.11.1
+    - libcxx ==19.1.6  # [osx]
+    - libdeflate ==1.23
+    - libdrm ==2.4.124  # [linux]
     - libedit ==3.1.20191231  # [linux or osx]
+    - libegl ==1.7.0  # [linux]
     - libev ==4.33  # [linux or osx]
-    - libevent ==2.1.12  # [linux]
-    - libexpat ==2.6.2
+    - libevent ==2.1.12
+    - libexpat ==2.6.4
     - libffi ==3.4.2
     - libflac ==1.4.3  # [linux]
-    - libgcc ==14.1.0  # [linux]
-    - libgcc-ng ==14.1.0  # [linux]
-    - libgcrypt ==1.10.3  # [linux]
+    - libgcc ==14.2.0  # [linux or win]
+    - libgcc-ng ==14.2.0  # [linux]
+    - libgcrypt-lib ==1.11.0  # [linux]
+    - libgettextpo ==0.22.5  # [linux]
+    - libgettextpo-devel ==0.22.5  # [linux]
+    - libgfortran ==14.2.0  # [linux]
     - libgfortran ==5.0.0  # [osx]
-    - libgfortran ==14.1.0  # [linux]
-    - libgfortran-ng ==14.1.0  # [linux]
-    - libgfortran5 ==14.1.0  # [linux]
     - libgfortran5 ==13.2.0  # [osx]
-    - libglib ==2.78.4
-    - libgpg-error ==1.48  # [linux]
-    - libhwloc ==2.9.3
+    - libgfortran5 ==14.2.0  # [linux]
+    - libgl ==1.7.0  # [linux]
+    - libglib ==2.82.2
+    - libglvnd ==1.7.0  # [linux]
+    - libglx ==1.7.0  # [linux]
+    - libgomp ==14.2.0  # [linux or win]
+    - libgoogle-cloud ==2.33.0
+    - libgoogle-cloud-storage ==2.33.0
+    - libgpg-error ==1.51  # [linux]
+    - libgrpc ==1.67.1
     - libiconv ==1.17
-    - libjpeg-turbo ==2.1.5.1  # [win]
-    - libjpeg-turbo ==3.0.0  # [linux or osx]
+    - libintl ==0.22.5  # [osx or win]
+    - libintl-devel ==0.22.5  # [osx or win]
+    - libjpeg-turbo ==3.0.0
     - liblapack ==3.9.0
-    - liblief ==0.12.3
+    - liblief ==0.14.1
     - libllvm14 ==14.0.6  # [linux or osx]
     - libllvm15 ==15.0.7  # [linux or osx]
-    - libllvm16 ==16.0.6  # [osx]
-    - libmamba ==1.5.6
-    - libmambapy ==1.5.6
-    - libnghttp2 ==1.58.0  # [linux or osx]
+    - libllvm17 ==17.0.6  # [arm64]
+    - libllvm19 ==19.1.6  # [linux or osx]
+    - liblzma ==5.6.3
+    - libmamba ==2.0.5
+    - libmambapy ==2.0.5
+    - libnghttp2 ==1.64.0  # [linux or osx]
     - libnsl ==2.0.1  # [linux]
-    - libopenblas ==0.3.27  # [osx]
-    - libogg ==1.3.4
+    - libntlm ==1.8  # [linux or arm64]
+    - libogg ==1.3.5
+    - libopenblas ==0.3.28
+    - libopengl ==1.7.0  # [linux]
     - libopus ==1.3.1  # [linux or osx]
-    - libpng ==1.6.43
-    - libpq ==16.2  # [linux or osx]
+    - libparquet ==18.1.0
+    - libpciaccess ==0.18  # [linux]
+    - libpng ==1.6.44
+    - libpq ==16.6  # [linux or osx]
+    - libprotobuf ==5.28.3
+    - libre2-11 ==2024.07.02
     - libsndfile ==1.2.2  # [linux]
-    - libsodium ==1.0.18
-    - libsolv ==0.7.28
-    - libsqlite ==3.45.1
-    - libssh2 ==1.11.0
-    - libstdcxx-ng ==13.2.0  # [linux]
-    - libsystemd0 ==255  # [linux]
-    - libtiff ==4.5.1  # [win]
-    - libtiff ==4.6.0  # [linux or osx]
+    - libsodium ==1.0.20
+    - libsolv ==0.7.30
+    - libsqlite ==3.47.2
+    - libssh2 ==1.11.1
+    - libstdcxx ==14.2.0  # [linux]
+    - libstdcxx-ng ==14.2.0  # [linux]
+    - libsystemd0 ==256.9  # [linux]
+    - libthrift ==0.21.0
+    - libtiff ==4.7.0
+    - libutf8proc ==2.9.0
     - libuuid ==2.38.1  # [linux]
-    - libuv ==1.46.0  # [linux or osx]
+    - libuv ==1.49.2  # [linux or osx]
     - libvorbis ==1.3.7
-    - libwebp ==1.3.2
-    - libwebp-base ==1.3.2
-    - libxcb ==1.13  # [win]
-    - libxcb ==1.15  # [linux or osx]
+    - libwebp ==1.5.0
+    - libwebp-base ==1.5.0
+    - libwinpthread ==12.0.0.r4.gg4f2fc60ca  # [win]
+    - libxcb ==1.17.0
     - libxcrypt ==4.4.36  # [linux]
-    - libxkbcommon ==1.6.0  # [linux]
-    - libxml2 ==2.12.5
+    - libxkbcommon ==1.7.0  # [linux]
+    - libxml2 ==2.13.5
     - libxslt ==1.1.39
-    - libzlib ==1.2.13
-    - line_profiler ==4.1.1
-    - llvm-openmp ==17.0.6  # [linux or osx]
-    - llvmlite ==0.42.0
-    - lxml ==5.1.0
-    - lz4-c ==1.9.4
+    - libzlib ==1.3.1
+    - line_profiler ==4.1.3
+    - llvm-openmp ==19.1.6  # [osx]
+    - llvm-tools ==19.1.6  # [osx]
+    - llvm-tools-19 ==19.1.6  # [osx]
+    - llvmlite ==0.43.0
+    - locket ==1.0.0
+    - lxml ==5.3.0
+    - lz4-c ==1.10.0
     - lzo ==2.10
     - m2-conda-epoch ==20230914  # [win]
+    - m2-msys2-runtime ==3.4.9.1  # [win]
     - m2-patch ==2.7.6.2  # [win]
-    - mamba ==1.5.6
-    - markupsafe ==2.1.5
+    - mamba ==2.0.5
+    - markupsafe ==3.0.2
     - mathjax ==2.7.7
-    - matplotlib ==3.8.3
-    - matplotlib-base ==3.8.3
-    - matplotlib-inline ==0.1.6
+    - matplotlib ==3.10.0  # [osx]
+    - matplotlib ==3.9.1  # [linux or win]
+    - matplotlib-base ==3.10.0  # [osx]
+    - matplotlib-base ==3.9.1  # [linux or win]
+    - matplotlib-inline ==0.1.7
     - mccabe ==0.7.0
-    - menuinst ==2.0.2
+    - menuinst ==2.2.0
     - mistune ==3.0.2
-    - mkl ==2022.1.0  # [win]
-    - mkl ==2022.2.1  # [linux]
-    - more-itertools ==10.2.0
-    - mpg123 ==1.32.4  # [linux]
+    - more-itertools ==10.5.0
+    - mpg123 ==1.32.9  # [linux]
     - mpld3 ==0.5.10
+    - mpmath ==1.3.0
+    - multidict ==6.1.0
     - munkres ==1.1.4
     - mypy_extensions ==1.0.0
-    - mysql-common ==8.0.33  # [linux or osx]
-    - mysql-libs ==8.0.33  # [linux or osx]
+    - mysql-common ==9.0.1  # [linux or osx]
+    - mysql-libs ==9.0.1  # [linux or osx]
     - nb_conda ==2.2.1
-    - nb_conda_kernels ==2.3.1
-    - nbclassic ==1.0.0
-    - nbclient ==0.8.0
-    - nbconvert ==7.16.1
-    - nbconvert-core ==7.16.1
-    - nbconvert-pandoc ==7.16.1
-    - nbformat ==5.9.2
-    - nbsphinx ==0.9.3
-    - ncurses ==6.4  # [linux or osx]
+    - nb_conda_kernels ==2.5.1
+    - nbclassic ==1.1.0
+    - nbclient ==0.10.2
+    - nbconvert ==7.16.4
+    - nbconvert-core ==7.16.4
+    - nbconvert-pandoc ==7.16.4
+    - nbformat ==5.10.4
+    - nbsphinx ==0.9.6
+    - ncurses ==6.5  # [linux or osx]
     - nest-asyncio ==1.6.0
-    - networkx ==3.2.1
-    - nodejs ==20.9.0
+    - networkx ==3.4.2
+    - nlohmann_json ==3.11.3
+    - nodejs ==22.12.0
+    - nomkl ==1.0  # [linux or win]
     - nose ==1.3.7
-    - notebook ==6.5.6
+    - notebook ==6.5.7
     - notebook-shim ==0.2.4
-    - nspr ==4.35  # [linux or osx]
-    - nss ==3.98  # [linux or osx]
-    - numba ==0.59.0
-    - numexpr ==2.8.4
+    - nspr ==4.36  # [linux or osx]
+    - nss ==3.107  # [linux or osx]
+    - numba ==0.60.0
+    - numexpr ==2.10.2
     - numpy ==1.26.4
-    - numpydoc ==1.6.0
+    - numpydoc ==1.8.0
     - oauthlib ==3.2.2
-    - openjpeg ==2.5.0  # [win]
-    - openjpeg ==2.5.1  # [linux or osx]
-    - openpyxl ==3.1.2
-    - openssl ==3.3.1
+    - openjpeg ==2.5.3
+    - openldap ==2.6.9  # [linux or arm64]
+    - openpyxl ==3.1.5
+    - openssl ==3.4.0
+    - orc ==2.0.3
     - overrides ==7.7.0
-    - packaging ==23.2
-    - pandas ==2.2.1
-    - pandoc ==3.1.12.1
+    - packaging ==24.2
+    - pandas ==2.2.3
+    - pandoc ==3.6.1
     - pandocfilters ==1.5.0
-    - paramiko ==3.4.0
-    - parso ==0.8.3
+    - paramiko ==3.5.0
+    - parso ==0.8.4
+    - partd ==1.4.2
     - patch ==2.7.6  # [linux or osx]
     - patchelf ==0.17.2  # [linux]
     - pathspec ==0.12.1
-    - pcre2 ==10.42
+    - pcre2 ==10.44
     - pexpect ==4.9.0
     - pickleshare ==0.7.5
-    - pillow ==10.2.0  # [linux or osx]
-    - pillow ==9.5.0  # [win]
-    - pip ==24.0
-    - pixman ==0.43.2  # [linux]
-    - pkginfo ==1.9.6
+    - pillow ==11.0.0
+    - pip ==24.3.1
+    - pixman ==0.44.2  # [linux]
+    - pkginfo ==1.12.0
     - pkgutil-resolve-name ==1.3.10
-    - platformdirs ==4.2.0
-    - plotly ==5.19.0
-    - pluggy ==1.4.0
+    - platformdirs ==4.3.6
+    - plotly ==5.24.1
+    - pluggy ==1.5.0
     - ply ==3.11
-    - prometheus_client ==0.20.0
-    - prompt-toolkit ==3.0.42
-    - prompt_toolkit ==3.0.42
-    - psutil ==5.9.8
-    - pthread-stubs ==0.4  # [linux or osx]
-    - pthreads-win32 ==2.9.1  # [win]
+    - prometheus_client ==0.21.1
+    - prompt-toolkit ==3.0.48
+    - prompt_toolkit ==3.0.48
+    - propcache ==0.2.1
+    - psutil ==6.1.1
+    - pthread-stubs ==0.4
     - ptyprocess ==0.7.0
-    - pulseaudio-client ==16.1  # [linux]
-    - pure_eval ==0.2.2
+    - pulseaudio-client ==17.0  # [linux]
+    - pure_eval ==0.2.3
     - py-cpuinfo ==9.0.0
-    - py-lief ==0.12.3
+    - py-lief ==0.14.1
+    - py2vega ==0.6.1
+    - pyarrow ==18.1.0
+    - pyarrow-core ==18.1.0
     - pybind11-abi ==4
-    - pycodestyle ==2.11.1
+    - pycodestyle ==2.12.1
     - pycosat ==0.6.6
-    - pycparser ==2.21
-    - pyerfa ==2.0.1.1
+    - pycparser ==2.22
+    - pyerfa ==2.0.1.5
     - pyflakes ==3.2.0
-    - pygments ==2.17.2
-    - pyjwt ==2.8.0
-    - pylint ==3.1.0
+    - pygments ==2.18.0
+    - pyjwt ==2.10.1
+    - pylint ==3.3.3
     - pynacl ==1.5.0
-    - pyobjc-core ==10.1  # [osx]
-    - pyobjc-framework-cocoa ==10.1  # [osx]
-    - pyparsing ==3.1.1
+    - pyobjc-core ==10.3.2  # [osx]
+    - pyobjc-framework-cocoa ==10.3.2  # [osx]
+    - pyparsing ==3.2.1
     - pyqt ==5.15.9
     - pyqt5-sip ==12.12.2
-    - pyqtgraph ==0.13.3
+    - pyqtgraph ==0.13.7
     - pysocks ==1.7.1
-    - pytables ==3.8.0
-    - pytest ==7.4.4
-    - pytest-timeout ==2.2.0
-    - python ==3.11.8
-    - python-dateutil ==2.8.2
-    - python-docx ==1.1.0
-    - python-fastjsonschema ==2.19.1
+    - pytables ==3.10.1
+    - pytest ==8.3.4
+    - pytest-timeout ==2.3.1
+    - python ==3.12.8
+    - python-dateutil ==2.9.0.post0
+    - python-docx ==1.1.2
+    - python-fastjsonschema ==2.21.1
     - python-json-logger ==2.0.7
     - python-kaleido ==0.2.1
-    - python-libarchive-c ==5.0
-    - python-tzdata ==2024.1
-    - python_abi ==3.11
+    - python-libarchive-c ==5.1
+    - python-tzdata ==2024.2
+    - python_abi ==3.12
     - pytoolconfig ==1.2.5
     - pytz ==2024.1
-    - pyvo ==1.5.1
-    - pywin32 ==306  # [win]
-    - pywin32-ctypes ==0.2.2  # [win]
-    - pywinpty ==2.0.13  # [win]
-    - pyyaml ==6.0.1
-    - pyzmq ==24.0.1
+    - pyvo ==1.6
+    - pywin32 ==307  # [win]
+    - pywin32-ctypes ==0.2.3  # [win]
+    - pywinpty ==2.0.14  # [win]
+    - pyyaml ==6.0.2
+    - pyzmq ==26.2.0
+    - qhull ==2020.2
     - qt ==5.15.8
     - qt-main ==5.15.8
     - qt-webengine ==5.15.8
-    - qtconsole ==5.5.1
-    - qtconsole-base ==5.5.1
-    - qtpy ==2.4.1
+    - qtconsole ==5.6.1
+    - qtconsole-base ==5.6.1
+    - qtpy ==2.4.2
+    - re2 ==2024.07.02
     - readline ==8.2  # [linux or osx]
-    - referencing ==0.33.0
-    - regions ==0.8
-    - reproc ==14.2.4.post0
-    - reproc-cpp ==14.2.4.post0
-    - requests ==2.31.0
-    - requests-oauthlib ==1.3.1
+    - referencing ==0.35.1
+    - regions ==0.10
+    - reproc ==14.2.5.post0
+    - reproc-cpp ==14.2.5.post0
+    - requests ==2.32.3
+    - requests-oauthlib ==2.0.0
     - requests-toolbelt ==1.0.0
     - rfc3339-validator ==0.1.4
     - rfc3986-validator ==0.1.1
-    - ripgrep ==11.0.2  # [win]
-    - ripgrep ==14.1.0  # [linux or osx]
-    - rope ==1.12.0
-    - rpds-py ==0.18.0
+    - ripgrep ==14.1.1
+    - rope ==1.13.0
+    - rpds-py ==0.22.3
     - ruamel.yaml ==0.18.6
     - ruamel.yaml.clib ==0.2.8
-    - ruff ==0.2.2
-    - scikit-learn ==1.4.1.post1
+    - ruff ==0.8.5
+    - s2n ==1.5.10  # [linux]
+    - s3fs ==2024.12.0
+    - scikit-learn ==1.6.0
     - scipy ==1.14.1
     - secretstorage ==3.3.3  # [linux]
-    - send2trash ==1.8.2
-    - setuptools ==69.1.1
-    - setuptools-scm ==8.0.4
-    - setuptools_scm ==8.0.4
-    - sherpa ==4.15.1 # [not win and not arm64]
-    - sherpa ==4.16  # [osx and arm64]
+    - send2trash ==1.8.3
+    - setuptools ==75.6.0
+    - setuptools-scm ==8.1.0
+    - setuptools_scm ==8.1.0
+    - sherpa ==4.17.0  # [linux or osx]
     - sigtool ==0.1.3  # [osx]
-    - sip ==6.7.12
-    - six ==1.16.0
+    - simdjson ==3.11.3
+    - sip ==6.7.12  # [linux or osx-64 or win]
+    - sip ==6.8.6  # [arm64]
+    - six ==1.17.0
     - smmap ==5.0.0
-    - snappy ==1.1.10
+    - snappy ==1.2.1
     - sniffio ==1.3.1
     - snowballstemmer ==2.2.0
+    - sortedcontainers ==2.4.0
     - soupsieve ==2.5
-    - sphinx ==7.2.6
-    - sphinx-argparse ==0.4.0
-    - sphinxcontrib-applehelp ==1.0.8
-    - sphinxcontrib-devhelp ==1.0.6
-    - sphinxcontrib-htmlhelp ==2.0.5
+    - spdlog ==1.15.0
+    - sphinx ==8.1.3
+    - sphinx-argparse ==0.5.2
+    - sphinxcontrib-applehelp ==2.0.0
+    - sphinxcontrib-devhelp ==2.0.0
+    - sphinxcontrib-htmlhelp ==2.1.0
     - sphinxcontrib-jsmath ==1.0.1
-    - sphinxcontrib-qthelp ==1.0.7
+    - sphinxcontrib-qthelp ==2.0.0
     - sphinxcontrib-serializinghtml ==1.1.10
-    - sqlalchemy ==2.0.27  # [win]
-    - sqlite ==3.45.1
-    - sqlparse ==0.4.4
-    - stack_data ==0.6.2
+    - sqlalchemy ==2.0.36
+    - sqlite ==3.47.2
+    - sqlparse ==0.5.3
+    - stack_data ==0.6.3
     - tabulate ==0.9.0
-    - tapi ==1100.0.11  # [osx]
-    - tbb ==2021.11.0
-    - tenacity ==8.2.3
-    - terminado ==0.18.0
-    - threadpoolctl ==3.3.0
-    - tinycss2 ==1.2.1
+    - tapi ==1300.6.5  # [osx]
+    - tenacity ==9.0.0
+    - terminado ==0.18.1
+    - threadpoolctl ==3.5.0
+    - tinycss2 ==1.4.0
     - tk ==8.6.13
     - toml ==0.10.2
-    - tomli ==2.0.1
-    - tomlkit ==0.12.4
-    - tornado ==6.4
-    - tqdm ==4.66.2
-    - traitlets ==5.14.1
-    - truststore ==0.8.0
-    - types-python-dateutil ==2.8.19.20240106
-    - typing-extensions ==4.10.0
-    - typing_extensions ==4.10.0
+    - tomli ==2.2.1
+    - tomlkit ==0.13.2
+    - toolz ==1.0.0
+    - tornado ==6.4.2
+    - tqdm ==4.67.1
+    - traitlets ==5.14.3
+    - traittypes ==0.2.1
+    - truststore ==0.10.0
+    - types-python-dateutil ==2.9.0.20241206
+    - typing-extensions ==4.12.2
+    - typing_extensions ==4.12.2
     - typing_utils ==0.1.0
-    - tzdata ==2024a
+    - tzdata ==2024b
     - ucrt ==10.0.22621.0  # [win]
+    - unicodedata2 ==15.1.0
     - uri-template ==1.3.0
-    - urllib3 ==2.2.1
+    - urllib3 ==2.3.0
     - vc ==14.3  # [win]
-    - vc14_runtime ==14.38.33130  # [win]
-    - vs2015_runtime ==14.38.33130  # [win]
+    - vc14_runtime ==14.42.34433  # [win]
+    - vs2015_runtime ==14.42.34433  # [win]
+    - wayland ==1.23.1  # [linux]
     - wcwidth ==0.2.13
-    - webcolors ==1.13
+    - webcolors ==24.11.1
     - webencodings ==0.5.1
-    - websocket-client ==1.7.0
-    - wheel ==0.42.0
-    - widgetsnbextension ==4.0.10
+    - websocket-client ==1.8.0
+    - wheel ==0.45.1
+    - widgetsnbextension ==4.0.13
     - win_inet_pton ==1.1.0  # [win]
     - winpty ==0.4.3  # [win]
-    - xcb-util ==0.4.0  # [linux]
+    - wrapt ==1.17.0
+    - xcb-util ==0.4.1  # [linux]
+    - xcb-util-cursor ==0.1.5  # [linux]
     - xcb-util-image ==0.4.0  # [linux]
-    - xcb-util-keysyms ==0.4.0  # [linux]
-    - xcb-util-renderutil ==0.3.9  # [linux]
-    - xcb-util-wm ==0.4.1  # [linux]
-    - xkeyboard-config ==2.41  # [linux]
-    - xorg-compositeproto ==0.4.2  # [linux]
-    - xorg-damageproto ==1.2.1  # [linux]
-    - xorg-fixesproto ==5.0  # [linux]
-    - xorg-inputproto ==2.3.2  # [linux]
-    - xorg-kbproto ==1.0.7  # [linux]
-    - xorg-libice ==1.1.1  # [linux]
-    - xorg-libsm ==1.2.4  # [linux]
-    - xorg-libx11 ==1.8.9  # [linux]
-    - xorg-libxau ==1.0.11  # [linux or osx]
-    - xorg-libxau ==1.0.8  # [win]
+    - xcb-util-keysyms ==0.4.1  # [linux]
+    - xcb-util-renderutil ==0.3.10  # [linux]
+    - xcb-util-wm ==0.4.2  # [linux]
+    - xkeyboard-config ==2.43  # [linux]
+    - xorg-libice ==1.1.2  # [linux]
+    - xorg-libsm ==1.2.5  # [linux]
+    - xorg-libx11 ==1.8.10  # [linux]
+    - xorg-libxau ==1.0.12
     - xorg-libxcomposite ==0.4.6  # [linux]
-    - xorg-libxdamage ==1.1.5  # [linux]
-    - xorg-libxdmcp ==1.1.2  # [win]
-    - xorg-libxdmcp ==1.1.3  # [linux or osx]
-    - xorg-libxext ==1.3.4  # [linux]
-    - xorg-libxfixes ==5.0.3  # [linux]
-    - xorg-libxi ==1.7.10  # [linux]
-    - xorg-libxrandr ==1.5.2  # [linux]
-    - xorg-libxrender ==0.9.11  # [linux]
-    - xorg-libxtst ==1.2.3  # [linux]
-    - xorg-randrproto ==1.5.0  # [linux]
-    - xorg-recordproto ==1.14.2  # [linux]
-    - xorg-renderproto ==0.11.1  # [linux]
-    - xorg-util-macros ==1.19.3  # [linux]
-    - xorg-xextproto ==7.3.0  # [linux]
+    - xorg-libxcursor ==1.2.3  # [linux]
+    - xorg-libxdamage ==1.1.6  # [linux]
+    - xorg-libxdmcp ==1.1.5
+    - xorg-libxext ==1.3.6  # [linux]
+    - xorg-libxfixes ==6.0.1  # [linux]
+    - xorg-libxi ==1.8.2  # [linux]
+    - xorg-libxrandr ==1.5.4  # [linux]
+    - xorg-libxrender ==0.9.12  # [linux]
+    - xorg-libxtst ==1.2.5  # [linux]
+    - xorg-libxxf86vm ==1.1.6  # [linux]
     - xorg-xf86vidmodeproto ==2.3.1  # [linux]
-    - xorg-xproto ==7.0.31  # [linux]
-    - xyzservices ==2023.10.1
-    - xz ==5.2.6
+    - xyzservices ==2024.9.0
     - yaml ==0.2.5
     - yaml-cpp ==0.8.0
-    - zeromq ==4.3.4  # [win]
-    - zeromq ==4.3.5  # [linux or osx]
-    - zipp ==3.17.0
-    - zlib ==1.2.13  # [linux or osx]
-    - zlib-ng ==2.0.7
-    - zstandard ==0.19.0
+    - yarl ==1.18.3
+    - zeromq ==4.3.5
+    - zipp ==3.21.0
+    - zlib ==1.3.1  # [linux or osx]
+    - zlib-ng ==2.2.3
+    - zstandard ==0.23.0
     - zstd ==1.5.6

--- a/pkg_defs/ska3-flight-latest/meta.yaml
+++ b/pkg_defs/ska3-flight-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight-latest
-  version: 2024.11
+  version: 2025.0
 
 build:
   noarch: generic

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -14,19 +14,19 @@ requirements:
     - acispy ==2.7.0
     - agasc ==4.22.0
     - backstop_history ==3.2.1
-    - chandra_aca ==4.48.0
+    - chandra_aca ==4.48.1
     - chandra_limits ==0.10.0
     - chandra_maneuver ==4.3.0
     - chandra_time ==4.1.2
-    - cheta ==4.62.2
-    - cxotime ==3.9.1
+    - cheta ==4.62.3
+    - cxotime ==3.9.2
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
-    - kadi ==7.14.0
-    - maude ==3.12.0
-    - mica ==4.38.0
-    - parse_cm ==3.16.1
-    - proseco ==5.16.0
+    - kadi ==7.14.1
+    - maude ==3.12.1
+    - mica ==4.38.1
+    - parse_cm ==3.16.2
+    - proseco ==5.16.1
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -34,7 +34,7 @@ requirements:
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
-    - ska_dbi ==5.1.0
+    - ska_dbi ==5.1.1
     - ska_file ==4.0.0
     - ska_ftp ==4.0.1
     - ska_helpers ==0.17.0
@@ -47,7 +47,7 @@ requirements:
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - sparkles ==4.28.0
+    - sparkles ==4.28.1
     - starcheck ==14.12.0
-    - testr ==4.12.0
+    - testr ==4.13.0
     - xija ==4.32.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2024.12
+  version: 2025.0
 
 build:
   noarch: generic
@@ -30,6 +30,8 @@ requirements:
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
+    - ska3-core ==2025.0
+    - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
     - ska_dbi ==5.1.0
@@ -45,8 +47,6 @@ requirements:
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - ska3-core ==2024.11
-    - ska3-template ==2022.06.02
     - sparkles ==4.28.0
     - starcheck ==14.12.0
     - testr ==4.12.0

--- a/pkg_defs/ska3-perl-latest/meta.yaml
+++ b/pkg_defs/ska3-perl-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-perl-latest
-  version: 2024.7
+  version: 2025.0
 
 build:
   skip: True  # [win]
@@ -14,7 +14,9 @@ requirements:
     - xtime # [linux]
     - perl-extended-deps # [linux]
     - perl-pdl # [linux]
+    - perl-io-tty # [linux]
     - perl-astro-fits-cfitsio-simple # [linux]
+    - perl-astro-fits-cfitsio # [linux]
     - perl-chandra-time # [linux]
     - perl-cxc-sysarch # [linux]
     - perl-ska-convert # [linux]

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,6 +1,6 @@
 ---
 package:
-  name: ska3-core
+  name: ska3-perl
   version: 2025.0
 
 build:

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - perl-cxc-sysarch ==1.00  # [linux]
     - perl-dbd-sybase ==1.24  # [linux]
     - perl-extended-deps ==0.5.0  # [linux]
-    - perl-io-tty ==1.16  # [osx-64]
+    - perl-io-tty ==1.16  # [osx and not arm64]
     - perl-io-tty ==1.20  # [linux or arm64]
     - perl-pdl ==2.089  # [linux]
     - perl-ska-agasc ==3.5.0  # [linux]

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -44,7 +44,6 @@ requirements:
     - perl-ska-web ==4.0  # [linux]
     - perl-tk ==804.035  # [linux]
     - pkg-config ==0.29.2  # [linux or osx]
-    - ska3-perl ==2025.0  # [linux or osx]
     - sysroot_linux-64 ==2.17  # [linux]
     - task_schedule ==4.3.0  # [linux or osx]
     - tbb ==2021.13.0  # [linux]

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -1,46 +1,56 @@
 ---
 package:
-  name: ska3-perl
-  version: 2024.7
+  name: ska3-core
+  version: 2025.0
 
 build:
   skip: True  # [win]
-  number: 1
 
 requirements:
   run:
-    - _sysroot_linux-64_curr_repodata_hack ==3  # [linux]
-    - blas ==1.0  # [linux]
-    - cfitsio ==4.4.0  # [linux]
-    - expat ==2.6.2
+    - blas ==2.126  # [linux]
+    - blas-devel ==3.9.0  # [linux]
+    - cfitsio ==4.5.0  # [linux]
+    - expat ==2.6.4  # [osx]
     - gsl ==2.7  # [linux]
     - kernel-headers_linux-64 ==3.10.0  # [linux]
+    - libhwloc ==2.11.2  # [linux]
+    - liblapacke ==3.9.0  # [linux]
     - libx11-common-cos7-x86_64 ==1.6.7  # [linux]
     - libx11-cos7-x86_64 ==1.6.7  # [linux]
     - libx11-devel-cos7-x86_64 ==1.6.7  # [linux]
-    - mkl-service ==2.4.0  # [linux]
-    - mkl_fft ==1.3.1  # [linux]
-    - perl ==5.32.1
-    - perl-app-cpanminus ==1.7047
-    - perl-app-env-ascds =0.04=pl5321_1  # [linux]
-    - perl-astro-fits-cfitsio-simple ==0.20 # [linux]
-    - perl-chandra-time =0.9.2=pl5321h2bc3f7f_1  # [linux]
-    - perl-core-deps ==0.4.0
-    - perl-cxc-sysarch =1.00=pl5321_1  # [linux]
+    - llvm-openmp ==19.1.6  # [linux]
+    - mkl ==2024.2.2  # [linux]
+    - mkl-devel ==2024.2.2  # [linux]
+    - mkl-include ==2024.2.2  # [linux]
+    - mkl-service ==2.4.2  # [linux]
+    - mkl_fft ==1.3.11  # [linux]
+    - perl ==5.32.1  # [linux or osx]
+    - perl-app-cpanminus ==1.7048  # [linux or osx]
+    - perl-app-env-ascds ==0.04  # [linux]
+    - perl-astro-fits-cfitsio ==1.15  # [linux]
+    - perl-astro-fits-cfitsio-simple ==0.20  # [linux]
+    - perl-chandra-time ==0.9.2  # [linux]
+    - perl-core-deps ==0.5.0  # [linux or osx]
+    - perl-cxc-sysarch ==1.00  # [linux]
     - perl-dbd-sybase ==1.24  # [linux]
-    - perl-extended-deps ==0.4.0  # [linux]
-    - perl-io-tty ==1.16 # [osx and x86_64]
-    - perl-io-tty ==1.20 # [linux or arm64]
-    - perl-ska-agasc =3.5.0=pl5321_2# [linux]
-    - perl-ska-classic =0.6=pl5321_1
-    - perl-ska-convert =4.3=pl5321_2  # [linux]
-    - perl-ska-web =4.0=pl5321_1  # [linux]
-    - perl-tk =804.035=pl5321h3fd9d12_1 # [linux]
-    - pkg-config ==0.29.2
+    - perl-extended-deps ==0.5.0  # [linux]
+    - perl-io-tty ==1.16  # [osx-64]
+    - perl-io-tty ==1.20  # [linux or arm64]
+    - perl-pdl ==2.089  # [linux]
+    - perl-ska-agasc ==3.5.0  # [linux]
+    - perl-ska-classic ==0.6  # [linux or osx]
+    - perl-ska-convert ==4.3  # [linux]
+    - perl-ska-web ==4.0  # [linux]
+    - perl-tk ==804.035  # [linux]
+    - pkg-config ==0.29.2  # [linux or osx]
+    - ska3-perl ==2025.0  # [linux or osx]
     - sysroot_linux-64 ==2.17  # [linux]
-    - task_schedule ==4.3.0
-    - watch_cron_logs ==4.2.1
+    - task_schedule ==4.3.0  # [linux or osx]
+    - tbb ==2021.13.0  # [linux]
+    - watch_cron_logs ==4.2.1  # [linux]
+    - watch_cron_logs ==4.2.2  # [osx]
     - xorg-libxft ==2.3.8  # [linux]
-    - xorg-libx11 ==1.8.9  #[linux]
+    - xorg-xproto ==7.0.31  # [linux]
     - xtime ==1.2.2  # [linux]
-    - zip ==3.0
+    - zip ==3.0  # [linux or osx]


### PR DESCRIPTION
# ska3-flight 2025.0

This is a test PR. No final release will come from this.

## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.0/).

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2025.0rc2 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/twelve \
  ska3-flight==2025.0rc2
```

If this release includes an update to ska3-perl, the install process for Aspect will include that. Note: ska3-perl is generally not needed for non-Aspect users.

```
conda create -n ska3-flight-2025.0rc2 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/twelve \
  ska3-flight==2025.0rc2 ska3-perl==2025.0rc2
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2025.0 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

# Related Issues
