### PR TITLE
2025.6

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cxotime ==3.10.1
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
-    - kadi ==7.17.0
+    - kadi ==7.17.1
     - maude ==3.13.0
     - mica ==4.39.0
     - parse_cm ==3.17.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -10,19 +10,19 @@ requirements:
   run:
     - aca_view ==0.16.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==5.3.0
+    - acis_thermal_check ==5.3.1
     - acispy ==2.8.0
     - agasc ==4.23.0
     - backstop_history ==3.2.1
     - chandra_aca ==4.51.0
-    - chandra_limits ==0.10.0
+    - chandra_limits ==0.10.1
     - chandra_maneuver ==4.3.1
     - chandra_time ==4.2.0
-    - cheta ==4.63.1
+    - cheta ==4.63.2
     - cxotime ==3.10.1
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
-    - kadi ==7.16.0
+    - kadi ==7.17.0
     - maude ==3.13.0
     - mica ==4.39.0
     - parse_cm ==3.17.0
@@ -48,6 +48,6 @@ requirements:
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
     - sparkles ==4.29.0
-    - starcheck ==14.13.0
+    - starcheck ==14.14.0
     - testr ==4.13.0
     - xija ==4.33.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2025.3
+  version: 2025.6
 
 build:
   noarch: generic
@@ -12,32 +12,32 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.3.0
     - acispy ==2.8.0
-    - agasc ==4.22.0
+    - agasc ==4.23.0
     - backstop_history ==3.2.1
-    - chandra_aca ==4.49.0
+    - chandra_aca ==4.51.0
     - chandra_limits ==0.10.0
-    - chandra_maneuver ==4.3.0
+    - chandra_maneuver ==4.3.1
     - chandra_time ==4.2.0
     - cheta ==4.63.1
-    - cxotime ==3.10.0
+    - cxotime ==3.10.1
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
     - kadi ==7.16.0
-    - maude ==3.12.1
-    - mica ==4.38.3
+    - maude ==3.13.0
+    - mica ==4.39.0
     - parse_cm ==3.17.0
     - proseco ==5.16.1
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2025.3
+    - ska3-core ==2025.6
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
-    - ska_dbi ==5.1.1
+    - ska_dbi ==5.2.0
     - ska_file ==4.0.0
     - ska_ftp ==4.0.1
-    - ska_helpers ==0.18.0
+    - ska_helpers ==0.19.0
     - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2025.6
+    - ska3-core ==2025.5
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0


### PR DESCRIPTION
# ska3-flight 2025.6

This release includes:
- kadi
  - [Add capability for computed kadi states](https://github.com/sot/kadi/pull/350) and use it for attitude and sun-related states (this includes attitude-related states like pitch/roll)
  - [Implements the RASL maneuver command event as a constant-rate roll about the sun](https://github.com/sot/kadi/pull/356)
  - [Add ACIS DPA power state ](https://github.com/sot/kadi/pull/358)
- Many small fixes and documentation improvements (see below).
- update ska3-core from 2025.3 to 2025.6, to fix compiler compatibilty in recent OSX versions, and to update astropy.

## Interface Impacts:

- chandra_aca:
  - Changed the name of the keyward argument in `chandra_aca.aca_image.get_tccd_data` from "maude_channel" to "channel" to match the kwarg used in other methods.
- kadi
  - Adds dpa_power commanded state.
  - New computed states:
    - rasl: roll about sun line
    - 'sun_ra', sun_dec: sun RA and dec
  - New (optional) states for which ACIS FEPs/CCDs are on
  - Attitude and sun-related states will change in value and in the interval start/stop bins. In all cases the new values match telemetry better, sometimes substantially better. See the [validation notebook](https://github.com/sot/kadi/blob/dd580932bc0fab3356767583ec037730116bc6a2/validate/pr350-computed-states/compare-attitude-states.ipynb) for details

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.6rc1-HEAD/).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.6rc1-OSX/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.6rc1-GRETA/).


skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2025.6rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2025.6rc#
```

If this release includes an update to ska3-perl, the install process for Aspect will include that. Note: ska3-perl is generally not needed for non-Aspect users.

```
conda create -n ska3-flight-2025.6rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2025.6rc# ska3-perl==2025.6rc#
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2025.6 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-flight changes (2025.3 -> 2025.6rc1)

### Updated Packages

- **acis_thermal_check:** 5.3.0 -> 5.3.1 (5.3.0 -> 5.3.1)
  - [PR 77](https://github.com/acisops/acis_thermal_check/pull/77) (Jean Connelly): Update answers for pitch/state changes from kadi
- **agasc:** 4.22.0 -> 4.23.0 (4.22.0 -> 4.23.0)
  - [PR 196](https://github.com/sot/agasc/pull/196) (Javier Gonzalez): Handle cases where kadi events come from maude
  - [PR 198](https://github.com/sot/agasc/pull/198) (Javier Gonzalez): fix bug causing wrong values of magnitude changes in report
  - [PR 197](https://github.com/sot/agasc/pull/197) (Javier Gonzalez): ruff fixes
- **chandra_aca:** 4.49.0 -> 4.51.0 (4.49.0 -> 4.50.0 -> 4.51.0)
  - [PR 190](https://github.com/sot/chandra_aca/pull/190) (Tom Aldcroft): Overhaul docs using pydata_sphinx_theme and sphinx_autoapi
  - [PR 189](https://github.com/sot/chandra_aca/pull/189) (Tom Aldcroft): Add drift_pars kwarg to get_aca_offsets and get_fid_offset
  - [PR 194](https://github.com/sot/chandra_aca/pull/194) (Jean Connelly): Fix bug quoting the maude channel for cheta.fetch
  - [PR 193](https://github.com/sot/chandra_aca/pull/193) (Jean Connelly): Change time range in short image test
  - [PR 191](https://github.com/sot/chandra_aca/pull/191) (Jean Connelly): Don't fetch ccd temperature if bgsub=False
- **chandra_limits:** 0.10.0 -> 0.10.1 (0.10.0 -> 0.10.1)
  - [PR 22](https://github.com/sot/chandra_limits/pull/22) (Jean Connelly): Update unit/regress test for new kadi state vals
- **chandra_maneuver:** 4.3.0 -> 4.3.1 (4.3.0 -> 4.3.1)
  - [PR 30](https://github.com/sot/chandra_maneuver/pull/30) (Jean Connelly): Ruff
- **cheta:** 4.63.1 -> 4.63.2 (4.63.1 -> 4.63.2)
  - [PR 275](https://github.com/sot/cheta/pull/275) (Jean Connelly): Update pitchs in a cmd state test 
- **cxotime:** 3.10.0 -> 3.10.1 (3.10.0 -> 3.10.1)
  - [PR 51](https://github.com/sot/cxotime/pull/51) (Tom Aldcroft): Fix mistake converting string date during leap second to jd1, jd2
- **kadi:** 7.16.0 -> 7.17.1 (7.16.0 -> 7.17.0 -> 7.17.1)
  - [PR 359](https://github.com/sot/kadi/pull/359) (Tom Aldcroft): Allow maneuver time steps to be configurable
  - [PR 356](https://github.com/sot/kadi/pull/356) (Tom Aldcroft): Implement RASL as constant-rate maneuver
  - [PR 358](https://github.com/sot/kadi/pull/358) (Tom Aldcroft): Add ACIS DPA power state and refactor validation using that state
  - [PR 350](https://github.com/sot/kadi/pull/350) (Tom Aldcroft): Add capability for computed kadi states and use for attitude and sun-related states
  - [PR 357](https://github.com/sot/kadi/pull/357) (John ZuHone): validation of ACIS state power
  - [PR 354](https://github.com/sot/kadi/pull/354) (Jean Connelly): Parse major events html from 23-Apr-2025
  - [PR 353](https://github.com/sot/kadi/pull/353) (Tom Aldcroft): Fix issue setting the lookback default after it gets used
  - [PR 360](https://github.com/sot/kadi/pull/360) (Jean Connelly): Add ecsv regress files to installed test data
- **maude:** 3.12.1 -> 3.13.0 (3.12.1 -> 3.13.0)
  - [PR 50](https://github.com/sot/maude/pull/50) (Jean Connelly): Add a configurable timeout to the maude requests
- **mica:** 4.38.3 -> 4.39.0 (4.38.3 -> 4.39.0)
  - [PR 322](https://github.com/sot/mica/pull/322) (Javier Gonzalez): fix archive.cds.get_proposal_abstract
  - [PR 320](https://github.com/sot/mica/pull/320) (Jean Connelly): Fix bug in acq/guide stats processing range
  - [PR 321](https://github.com/sot/mica/pull/321) (Jean Connelly): Remove centroid dashboard/reports processing
  - [PR 319](https://github.com/sot/mica/pull/319) (Jean Connelly): New ruff fixes
- **ska3-core:** 2025.3 -> 2025.5
- **ska_dbi:** 5.1.1 -> 5.2.0 (5.1.1 -> 5.2.0)
  - [PR 28](https://github.com/sot/ska_dbi/pull/28) (Jean Connelly): Sqsh output looks to be latin-1 so fix decoding
- **ska_helpers:** 0.18.0 -> 0.19.0 (0.18.0 -> 0.19.0)
  - [PR 63](https://github.com/sot/ska_helpers/pull/63) (Javier Gonzalez): Fix test_docs after #62
  - [PR 62](https://github.com/sot/ska_helpers/pull/62) (Tom Aldcroft): Improve sphinx docs base conf.py
- **starcheck:** 14.13.0 -> 14.14.0 (14.13.0 -> 14.14.0)
  - [PR 454](https://github.com/sot/starcheck/pull/454) (Jean Connelly): Add srdc info statement
  - [PR 453](https://github.com/sot/starcheck/pull/453) (Jean Connelly): Move large dither check before dither-in-obs check again
  - [PR 452](https://github.com/sot/starcheck/pull/452) (Jean Connelly): Add checks for no dither and small dither observations

## ska3-core changes (OSX, 2025.3 -> 2025.5)

### New Packages

- **uncompresspy: 0.4.0**

### Updated Packages

- **astropy:** 7.0.0 -> 7.1.0
- **astropy-base:** 7.0.0 -> 7.1.0
- **astropy-iers-data:** 0.2024.12.30.0.33.36 -> 0.2025.6.9.0.39.3
- **ca-certificates:** 2024.12.14 -> 2025.4.26
- **certifi:** 2024.12.14 -> 2025.1.31
- **libgfortran:** 5.0.0 -> 14.2.0
- **libgfortran5:** 13.2.0 -> 14.2.0
- **openssl:** 3.4.0 -> 3.5.0
- **scipy:** 1.14.1 -> 1.15.2



# Related Issues

#1551 