### PR TITLE
Update ruff-base.toml to exclude "build" dir

### DIFF
--- a/templates/ruff-base.toml
+++ b/templates/ruff-base.toml
@@ -45,6 +45,7 @@ lint.ignore = [
 
 extend-exclude = [
   "docs",
+  "build",
 ]
 
 [lint.pycodestyle]


### PR DESCRIPTION
Python files hanging around in `build` should not be ruff formatted.

I tested this in `ska_trend` and confirmed that `build` was excluded as expected.