### PR TITLE
2025.2

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -361,7 +361,6 @@ requirements:
     - networkx ==3.4.2
     - nlohmann_json ==3.11.3
     - nodejs ==22.12.0
-    - nomkl ==1.0  # [win]
     - nose ==1.3.7
     - nodeenv ==1.9.1
     - notebook ==6.5.7

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -167,6 +167,7 @@ requirements:
     - importlib-metadata ==8.5.0
     - importlib_resources ==6.4.5
     - iniconfig ==2.0.0
+    - intel-openmp ==2024.2.1  # [win]
     - ipydatagrid ==1.4.0
     - ipykernel ==6.29.5
     - ipympl ==0.9.5
@@ -266,6 +267,7 @@ requirements:
     - libgoogle-cloud-storage ==2.33.0
     - libgpg-error ==1.51  # [linux]
     - libgrpc ==1.67.1
+    - libhwloc ==2.11.2  # [win]
     - libiconv ==1.17
     - libintl ==0.22.5  # [osx or win]
     - libintl-devel ==0.22.5  # [osx or win]
@@ -281,7 +283,7 @@ requirements:
     - libnghttp2 ==1.64.0  # [linux or osx]
     - libnsl ==2.0.1  # [linux]
     - libogg ==1.3.5
-    - libopenblas ==0.3.28  # [osx or win]
+    - libopenblas ==0.3.28  # [osx]
     - libopus ==1.3.1  # [linux or osx]
     - libparquet ==18.1.0
     - libpciaccess ==0.18  # [linux]
@@ -335,7 +337,7 @@ requirements:
     - mccabe ==0.7.0
     - menuinst ==2.2.0
     - mistune ==3.0.2
-    - mkl ==2024.2.2  # [linux]
+    - mkl ==2024.2.2  # [linux or win]
     - more-itertools ==10.5.0
     - mpg123 ==1.32.9  # [linux]
     - mpld3 ==0.5.10
@@ -508,6 +510,7 @@ requirements:
     - stack_data ==0.6.3
     - tabulate ==0.9.0
     - tapi ==1300.6.5  # [osx]
+    - tbb ==2021.13.0  # [win]
     - tenacity ==9.0.0
     - terminado ==0.18.1
     - threadpoolctl ==3.5.0

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2025.1
+  version: 2025.2
 
 requirements:
   run:

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,38 +1,40 @@
 ---
 package:
   name: ska3-matlab
-  version: "2024.10"
+  version: 2025.2
 
 build:
   noarch: generic
 
 requirements:
   run:
-    - aca_view ==0.14.2
+    - aca_view ==0.16.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==5.1.1
+    - acis_thermal_check ==5.2.0
     - acispy ==2.7.0
-    - agasc ==4.21.2
+    - agasc ==4.22.0
     - backstop_history ==3.2.1
-    - chandra_aca ==4.46.0
-    - chandra_limits ==0.9.2
+    - chandra_aca ==4.48.1
+    - chandra_limits ==0.10.0
     - chandra_maneuver ==4.3.0
     - chandra_time ==4.1.2
-    - cheta ==4.62.0
-    - cxotime ==3.8.0
+    - cheta ==4.62.3
+    - cxotime ==3.9.2
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
-    - kadi ==7.12.0
-    - maude ==3.11.1
-    - mica ==4.36.0
-    - parse_cm ==3.16.0
-    - proseco ==5.15.0
+    - kadi ==7.14.1
+    - maude ==3.12.1
+    - mica ==4.38.1
+    - parse_cm ==3.16.2
+    - proseco ==5.16.1
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
+    - ska3-core ==2025.2
+    - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
-    - ska_dbi ==5.1.0
+    - ska_dbi ==5.1.1
     - ska_file ==4.0.0
     - ska_ftp ==4.0.1
     - ska_helpers ==0.17.0
@@ -45,9 +47,7 @@ requirements:
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - ska3-core ==2024.10
-    - ska3-template ==2022.06.02
-    - sparkles ==4.27.0
+    - sparkles ==4.28.1
     - starcheck ==14.12.0
-    - testr ==4.12.0
+    - testr ==4.13.0
     - xija ==4.32.0


### PR DESCRIPTION
# ska3-matlab 2025.2

This PR includes:
- acisfp_check: Update to allow for HRC dependence in the ACIS FP model.
- chandra_aca: Add some routines to get background subtracted images (relevant only for ACA).
- maude: Add `get_last_backorbit_date` function  to return the last available backorbit (SSR-dump) data for a list of MSIDs. This is useful to avoid accidentally getting realtime data that may have gaps or corruptions.
- kadi: Support offset pitch for Safe mode and NSM events and improve Safe mode
- aca_view: improvements to handle real-time telemetry.

**pytables version increases in this PR. Issue #1295 confirmed OK by @jskrist **

## Notes

**On windows, most scripts as installed by conda-build will call python at the wrong location. This should not be an issue for matlab users, because matlab users do not use any of our executable scripts. Anyway, we changed our build to fix some scripts that might be used by some users, and if this becomes an issue there is always a workaround.**

The BLAS implementation used on Windows is changing from OpenBLAS to Intel's MKL in this release. This was motivated by some memory issues found during FOT testing. One specific issue was that just importing numpy was increasing pageable memory usage (from ~40MB to more than 1GB).

## Interface Impacts:

- chandra_aca:
  - dtype of return value in `get_aca_images` changed. 
  - `get_aca_images` now allows fetching data over time ranges larger than 3 hours
- maude: Adds a new function `get_last_backorbit_date`
- mica: columns in return value of `get_aca_images` are unmasked, except images.

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.2rc3-HEAD/).
- [Windows](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.2rc3-Windows/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2025.2rc3 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2025.2rc3
```

### Testing Notes

- The `cxotime` test appears to fail on Windows, but this is just a poor test that happens to fail in the VM when run as part of the suite. When run on its own, it passes. The reason is that the test sleeps for half a second and checks that difference. In the test VM, under some circumstances, that time difference is 0.07 seconds larger. We will change this test in a future release.
- There are two warnings (in mica and agasc tests). These are not an issue and will be fixed in future releases.

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2025.2 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-core changes (2024.11 -> 2025.2rc3)

## ska3-matlab changes (2024.10 -> 2025.2rc3)

### Updated Packages

- **aca_view:** 0.14.2 -> 0.16.0 (0.14.2 -> 0.15.0 -> 0.16.0)
  - [PR 184](https://github.com/sot/aca_view/pull/184) (Javier Gonzalez): Never make slot data stale
  - [PR 195](https://github.com/sot/aca_view/pull/195) (Javier Gonzalez): fix null-quat check
  - [PR 193](https://github.com/sot/aca_view/pull/193) (Javier Gonzalez): avoid null quaternion
  - [PR 189](https://github.com/sot/aca_view/pull/189) (Javier Gonzalez): Ruff
  - [PR 200](https://github.com/sot/aca_view/pull/200) (Javier Gonzalez): fix edge case of AcaTelemetryTraverser.set_time
  - [PR 203](https://github.com/sot/aca_view/pull/203) (Javier Gonzalez): Fix issue #202
  - [PR 201](https://github.com/sot/aca_view/pull/201) (Javier Gonzalez): fix crash in general info widget when one slot has no data
- **acis_thermal_check:** 5.1.1 -> 5.2.0 (5.1.1 -> 5.2.0)
  - [PR 75](https://github.com/acisops/acis_thermal_check/pull/75) (John ZuHone): Update acisfp_check to allow for HRC dependence in the ACIS FP model
- **agasc:** 4.21.2 -> 4.22.0 (4.21.2 -> 4.22.0)
  - [PR 195](https://github.com/sot/agasc/pull/195) (Jean Connelly): Update for public use.
  - [PR 193](https://github.com/sot/agasc/pull/193) (Javier Gonzalez): add add_pmcorr_columns to agasc.__all__
- **chandra_aca:** 4.46.0 -> 4.48.1 (4.46.0 -> 4.47.0 -> 4.48.0 -> 4.48.1)
  - [PR 180](https://github.com/sot/chandra_aca/pull/180) (Javier Gonzalez): Fix END_INTEG_TIME
  - [PR 184](https://github.com/sot/chandra_aca/pull/184) (Jean Connelly): Ruff
  - [PR 174](https://github.com/sot/chandra_aca/pull/174) (Jean Connelly): Add some routines to get background subtracted images
  - [PR 182](https://github.com/sot/chandra_aca/pull/182) (Tom Aldcroft): `get_aca_images()` returns MaskedColumns only for data with masked values (except IMG)
  - [PR 183](https://github.com/sot/chandra_aca/pull/183) (Tom Aldcroft): Migrate maude_decom to CxoTime
  - [PR 181](https://github.com/sot/chandra_aca/pull/181) (Jean Connelly): Use CxoTime.linspace on get_aca_images for > 3hour range
  - [PR 186](https://github.com/sot/chandra_aca/pull/186) (Javier Gonzalez): replace uses of pformat_all with pformat
- **chandra_limits:** 0.9.2 -> 0.10.0 (0.9.2 -> 0.10.0)
  - [PR 18](https://github.com/sot/chandra_limits/pull/18) (John ZuHone): Fix ACIS focal plane limit colors and labels
  - [PR 19](https://github.com/sot/chandra_limits/pull/19) (John ZuHone): Try to catch incorrect reads of the local copy of the obscat
- **cheta:** 4.62.0 -> 4.62.3 (4.62.0 -> 4.62.1 -> 4.62.2 -> 4.62.3)
  - [PR 264](https://github.com/sot/cheta/pull/264) (Tom Aldcroft): Update NOTES.fix_bad_ingest.rst
  - [PR 265](https://github.com/sot/cheta/pull/265) (Tom Aldcroft): Refresh regression testing and fix ruff / improve variable naming
  - [PR 266](https://github.com/sot/cheta/pull/266) (Javier Gonzalez): replace uses of pformat_all with pformat
- **cxotime:** 3.8.0 -> 3.9.2 (3.8.0 -> 3.9.0 -> 3.9.1 -> 3.9.2)
  - [PR 44](https://github.com/sot/cxotime/pull/44) (Jean Connelly): Add a linspace class method
  - [PR 47](https://github.com/sot/cxotime/pull/47) (Jean Connelly): Update linspace step_max docs
  - [PR 48](https://github.com/sot/cxotime/pull/48) (Javier Gonzalez): replace uses of pformat_all with pformat
- **kadi:** 7.12.0 -> 7.14.1 (7.12.0 -> 7.13.0 -> 7.14.0 -> 7.14.1)
  - [PR 341](https://github.com/sot/kadi/pull/341) (Javier Gonzalez): fix package data regex
  - [PR 334](https://github.com/sot/kadi/pull/334) (Tom Aldcroft): Support offset pitch for `Safe mode` and `NSM` events and improve `Safe mode`
  - [PR 339](https://github.com/sot/kadi/pull/339) (Tom Aldcroft): Improve validation: YAML data files and set KADI_COMMANDS_DEFAULT_STOP
  - [PR 342](https://github.com/sot/kadi/pull/342) (Tom Aldcroft): Modernize ruff
  - [PR 338](https://github.com/sot/kadi/pull/338) (Jean Connelly): Set min_violation_duration to 180s for pcad validation
  - [PR 340](https://github.com/sot/kadi/pull/340) (Tom Aldcroft): Improve command states with better transition infrastructure
  - [PR 346](https://github.com/sot/kadi/pull/346) (Javier Gonzalez): replace uses of pformat_all with pformat
  - [PR 345](https://github.com/sot/kadi/pull/345) (Tom Aldcroft): Limit testing of starcats each year to 2003-2024
- **maude:** 3.11.1 -> 3.12.1 (3.11.1 -> 3.12.0 -> 3.12.1)
  - [PR 46](https://github.com/sot/maude/pull/46) (Tom Aldcroft): Add get_last_backorbit_date function
  - [PR 48](https://github.com/sot/maude/pull/48) (Javier Gonzalez): replace uses of pformat_all with pformat
  - [PR 47](https://github.com/sot/maude/pull/47) (Tom Aldcroft): Ruff
- **mica:** 4.36.0 -> 4.38.1 (4.36.0 -> 4.37.0 -> 4.38.0 -> 4.38.1)
  - [PR 301](https://github.com/sot/mica/pull/301) (Jean Connelly): Add a get_aca_images method for mica l0
  - [PR 308](https://github.com/sot/mica/pull/308) (Jean Connelly): Open up regex on file name and glob to work with CP data
  - [PR 307](https://github.com/sot/mica/pull/307) (Jean Connelly): Fix truncated V&V html column
  - [PR 306](https://github.com/sot/mica/pull/306) (Jean Connelly): Add color1 to agasc fetch in centroid_dashboard
  - [PR 305](https://github.com/sot/mica/pull/305) (Jean Connelly): Handle omitted star missing from miniagasc 1p8 in V&V
  - [PR 304](https://github.com/sot/mica/pull/304) (Jean Connelly): Fix a processing error in acq and guide stats 
  - [PR 303](https://github.com/sot/mica/pull/303) (Jean Connelly): Fix V&V processing error with Sqsh
  - [PR 302](https://github.com/sot/mica/pull/302) (Jean Connelly): Remove aiprops report
  - [PR 311](https://github.com/sot/mica/pull/311) (Jean Connelly): Unmask aca image data columns (from get_aca_images) except for IMG
  - [PR 316](https://github.com/sot/mica/pull/316) (Javier Gonzalez): skip test_report.py::test_target_summary_or/er
  - [PR 314](https://github.com/sot/mica/pull/314) (Javier Gonzalez): replace uses of pformat_all with pformat
  - [PR 312](https://github.com/sot/mica/pull/312) (Jean Connelly): Change report target_summary method to return dict or None
- **parse_cm:** 3.16.0 -> 3.16.2 (3.16.0 -> 3.16.1 -> 3.16.2)
  - [PR 55](https://github.com/sot/parse_cm/pull/55) (Tom Aldcroft): Stop showing source code in public docs
  - [PR 56](https://github.com/sot/parse_cm/pull/56) (Javier Gonzalez): replace uses of pformat_all with pformat
- **proseco:** 5.15.0 -> 5.16.1 (5.15.0 -> 5.16.0 -> 5.16.1)
  - [PR 403](https://github.com/sot/proseco/pull/403) (Jean Connelly): Change dyn_bgd_n_faint default to 2 and fix faint force-include bug
  - [PR 404](https://github.com/sot/proseco/pull/404) (Javier Gonzalez): replace uses of pformat_all with pformat
- **ska3-core:** 2024.10 -> 2025.2
- **ska_dbi:** 5.1.0 -> 5.1.1 (5.1.0 -> 5.1.1)
  - [PR 27](https://github.com/sot/ska_dbi/pull/27) (Jean Connelly): Ruff
- **sparkles:** 4.27.0 -> 4.28.1 (4.27.0 -> 4.27.1 -> 4.28.0 -> 4.28.1)
  - [PR 213](https://github.com/sot/sparkles/pull/213) (Javier Gonzalez): set obsid report dir with a name consistent with proseco
  - [PR 219](https://github.com/sot/sparkles/pull/219) (Jean Connelly): Update dec98_9 roll tests with new guide counts
  - [PR 217](https://github.com/sot/sparkles/pull/217) (Jean Connelly): Ruff: noqa an instance of PLC0206 in a yoshi test
  - [PR 215](https://github.com/sot/sparkles/pull/215) (Jean Connelly): Apply dynamic background bonus to rolled "n_stars"
  - [PR 214](https://github.com/sot/sparkles/pull/214) (Jean Connelly): Update a few tests to use old dyn_bgd_n_faint=0 default
  - [PR 220](https://github.com/sot/sparkles/pull/220) (Tom Aldcroft): Fix roll optimize deepcopy issue and fix warning in tests
- **testr:** 4.12.0 -> 4.13.0 (4.12.0 -> 4.13.0)
  - [PR 52](https://github.com/sot/testr/pull/52) (Tom Aldcroft): Explicitly set pytest rootdir option for running tests

### New Packages

- **aiobotocore: 2.16.1**
- **aiohappyeyeballs: 2.4.4**
- **aiohttp: 3.11.11**
- **aioitertools: 0.12.0**
- **aiosignal: 1.3.2**
- **astropy-base: 7.0.0**
- **aws-c-auth: 0.8.0**
- **aws-c-cal: 0.8.1**
- **aws-c-common: 0.10.6**
- **aws-c-compression: 0.3.0**
- **aws-c-event-stream: 0.5.0**
- **aws-c-http: 0.9.2**
- **aws-c-io: 0.15.3**
- **aws-c-mqtt: 0.11.0**
- **aws-c-s3: 0.7.7**
- **aws-c-sdkutils: 0.2.1**
- **aws-checksums: 0.2.2**
- **aws-crt-cpp: 0.29.7**
- **aws-sdk-cpp: 1.11.458**
- **azure-core-cpp: 1.14.0**
- **azure-identity-cpp: 1.10.0**
- **azure-storage-blobs-cpp: 12.13.0**
- **azure-storage-common-cpp: 12.8.0**
- **azure-storage-files-datalake-cpp: 12.12.0**
- **backports.tarfile: 1.2.0**
- **botocore: 1.35.88**
- **bottleneck: 1.4.2**
- **bqplot: 0.12.43**
- **cfgv: 3.3.1**
- **cloudpickle: 3.1.0**
- **cpp-expected: 1.1.0**
- **dask-core: 2024.12.1**
- **distlib: 0.3.9**
- **frozendict: 2.4.6**
- **frozenlist: 1.5.0**
- **fsspec: 2024.12.0**
- **gast: 0.4.0**
- **gettext-tools: 0.22.5**
- **gflags: 2.2.2**
- **glog: 0.7.1**
- **greenlet: 3.1.1**
- **identify: 2.6.4**
- **ipydatagrid: 1.4.0**
- **jaraco.context: 6.0.1**
- **jaraco.functools: 4.1.0**
- **jira-base: 3.8.0**
- **jira-with-cli: 3.8.0**
- **jmespath: 1.0.1**
- **libabseil: 20240722.0**
- **libarrow: 18.1.0**
- **libarrow-acero: 18.1.0**
- **libarrow-dataset: 18.1.0**
- **libarrow-substrait: 18.1.0**
- **libasprintf: 0.22.5**
- **libasprintf-devel: 0.22.5**
- **libclang-cpp15: 15.0.7**
- **libcrc32c: 1.1.2**
- **libdrm: 2.4.124**
- **libegl: 1.7.0**
- **libgcrypt-lib: 1.11.0**
- **libgettextpo: 0.22.5**
- **libgettextpo-devel: 0.22.5**
- **libgl: 1.7.0**
- **libglvnd: 1.7.0**
- **libglx: 1.7.0**
- **libgoogle-cloud: 2.33.0**
- **libgoogle-cloud-storage: 2.33.0**
- **libgrpc: 1.67.1**
- **libllvm19: 19.1.6**
- **liblzma: 5.6.3**
- **libparquet: 18.1.0**
- **libpciaccess: 0.18**
- **libprotobuf: 5.28.3**
- **libre2-11: 2024.07.02**
- **libstdcxx: 14.2.0**
- **libthrift: 0.21.0**
- **libutf8proc: 2.9.0**
- **locket: 1.0.0**
- **mpmath: 1.3.0**
- **multidict: 6.1.0**
- **nlohmann_json: 3.11.3**
- **nodeenv: 1.9.1**
- **orc: 2.0.3**
- **partd: 1.4.2**
- **pre-commit: 4.0.1**
- **propcache: 0.2.1**
- **py2vega: 0.6.1**
- **pyarrow: 18.1.0**
- **pyarrow-core: 18.1.0**
- **pyqtwebengine: 5.15.9**
- **qhull: 2020.2**
- **re2: 2024.07.02**
- **s2n: 1.5.10**
- **s3fs: 2024.12.0**
- **simdjson: 3.11.3**
- **sortedcontainers: 2.4.0**
- **spdlog: 1.15.0**
- **sqlalchemy: 2.0.36**
- **toolz: 1.0.0**
- **traittypes: 0.2.1**
- **ukkonen: 1.0.1**
- **unicodedata2: 15.1.0**
- **virtualenv: 20.28.1**
- **wrapt: 1.17.0**
- **xorg-libxxf86vm: 1.1.6**
- **yarl: 1.18.3**

### Removed Packages

- **flake8**
- **importlib_metadata**
- **libclang**
- **libgcrypt**
- **libgfortran-ng**
- **libhwloc**
- **llvm-openmp**
- **pyflakes**
- **pylint**
- **ruff**
- **tbb**
- **xorg-compositeproto**
- **xorg-damageproto**
- **xorg-fixesproto**
- **xorg-inputproto**
- **xorg-kbproto**
- **xorg-randrproto**
- **xorg-recordproto**
- **xorg-renderproto**
- **xorg-util-macros**
- **xorg-xextproto**
- **xorg-xproto**
- **xz**

### Updated Packages

- **alabaster:** 0.7.16 -> 1.0.0
- **alsa-lib:** 1.2.10 -> 1.2.13
- **anyio:** 4.3.0 -> 4.7.0
- **astroid:** 3.1.0 -> 3.3.8
- **astropy:** 6.0.0 -> 7.0.0
- **astropy-healpix:** 1.0.2 -> 1.0.3
- **astropy-iers-data:** 0.2024.2.26.0.28.55 -> 0.2024.12.30.0.33.36
- **astroquery:** 0.4.6 -> 0.4.7
- **asttokens:** 2.4.1 -> 3.0.0
- **attrs:** 23.2.0 -> 24.3.0
- **autopep8:** 2.0.4 -> 2.3.1
- **babel:** 2.14.0 -> 2.16.0
- **bcrypt:** 4.1.2 -> 4.2.1
- **black:** 24.2.0 -> 24.10.0
- **bleach:** 6.1.0 -> 6.2.0
- **blinker:** 1.7.0 -> 1.9.0
- **blosc:** 1.21.5 -> 1.21.6
- **bokeh:** 3.3.4 -> 3.6.2
- **boltons:** 23.1.1 -> 24.0.0
- **c-ares:** 1.27.0 -> 1.34.4
- **c-blosc2:** 2.13.2 -> 2.15.2
- **ca-certificates:** 2024.2.2 -> 2024.12.14
- **cairo:** 1.18.0 -> 1.18.2
- **certifi:** 2024.2.2 -> 2024.12.14
- **cffi:** 1.16.0 -> 1.17.1
- **charset-normalizer:** 3.3.2 -> 3.4.0
- **click:** 8.1.7 -> 8.1.8
- **comm:** 0.2.1 -> 0.2.2
- **conda:** 23.11.0 -> 24.11.2
- **conda-build:** 24.1.2 -> 24.11.2
- **conda-index:** 0.4.0 -> 0.5.0
- **conda-libmamba-solver:** 24.1.0 -> 24.11.1
- **conda-package-handling:** 2.2.0 -> 2.4.0
- **conda-package-streaming:** 0.9.0 -> 0.11.0
- **configobj:** 5.0.8 -> 5.0.9
- **contourpy:** 1.2.0 -> 1.3.1
- **coverage:** 7.4.3 -> 7.6.10
- **cryptography:** 42.0.5 -> 44.0.0
- **cython:** 3.0.8 -> 3.0.11
- **debugpy:** 1.8.1 -> 1.8.11
- **dill:** 0.3.8 -> 0.3.9
- **docutils:** 0.20.1 -> 0.21.2
- **et_xmlfile:** 1.1.0 -> 2.0.0
- **exceptiongroup:** 1.2.0 -> 1.2.2
- **executing:** 2.0.1 -> 2.1.0
- **expat:** 2.6.2 -> 2.6.4
- **filelock:** 3.13.1 -> 3.16.1
- **fmt:** 10.2.1 -> 11.0.2
- **fontconfig:** 2.14.2 -> 2.15.0
- **fonttools:** 4.49.0 -> 4.55.3
- **gettext:** 0.21.1 -> 0.22.5
- **giflib:** 5.2.1 -> 5.2.2
- **gitpython:** 3.1.42 -> 3.1.43
- **glib:** 2.78.4 -> 2.82.2
- **glib-tools:** 2.78.4 -> 2.82.2
- **gst-plugins-base:** 1.22.9 -> 1.24.7
- **gstreamer:** 1.22.9 -> 1.24.7
- **h5py:** 3.10.0 -> 3.12.1
- **harfbuzz:** 8.3.0 -> 9.0.0
- **hdf5:** 1.14.3 -> 1.14.4
- **httpcore:** 1.0.4 -> 1.0.7
- **httpx:** 0.27.0 -> 0.28.1
- **icu:** 73.2 -> 75.1
- **idna:** 3.6 -> 3.10
- **importlib-metadata:** 7.0.1 -> 8.5.0
- **importlib_resources:** 6.1.2 -> 6.4.5
- **ipykernel:** 6.29.3 -> 6.29.5
- **ipympl:** 0.9.3 -> 0.9.5
- **ipyparallel:** 8.6.1 -> 9.0.0
- **ipython:** 8.29.0 -> 8.31.0
- **ipywidgets:** 8.1.2 -> 8.1.5
- **jaraco.classes:** 3.3.1 -> 3.4.0
- **jedi:** 0.19.1 -> 0.19.2
- **jinja2:** 3.1.3 -> 3.1.5
- **jira:** 3.6.0 -> 3.8.0
- **joblib:** 1.3.2 -> 1.4.2
- **json5:** 0.9.17 -> 0.10.0
- **jsonpointer:** 2.4 -> 3.0.0
- **jsonschema:** 4.21.1 -> 4.23.0
- **jsonschema-specifications:** 2023.12.1 -> 2024.10.1
- **jsonschema-with-format-nongpl:** 4.21.1 -> 4.23.0
- **jupyter:** 1.0.0 -> 1.1.1
- **jupyter-lsp:** 2.2.3 -> 2.2.5
- **jupyter_core:** 5.7.1 -> 5.7.2
- **jupyter_events:** 0.9.0 -> 0.11.0
- **jupyter_server:** 2.12.5 -> 2.15.0
- **jupyter_server_terminals:** 0.5.2 -> 0.5.3
- **jupyterlab:** 4.1.2 -> 4.3.4
- **jupyterlab_server:** 2.25.3 -> 2.27.3
- **jupyterlab_widgets:** 3.0.10 -> 3.0.13
- **keyring:** 24.3.1 -> 25.6.0
- **kiwisolver:** 1.4.5 -> 1.4.7
- **krb5:** 1.21.2 -> 1.21.3
- **ld_impl_linux-64:** 2.40 -> 2.43
- **libaec:** 1.1.2 -> 1.1.3
- **libarchive:** 3.7.2 -> 3.7.7
- **libcap:** 2.69 -> 2.71
- **libclang13:** 15.0.7 -> 19.1.6
- **libcurl:** 8.8.0 -> 8.11.1
- **libdeflate:** 1.19 -> 1.23
- **libexpat:** 2.6.2 -> 2.6.4
- **libgcc:** 14.1.0 -> 14.2.0
- **libgcc-ng:** 14.1.0 -> 14.2.0
- **libgfortran:** 14.1.0 -> 14.2.0
- **libgfortran5:** 14.1.0 -> 14.2.0
- **libglib:** 2.78.4 -> 2.82.2
- **libgpg-error:** 1.48 -> 1.51
- **liblief:** 0.12.3 -> 0.14.1
- **libmamba:** 1.5.6 -> 2.0.5
- **libmambapy:** 1.5.6 -> 2.0.5
- **libnghttp2:** 1.58.0 -> 1.64.0
- **libogg:** 1.3.4 -> 1.3.5
- **libpng:** 1.6.43 -> 1.6.44
- **libpq:** 16.2 -> 16.6
- **libsodium:** 1.0.18 -> 1.0.20
- **libsolv:** 0.7.28 -> 0.7.30
- **libsqlite:** 3.45.1 -> 3.47.2
- **libssh2:** 1.11.0 -> 1.11.1
- **libstdcxx-ng:** 13.2.0 -> 14.2.0
- **libsystemd0:** 255 -> 256.9
- **libtiff:** 4.6.0 -> 4.7.0
- **libuv:** 1.46.0 -> 1.49.2
- **libwebp:** 1.3.2 -> 1.5.0
- **libwebp-base:** 1.3.2 -> 1.5.0
- **libxcb:** 1.15 -> 1.17.0
- **libxkbcommon:** 1.6.0 -> 1.7.0
- **libxml2:** 2.12.5 -> 2.13.5
- **libzlib:** 1.2.13 -> 1.3.1
- **line_profiler:** 4.1.1 -> 4.1.3
- **lxml:** 5.1.0 -> 5.3.0
- **lz4-c:** 1.9.4 -> 1.10.0
- **mamba:** 1.5.6 -> 2.0.5
- **markupsafe:** 2.1.5 -> 3.0.2
- **matplotlib:** 3.8.3 -> 3.9.1
- **matplotlib-base:** 3.8.3 -> 3.9.1
- **matplotlib-inline:** 0.1.6 -> 0.1.7
- **menuinst:** 2.0.2 -> 2.2.0
- **mkl:** 2022.2.1 -> 2024.2.2
- **more-itertools:** 10.2.0 -> 10.5.0
- **mpg123:** 1.32.4 -> 1.32.9
- **mysql-common:** 8.0.33 -> 9.0.1
- **mysql-libs:** 8.0.33 -> 9.0.1
- **nb_conda_kernels:** 2.3.1 -> 2.5.1
- **nbclassic:** 1.0.0 -> 1.1.0
- **nbclient:** 0.8.0 -> 0.10.2
- **nbconvert:** 7.16.1 -> 7.16.4
- **nbconvert-core:** 7.16.1 -> 7.16.4
- **nbconvert-pandoc:** 7.16.1 -> 7.16.4
- **nbformat:** 5.9.2 -> 5.10.4
- **nbsphinx:** 0.9.3 -> 0.9.6
- **ncurses:** 6.4 -> 6.5
- **networkx:** 3.2.1 -> 3.4.2
- **nodejs:** 20.9.0 -> 22.12.0
- **notebook:** 6.5.6 -> 6.5.7
- **nspr:** 4.35 -> 4.36
- **nss:** 3.98 -> 3.107
- **numba:** 0.59.0 -> 0.59.1
- **numexpr:** 2.8.4 -> 2.10.2
- **numpydoc:** 1.6.0 -> 1.8.0
- **openjpeg:** 2.5.1 -> 2.5.3
- **openpyxl:** 3.1.2 -> 3.1.5
- **openssl:** 3.3.1 -> 3.4.0
- **packaging:** 23.2 -> 24.2
- **pandas:** 2.2.1 -> 2.2.3
- **pandoc:** 3.1.12.1 -> 3.6.1
- **paramiko:** 3.4.0 -> 3.5.0
- **parso:** 0.8.3 -> 0.8.4
- **pcre2:** 10.42 -> 10.44
- **pillow:** 10.2.0 -> 11.0.0
- **pip:** 24.0 -> 24.3.1
- **pixman:** 0.43.2 -> 0.44.2
- **pkginfo:** 1.9.6 -> 1.12.0
- **platformdirs:** 4.2.0 -> 4.3.6
- **plotly:** 5.19.0 -> 5.24.1
- **pluggy:** 1.4.0 -> 1.5.0
- **prometheus_client:** 0.20.0 -> 0.21.1
- **prompt-toolkit:** 3.0.42 -> 3.0.48
- **prompt_toolkit:** 3.0.42 -> 3.0.48
- **psutil:** 5.9.8 -> 6.1.1
- **pulseaudio-client:** 16.1 -> 17.0
- **pure_eval:** 0.2.2 -> 0.2.3
- **py-lief:** 0.12.3 -> 0.14.1
- **pycodestyle:** 2.11.1 -> 2.12.1
- **pycparser:** 2.21 -> 2.22
- **pyerfa:** 2.0.1.1 -> 2.0.1.5
- **pygments:** 2.17.2 -> 2.18.0
- **pyjwt:** 2.8.0 -> 2.10.1
- **pyparsing:** 3.1.1 -> 3.2.1
- **pyqtgraph:** 0.13.3 -> 0.13.7
- **pytables:** 3.8.0 -> 3.10.1
- **pytest:** 7.4.4 -> 8.3.4
- **pytest-timeout:** 2.2.0 -> 2.3.1
- **python:** 3.11.8 -> 3.12.8
- **python-dateutil:** 2.8.2 -> 2.9.0.post0
- **python-docx:** 1.1.0 -> 1.1.2
- **python-fastjsonschema:** 2.19.1 -> 2.21.1
- **python-libarchive-c:** 5.0 -> 5.1
- **python-tzdata:** 2024.1 -> 2024.2
- **python_abi:** 3.11 -> 3.12
- **pyvo:** 1.5.1 -> 1.6
- **pyyaml:** 6.0.1 -> 6.0.2
- **pyzmq:** 24.0.1 -> 26.2.0
- **qtconsole:** 5.5.1 -> 5.6.1
- **qtconsole-base:** 5.5.1 -> 5.6.1
- **qtpy:** 2.4.1 -> 2.4.2
- **referencing:** 0.33.0 -> 0.35.1
- **regions:** 0.8 -> 0.10
- **reproc:** 14.2.4.post0 -> 14.2.5.post0
- **reproc-cpp:** 14.2.4.post0 -> 14.2.5.post0
- **requests:** 2.31.0 -> 2.32.3
- **requests-oauthlib:** 1.3.1 -> 2.0.0
- **ripgrep:** 14.1.0 -> 14.1.1
- **rope:** 1.12.0 -> 1.13.0
- **rpds-py:** 0.18.0 -> 0.22.3
- **scikit-learn:** 1.4.1.post1 -> 1.6.0
- **send2trash:** 1.8.2 -> 1.8.3
- **setuptools:** 69.1.1 -> 75.6.0
- **setuptools-scm:** 8.0.4 -> 8.1.0
- **setuptools_scm:** 8.0.4 -> 8.1.0
- **sherpa:** 4.15.1 -> 4.17.0
- **six:** 1.16.0 -> 1.17.0
- **snappy:** 1.1.10 -> 1.2.1
- **sphinx:** 7.2.6 -> 8.1.3
- **sphinx-argparse:** 0.4.0 -> 0.5.2
- **sphinxcontrib-applehelp:** 1.0.8 -> 2.0.0
- **sphinxcontrib-devhelp:** 1.0.6 -> 2.0.0
- **sphinxcontrib-htmlhelp:** 2.0.5 -> 2.1.0
- **sphinxcontrib-qthelp:** 1.0.7 -> 2.0.0
- **sqlite:** 3.45.1 -> 3.47.2
- **sqlparse:** 0.4.4 -> 0.5.3
- **stack_data:** 0.6.2 -> 0.6.3
- **tenacity:** 8.2.3 -> 9.0.0
- **terminado:** 0.18.0 -> 0.18.1
- **threadpoolctl:** 3.3.0 -> 3.5.0
- **tinycss2:** 1.2.1 -> 1.4.0
- **tomli:** 2.0.1 -> 2.2.1
- **tomlkit:** 0.12.4 -> 0.13.2
- **tornado:** 6.4 -> 6.4.2
- **tqdm:** 4.66.2 -> 4.67.1
- **traitlets:** 5.14.1 -> 5.14.3
- **truststore:** 0.8.0 -> 0.10.0
- **types-python-dateutil:** 2.8.19.20240106 -> 2.9.0.20241206
- **typing-extensions:** 4.10.0 -> 4.12.2
- **typing_extensions:** 4.10.0 -> 4.12.2
- **tzdata:** 2024a -> 2024b
- **urllib3:** 2.2.1 -> 2.3.0
- **webcolors:** 1.13 -> 24.11.1
- **websocket-client:** 1.7.0 -> 1.8.0
- **wheel:** 0.42.0 -> 0.45.1
- **widgetsnbextension:** 4.0.10 -> 4.0.13
- **xcb-util:** 0.4.0 -> 0.4.1
- **xcb-util-keysyms:** 0.4.0 -> 0.4.1
- **xcb-util-renderutil:** 0.3.9 -> 0.3.10
- **xcb-util-wm:** 0.4.1 -> 0.4.2
- **xkeyboard-config:** 2.41 -> 2.43
- **xorg-libice:** 1.1.1 -> 1.1.2
- **xorg-libsm:** 1.2.4 -> 1.2.5
- **xorg-libx11:** 1.8.9 -> 1.8.10
- **xorg-libxau:** 1.0.11 -> 1.0.12
- **xorg-libxdamage:** 1.1.5 -> 1.1.6
- **xorg-libxdmcp:** 1.1.3 -> 1.1.5
- **xorg-libxext:** 1.3.4 -> 1.3.6
- **xorg-libxfixes:** 5.0.3 -> 6.0.1
- **xorg-libxi:** 1.7.10 -> 1.8.2
- **xorg-libxrandr:** 1.5.2 -> 1.5.4
- **xorg-libxrender:** 0.9.11 -> 0.9.12
- **xorg-libxtst:** 1.2.3 -> 1.2.5
- **xyzservices:** 2023.10.1 -> 2024.9.0
- **zipp:** 3.17.0 -> 3.21.0
- **zlib:** 1.2.13 -> 1.3.1
- **zlib-ng:** 2.0.7 -> 2.2.3
- **zstandard:** 0.19.0 -> 0.23.0


# Related Issues

Fixes #1477 