### PR TITLE
add channels by hand after environment is setup

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -13,6 +13,7 @@ name: Build Ska Package
 #   - channel_in: the channel to use for the build environment (default is flight).
 #     This channel gets passed to package_build workflow, which also adds conda-forge
 #   - channel_out: the channel to upload the package to (default is test)
+#   - with_conda_forge: whether to add conda-forge to the channel list (default is false)
 #   - skare3_branch: the branch of skare3 to use for the build (default is master)
 #
 # You call it like this:
@@ -49,6 +50,7 @@ jobs:
       numpy_version: ${{ steps.arguments.outputs.numpy_version }}
       channel_in: ${{ steps.arguments.outputs.channel_in }}
       channel_out: ${{ steps.arguments.outputs.channel_out }}
+      with_conda_forge: ${{ steps.arguments.outputs.with_conda_forge }}
       skare3_branch: ${{ steps.arguments.outputs.skare3_branch }}
     steps:
     - name: Check arguments
@@ -90,6 +92,7 @@ jobs:
         set_default numpy_version "${{ github.event.client_payload.numpy_version }}" 1.26.2
         set_default channel_in "${{ github.event.client_payload.channel_in }}" "test"
         set_default channel_out "${{ github.event.client_payload.channel_out }}" "test"
+        set_boolean_default with_conda_forge "${{ github.event.client_payload.with_conda_forge }}" false
         set_default skare3_branch "${{ github.event.client_payload.skare3_branch }}" "master"
         if [ "${{ github.event.client_payload.upload }}" == "" ]; then echo upload is not given; fi
         if [ "${{ github.event.client_payload.upload }}" == "false" ]; then echo upload is false; fi
@@ -108,6 +111,7 @@ jobs:
         echo "- Numpy version: ${{ steps.arguments.outputs.numpy_version }}" >> $GITHUB_STEP_SUMMARY
         echo "- Input channel: ${{ steps.arguments.outputs.channel_in }}" >> $GITHUB_STEP_SUMMARY
         echo "- Output channel: ${{ steps.arguments.outputs.channel_out }}" >> $GITHUB_STEP_SUMMARY
+        echo "- With conda-forge: ${{ steps.arguments.outputs.with_conda_forge }}" >> $GITHUB_STEP_SUMMARY
   build:
     # This steps does the actual building
     needs: arguments  # this job needs the arguments job because it uses the outputs
@@ -122,6 +126,7 @@ jobs:
       install_ska_helpers: ${{ needs.arguments.outputs.install_ska_helpers == 'true' }}
       # the following channel in ska3-conda is used to create the build environment
       channel: ${{ needs.arguments.outputs.channel_in }}
+      with_conda_forge: ${{ needs.arguments.outputs.with_conda_forge == 'true' }}
     secrets:
       CONDA_PASSWORD: ${{ secrets.CONDA_PASSWORD }}
       CHANDRA_XRAY_TOKEN: ${{ secrets.CHANDRA_XRAY_TOKEN }}

--- a/.github/workflows/package_build.yml
+++ b/.github/workflows/package_build.yml
@@ -42,6 +42,11 @@ on:
         required: false
         type: string
         default: test
+      with_conda_forge:
+        description: Add conda-forge to the channel list
+        required: false
+        type: boolean
+        default: false
       install_ska_helpers:
         description: Install ska_helpers and testr
         required: false
@@ -107,7 +112,12 @@ jobs:
         python --version
         echo "adding ${{ inputs.channel }} channel"
         conda config --add channels https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/${{ inputs.channel }}
-        conda config --remove channels defaults  # defaults is added "implicitly" by conda in the previous line
+        if [[ "${{ inputs.with_conda_forge }}" == "false" ]]
+        then
+          echo "removing conda-forge channel"
+          conda config --remove channels conda-forge
+        fi
+        conda config --remove channels defaults  # defaults is added "implicitly" by conda in the previous lines
         conda config --show-sources
         conda config --show channels
     - name: Update Conda Environment

--- a/.github/workflows/package_build.yml
+++ b/.github/workflows/package_build.yml
@@ -112,10 +112,10 @@ jobs:
         python --version
         echo "adding ${{ inputs.channel }} channel"
         conda config --add channels https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/${{ inputs.channel }}
-        if [[ "${{ inputs.with_conda_forge }}" == "false" ]]
+        if [[ "${{ inputs.with_conda_forge }}" == "true" ]]
         then
-          echo "removing conda-forge channel"
-          conda config --remove channels conda-forge
+          echo "adding conda-forge channel"
+          conda config --add channels conda-forge
         fi
         conda config --remove channels defaults  # defaults is added "implicitly" by conda in the previous lines
         conda config --show-sources

--- a/.github/workflows/package_build.yml
+++ b/.github/workflows/package_build.yml
@@ -101,7 +101,15 @@ jobs:
         miniforge-version: latest
         python-version: ${{ inputs.python_version }}
         activate-environment: conda-build
-        channels: https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/${{ inputs.channel }},conda-forge
+    - name: Set channels
+      if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
+      run: |
+        python --version
+        echo "adding ${{ inputs.channel }} channel"
+        conda config --add channels https://ska:${{ secrets.CONDA_PASSWORD }}@cxc.cfa.harvard.edu/mta/ASPECT/ska3-conda/${{ inputs.channel }}
+        conda config --remove channels defaults  # defaults is added "implicitly" by conda in the previous line
+        conda config --show-sources
+        conda config --show channels
     - name: Update Conda Environment
       if: ${{ (matrix.os == 'ubuntu-latest') || !inputs.noarch }}
       run: |


### PR DESCRIPTION
This PR avoids the error seen in recent builds, where there is an authorization error when accessing our private conda repo. I do not know the exact cause of the error, but I am guessing that somewhere the repo URL is interpreted so all special characters are escaped, and the password is not replaced.

This PR also removes conda-forge from the channels used during build. This is to avoid breaking the build when something is updated in conda-forge. It adds an option to use conda-forge, because sometimes it might be needed.

I tested this in the test-actions repo.