### PR TITLE
Add pydata-sphinx-theme and sphinx-copybutton

### DIFF
--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -53,6 +53,7 @@ requirements:
    - pip
    - plotly
    - ply
+   - pydata-sphinx-theme
    - pre-commit
    - pytest-timeout
    - python-kaleido
@@ -71,6 +72,7 @@ requirements:
    - setuptools_scm
    - sherpa # [not win]
    - sphinx-argparse
+   - sphinx-copybutton
    - six
    - sphinx
    - sqlalchemy

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -72,6 +72,7 @@ requirements:
    - setuptools_scm
    - sherpa # [not win]
    - sphinx-argparse
+   - sphinx-autoapi
    - sphinx-copybutton
    - six
    - sphinx


### PR DESCRIPTION
Add pydata-sphinx-theme and sphinx-copybutton to core-latest.

This supersedes #1481 as it was based on 2025.1-branch.