### PR TITLE
Add configobj to ska3-core-latest

### DIFF
--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -17,6 +17,7 @@ requirements:
    - cloudpickle # [win]
    - conda
    - conda-build
+   - configobj
    - coverage
    - cython
    - docxtpl


### PR DESCRIPTION
Add configobj to ska3-core-latest

This package is already in ska3-core, but missing in ska3-core-latest.  However, there is a direct dependence in kadi so this should be in core latest too.