### PR TITLE
2025.4

### DIFF
--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core-latest
-  version: 2025.1
+  version: 2025.3
 
 requirements:
   run:

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -73,6 +73,7 @@ requirements:
    - setuptools_scm
    - sherpa # [not win]
    - sphinx-argparse
+   - sphinx-autoapi
    - sphinx-copybutton
    - six
    - sphinx

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core-latest
-  version: 2025.3
+  version: 2025.4
 
 requirements:
   run:

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -54,6 +54,7 @@ requirements:
    - pip
    - plotly
    - ply
+   - pydata-sphinx-theme
    - pre-commit
    - pytest-timeout
    - python-kaleido
@@ -72,6 +73,7 @@ requirements:
    - setuptools_scm
    - sherpa # [not win]
    - sphinx-argparse
+   - sphinx-copybutton
    - six
    - sphinx
    - sqlalchemy

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -17,6 +17,7 @@ requirements:
    - cloudpickle # [win]
    - conda
    - conda-build
+   - configobj
    - coverage
    - cython
    - docxtpl

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2025.3
+  version: 2025.4
 
 requirements:
   run:

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,12 +1,13 @@
 ---
 package:
   name: ska3-core
-  version: 2025.2
+  version: 2025.3
 
 requirements:
   run:
     - _libgcc_mutex ==0.1  # [linux]
     - _openmp_mutex ==4.5  # [linux or win]
+    - accessible-pygments ==0.0.5
     - aiobotocore ==2.16.1
     - aiohappyeyeballs ==2.4.4
     - aiohttp ==3.11.11
@@ -418,6 +419,7 @@ requirements:
     - pycodestyle ==2.12.1
     - pycosat ==0.6.6
     - pycparser ==2.22
+    - pydata-sphinx-theme ==0.16.1
     - pyerfa ==2.0.1.5
     - pygments ==2.18.0
     - pyjwt ==2.10.1
@@ -497,6 +499,8 @@ requirements:
     - spdlog ==1.15.0
     - sphinx ==8.1.3
     - sphinx-argparse ==0.5.2
+    - sphinx-autoapi ==3.5.0
+    - sphinx-copybutton ==0.5.2
     - sphinxcontrib-applehelp ==2.0.0
     - sphinxcontrib-devhelp ==2.0.0
     - sphinxcontrib-htmlhelp ==2.1.0
@@ -507,6 +511,7 @@ requirements:
     - sqlite ==3.47.2
     - sqlparse ==0.5.3
     - stack_data ==0.6.3
+    - stdlib-list ==0.11.1
     - tabulate ==0.9.0
     - tapi ==1300.6.5  # [osx]
     - tbb ==2021.13.0  # [win]

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2025.2
+  version: 2025.4
 
 build:
   noarch: generic
@@ -14,40 +14,40 @@ requirements:
     - acispy ==2.7.0
     - agasc ==4.22.0
     - backstop_history ==3.2.1
-    - chandra_aca ==4.48.1
+    - chandra_aca ==4.49.0
     - chandra_limits ==0.10.0
     - chandra_maneuver ==4.3.0
-    - chandra_time ==4.1.2
-    - cheta ==4.62.3
-    - cxotime ==3.9.2
+    - chandra_time ==4.2.0
+    - cheta ==4.63.1
+    - cxotime ==3.10.0
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
-    - kadi ==7.14.1
+    - kadi ==7.16.0
     - maude ==3.12.1
-    - mica ==4.38.1
-    - parse_cm ==3.16.2
+    - mica ==4.38.2
+    - parse_cm ==3.17.0
     - proseco ==5.16.1
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2025.2
+    - ska3-core ==2025.4
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
     - ska_dbi ==5.1.1
     - ska_file ==4.0.0
     - ska_ftp ==4.0.1
-    - ska_helpers ==0.17.0
+    - ska_helpers ==0.18.0
     - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.1
     - ska_path ==3.1.2
     - ska_quatutil ==4.0.0
-    - ska_shell ==4.0.1
+    - ska_shell ==4.1.0
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - sparkles ==4.28.1
-    - starcheck ==14.12.0
+    - sparkles ==4.29.0
+    - starcheck ==14.13.0
     - testr ==4.13.0
-    - xija ==4.32.0
+    - xija ==4.33.2


### PR DESCRIPTION
# ska3-matlab 2025.4

This PR includes:
- cxotime: Added the possibility to use an environment variable (`CXOTIME_NOW`)  to artificcialy set the "current" time in `CxoTime`.
- kadi
  - Support using MAUDE as the source of telemetry for kadi events, to allow the events to be up to date with ground telemetry soon after MAUDE dump data ingest completes.
  - Add infrastructure to filter command events to get an alternate command history (e.g.: the expected command events in the hypothetical case that an SCS 107 was not run)
  - Fixed a bug where the HRC appeared to be powered on after an SCS 107 in the middle of an HRC observation.
- sparkles: Check close-to-zero dither observations meet requirements (creep away and no dynamic background)
- starcheck: Remove high IR zone check

## Interface Impacts:

- cheta: Add back symbols that had been removed from `cheta.fetch`.
- kadi:
  - from now on, times beyond the last state will return the last state instead of failing with an exception.
  - Using KADI_COMMANDS_DEFAULT_STOP now generates a warning. Use CXOTIME_NOW instead.
  - Previously the `State` column in a local scenario command events file was being ignored. Now it behaves like the google sheet and (if that column is present), events are filtered accordingly. I.e. only `Predictive` and `Definitive` are allowed.
  - Added `event_filter` kwarg to  `get_cmds`, `get_states`, `get_continuity`, `get_observations`, 
    `get_starcats`, `get_starcats_as_table` functions.
  - Changes in events:
    - `safe_suns`: Obsid associated with safe sun event might change (depends on particular timing).
    - `normal_suns`: Normal suns now strictly match AOPCADMD == "NSUN" with no event fuzzing.
    - `scs107s`: SCS107 strictly based on RW momentum bias disabled. This is more accurate.
    - `eclipses`: Many spurious short eclipse events (< 100 s) removed.
  - New HRC commands result from any SCS-107 run (including NSM, Safe Mode). The command timing is different due to the addition of new commands with 1.025 sec waits. (https://github.com/sot/kadi/pull/344)

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.4/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2025.4rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2025.4rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2025.4 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-core changes (2025.2 -> 2025.4rc1)

### New Packages

- **accessible-pygments: 0.0.5**
- **pydata-sphinx-theme: 0.16.1**
- **sphinx-autoapi: 3.5.0**
- **sphinx-copybutton: 0.5.2**
- **stdlib-list: 0.11.1**



## ska3-core-latest changes (2025.1 -> 2025.4rc1)

### New Packages

- **configobj: **
- **pydata-sphinx-theme: **
- **sphinx-autoapi: **
- **sphinx-copybutton: **



## ska3-matlab changes (2025.2 -> 2025.4rc1)

### Updated Packages

- **chandra_aca:** 4.48.1 -> 4.49.0 (4.48.1 -> 4.49.0)
  - [PR 188](https://github.com/sot/chandra_aca/pull/188) (Jean Connelly): Change the get_aca_images default to bgsub=False
  - [PR 187](https://github.com/sot/chandra_aca/pull/187) (Jean Connelly): Update for ruff 0.9.0
- **chandra_time:** 4.1.2 -> 4.2.0 (4.1.2 -> 4.2.0)
  - [PR 59](https://github.com/sot/chandra_time/pull/59) (Tom Aldcroft): Support cxotime now sentinel and env var
- **cheta:** 4.62.3 -> 4.63.1 (4.62.3 -> 4.63.0 -> 4.63.1)
  - [PR 273](https://github.com/sot/cheta/pull/273) (Tom Aldcroft): Fix update scripts broken in #269 + unrelated docs fixes
  - [PR 271](https://github.com/sot/cheta/pull/271) (Tom Aldcroft): Require at least one row of data in full data for server sync
  - [PR 269](https://github.com/sot/cheta/pull/269) (Tom Aldcroft): Documentation overhaul
  - [PR 268](https://github.com/sot/cheta/pull/268) (Tom Aldcroft): Add remote access traceback + fix MSID.iplot() + docs update
  - [PR 270](https://github.com/sot/cheta/pull/270) (Tom Aldcroft): Support CXOTIME_NOW environment variable
  - [PR 274](https://github.com/sot/cheta/pull/274) (Tom Aldcroft): Add back most of fetch module contents to __all__
- **cxotime:** 3.9.2 -> 3.10.0 (3.9.2 -> 3.10.0)
  - [PR 50](https://github.com/sot/cxotime/pull/50) (Tom Aldcroft): Use `CXOTIME_NOW` environment variable as current time if set
  - [PR 49](https://github.com/sot/cxotime/pull/49) (Tom Aldcroft): Documentation overhaul and update to fast converter function generation
- **kadi:** 7.14.1 -> 7.16.0 (7.14.1 -> 7.14.2 -> 7.15.0 -> 7.16.0)
  - [PR 347](https://github.com/sot/kadi/pull/347) (Tom Aldcroft): Clip times in interpolate_states
  - [PR 349](https://github.com/sot/kadi/pull/349) (Tom Aldcroft): Use CXOTIME_NOW, deprecate KADI_COMMANDS_DEFAULT_STOP for default stop
  - [PR 348](https://github.com/sot/kadi/pull/348) (Tom Aldcroft): Documentation overhaul
  - [PR 351](https://github.com/sot/kadi/pull/351) (Tom Aldcroft): Add infrastructure to filter command events to get alternate command history
  - [PR 343](https://github.com/sot/kadi/pull/343) (Tom Aldcroft): Support MAUDE telemetry for events
  - [PR 344](https://github.com/sot/kadi/pull/344) (John ZuHone): [bugfix] Add commands to turn HRC off to SCS 107
- **mica:** 4.38.1 -> 4.38.2 (4.38.1 -> 4.38.2)
  - [PR 315](https://github.com/sot/mica/pull/315) (Tom Aldcroft): Use different alg for two_byte_sum that fixes off-by-one error
  - [PR 317](https://github.com/sot/mica/pull/317) (Jean Connelly): Set mica.report.report.main matplotlib backend to Agg
- **parse_cm:** 3.16.2 -> 3.17.0 (3.16.2 -> 3.17.0)
  - [PR 59](https://github.com/sot/parse_cm/pull/59) (Tom Aldcroft): Documentation update using ska_helpers.docs, pydata_sphinx_theme, sphinx_autoapi
  - [PR 58](https://github.com/sot/parse_cm/pull/58) (Tom Aldcroft): CSD parser remove ATS caching and test recent loads
  - [PR 57](https://github.com/sot/parse_cm/pull/57) (Tom Aldcroft): Ruff
- **ska3-core:** 2025.2 -> 2025.4rc1
- **ska_helpers:** 0.17.0 -> 0.18.0 (0.17.0 -> 0.18.0)
  - [PR 60](https://github.com/sot/ska_helpers/pull/60) (Tom Aldcroft): Add base conf.py for docs for all Ska projects
- **ska_shell:** 4.0.1 -> 4.1.0 (4.0.1 -> 4.1.0)
  - [PR 31](https://github.com/sot/ska_shell/pull/31) (Javier Gonzalez): No pexpect
- **sparkles:** 4.28.1 -> 4.29.0 (4.28.1 -> 4.29.0)
  - [PR 221](https://github.com/sot/sparkles/pull/221) (Jean Connelly): Check close-to-zero dither observations meet requirements
- **starcheck:** 14.12.0 -> 14.13.0 (14.12.0 -> 14.13.0)
  - [PR 451](https://github.com/sot/starcheck/pull/451) (Jean Connelly): Ruff
  - [PR 450](https://github.com/sot/starcheck/pull/450) (Jean Connelly): Remove high IR zone check
  - [PR 448](https://github.com/sot/starcheck/pull/448) (Tom Aldcroft): Refactor code and change format of HTML report
  - [PR 449](https://github.com/sot/starcheck/pull/449) (Jean Connelly): Don't run flight starcheck from in the repo
- **xija:** 4.32.0 -> 4.33.2 (4.32.0 -> 4.33.0 -> 4.33.1 -> 4.33.2)
  - [PR 142](https://github.com/sot/xija/pull/142) (Jean Connelly): Initialize ModelComponent pars and pars_dict in `__new__`
  - [PR 140](https://github.com/sot/xija/pull/140) (Tom Aldcroft): Minor interface improvements and fix bug writing Python spec file
  - [PR 143](https://github.com/sot/xija/pull/143) (Jean Connelly): Fix intersphinx_mapping syntax
  - [PR 141](https://github.com/sot/xija/pull/141) (Tom Aldcroft): Ruff
  - [PR 145](https://github.com/sot/xija/pull/145) (Tom Aldcroft): Improved implementation for pars_dict and pars attributes + pickle test
  - [PR 144](https://github.com/sot/xija/pull/144) (Tom Aldcroft): Remove legacy tests
 
# Related Issues

#1515 