### PR TITLE
2025.7

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cxotime ==3.10.1
     - fot-matlab ==2.5.0
     - hopper ==4.6.0
-    - kadi ==7.17.1
+    - kadi ==7.17.0
     - maude ==3.13.0
     - mica ==4.39.0
     - parse_cm ==3.17.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2025.5
+  version: 2025.7
 
 build:
   noarch: generic
@@ -10,19 +10,19 @@ requirements:
   run:
     - aca_view ==0.16.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==5.3.0
+    - acis_thermal_check ==5.3.1
     - acispy ==2.8.0
     - agasc ==4.23.0
     - backstop_history ==3.2.1
     - chandra_aca ==4.51.0
-    - chandra_limits ==0.10.0
+    - chandra_limits ==0.10.1
     - chandra_maneuver ==4.3.1
     - chandra_time ==4.2.0
-    - cheta ==4.63.1
+    - cheta ==4.63.2
     - cxotime ==3.10.1
-    - fot-matlab ==2.4.1
+    - fot-matlab ==2.5.0
     - hopper ==4.6.0
-    - kadi ==7.16.0
+    - kadi ==7.17.0
     - maude ==3.13.0
     - mica ==4.39.0
     - parse_cm ==3.17.0
@@ -30,7 +30,7 @@ requirements:
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2025.4
+    - ska3-core ==2025.7
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
@@ -48,6 +48,6 @@ requirements:
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
     - sparkles ==4.29.0
-    - starcheck ==14.13.0
+    - starcheck ==14.14.0
     - testr ==4.13.0
     - xija ==4.33.2

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cxotime ==3.10.1
     - fot-matlab ==2.5.0
     - hopper ==4.6.0
-    - kadi ==7.17.0
+    - kadi ==7.17.1
     - maude ==3.13.0
     - mica ==4.39.0
     - parse_cm ==3.17.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2025.4
+  version: 2025.5
 
 build:
   noarch: generic
@@ -10,21 +10,21 @@ requirements:
   run:
     - aca_view ==0.16.0
     - acis_taco ==4.2.3
-    - acis_thermal_check ==5.2.0
-    - acispy ==2.7.0
-    - agasc ==4.22.0
+    - acis_thermal_check ==5.3.0
+    - acispy ==2.8.0
+    - agasc ==4.23.0
     - backstop_history ==3.2.1
-    - chandra_aca ==4.49.0
+    - chandra_aca ==4.51.0
     - chandra_limits ==0.10.0
-    - chandra_maneuver ==4.3.0
+    - chandra_maneuver ==4.3.1
     - chandra_time ==4.2.0
     - cheta ==4.63.1
-    - cxotime ==3.10.0
+    - cxotime ==3.10.1
     - fot-matlab ==2.4.1
     - hopper ==4.6.0
     - kadi ==7.16.0
-    - maude ==3.12.1
-    - mica ==4.38.2
+    - maude ==3.13.0
+    - mica ==4.39.0
     - parse_cm ==3.17.0
     - proseco ==5.16.1
     - pyyaks ==4.5.0
@@ -34,16 +34,16 @@ requirements:
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
-    - ska_dbi ==5.1.1
+    - ska_dbi ==5.2.0
     - ska_file ==4.0.0
     - ska_ftp ==4.0.1
-    - ska_helpers ==0.18.0
+    - ska_helpers ==0.19.0
     - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.1
     - ska_path ==3.1.2
     - ska_quatutil ==4.0.0
-    - ska_shell ==4.1.0
+    - ska_shell ==4.1.1
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2025.7
+    - ska3-core ==2025.5
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0


### PR DESCRIPTION
# ska3-matlab 2025.7

This release includes:
- 

## Interface Impacts:

## Testing:

Two versions were tested: 2025.7rc1 and 2025.7rc2. These two are functionally the same except for some tests of the kadi package. The 2025.7rc1 includes some extra files for kadi regression tests, and these files caused an installation error on the FOT side, so these files were removed for 2025.7rc2. For this reason, 2025.7rc1 tests can be considered more complete, although the actual version being tested for promotion is 2025.7rc2.

- [GRETA (RC2)](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.7rc2-GRETA/).
- [OSX (RC1)](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.7rc1-OSX/).
- [Windows (RC1)](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.7rc1-Windows/).

There is one test that shows a failure on Windows. This relates to a new feature: ACIS DPA power state. This feature should be considered not supported on Windows until the issue has been resolved.

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2025.7rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2025.7rc#
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2025.7 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2025.4 -> 2025.7rc2)

### Updated Packages

- **acis_thermal_check:** 5.2.0 -> 5.3.1 (5.2.0 -> 5.3.0 -> 5.3.1)
  - [PR 76](https://github.com/acisops/acis_thermal_check/pull/76) (John ZuHone): Documentation page on what to do if something goes wrong with lr, new script to copy files to webpage
  - [PR 77](https://github.com/acisops/acis_thermal_check/pull/77) (Jean Connelly): Update answers for pitch/state changes from kadi
- **acispy:** 2.7.0 -> 2.8.0 (2.7.0 -> 2.8.0)
- **agasc:** 4.22.0 -> 4.23.0 (4.22.0 -> 4.23.0)
  - [PR 196](https://github.com/sot/agasc/pull/196) (Javier Gonzalez): Handle cases where kadi events come from maude
  - [PR 198](https://github.com/sot/agasc/pull/198) (Javier Gonzalez): fix bug causing wrong values of magnitude changes in report
  - [PR 197](https://github.com/sot/agasc/pull/197) (Javier Gonzalez): ruff fixes
- **chandra_aca:** 4.49.0 -> 4.51.0 (4.49.0 -> 4.50.0 -> 4.51.0)
  - [PR 190](https://github.com/sot/chandra_aca/pull/190) (Tom Aldcroft): Overhaul docs using pydata_sphinx_theme and sphinx_autoapi
  - [PR 189](https://github.com/sot/chandra_aca/pull/189) (Tom Aldcroft): Add drift_pars kwarg to get_aca_offsets and get_fid_offset
  - [PR 194](https://github.com/sot/chandra_aca/pull/194) (Jean Connelly): Fix bug quoting the maude channel for cheta.fetch
  - [PR 193](https://github.com/sot/chandra_aca/pull/193) (Jean Connelly): Change time range in short image test
  - [PR 191](https://github.com/sot/chandra_aca/pull/191) (Jean Connelly): Don't fetch ccd temperature if bgsub=False
- **chandra_limits:** 0.10.0 -> 0.10.1 (0.10.0 -> 0.10.1)
  - [PR 22](https://github.com/sot/chandra_limits/pull/22) (Jean Connelly): Update unit/regress test for new kadi state vals
- **chandra_maneuver:** 4.3.0 -> 4.3.1 (4.3.0 -> 4.3.1)
  - [PR 30](https://github.com/sot/chandra_maneuver/pull/30) (Jean Connelly): Ruff
- **cheta:** 4.63.1 -> 4.63.2 (4.63.1 -> 4.63.2)
  - [PR 275](https://github.com/sot/cheta/pull/275) (Jean Connelly): Update pitchs in a cmd state test 
- **cxotime:** 3.10.0 -> 3.10.1 (3.10.0 -> 3.10.1)
  - [PR 51](https://github.com/sot/cxotime/pull/51) (Tom Aldcroft): Fix mistake converting string date during leap second to jd1, jd2
- **fot-matlab:** 2.4.1 -> 2.5.0 (2.4.1 -> 2.5.0)
  - [PR 30](https://github.com/sot/fot-matlab/pull/30) (James Kristoff): Ruff take 2
  - [PR 29](https://github.com/sot/fot-matlab/pull/29) (James Jay): Creating a Suite of fot-matlab Utilities
  - [PR 1](https://github.com/sot/fot-matlab/pull/1) (Unknown): updates to PR for generality and performance
- **kadi:** 7.16.0 -> 7.17.0 (7.16.0 -> 7.17.0)
  - [PR 359](https://github.com/sot/kadi/pull/359) (Tom Aldcroft): Allow maneuver time steps to be configurable
  - [PR 356](https://github.com/sot/kadi/pull/356) (Tom Aldcroft): **Implement RASL as constant-rate maneuver**
  - [PR 358](https://github.com/sot/kadi/pull/358) (Tom Aldcroft): Add ACIS DPA power state and refactor validation using that state
  - [PR 350](https://github.com/sot/kadi/pull/350) (Tom Aldcroft): **Add capability for computed kadi states and use for attitude and sun-related states**
  - [PR 357](https://github.com/sot/kadi/pull/357) (John ZuHone): validation of ACIS state power
  - [PR 354](https://github.com/sot/kadi/pull/354) (Jean Connelly): Parse major events html from 23-Apr-2025
  - [PR 353](https://github.com/sot/kadi/pull/353) (Tom Aldcroft): Fix issue setting the lookback default after it gets used
- **maude:** 3.12.1 -> 3.13.0 (3.12.1 -> 3.13.0)
  - [PR 50](https://github.com/sot/maude/pull/50) (Jean Connelly): Add a configurable timeout to the maude requests
- **mica:** 4.38.2 -> 4.39.0 (4.38.2 -> 4.38.3 -> 4.39.0)
  - [PR 318](https://github.com/sot/mica/pull/318) (Jean Connelly): Limit stat update range to end of AOPCADMD data
  - [PR 322](https://github.com/sot/mica/pull/322) (Javier Gonzalez): fix archive.cds.get_proposal_abstract
  - [PR 320](https://github.com/sot/mica/pull/320) (Jean Connelly): Fix bug in acq/guide stats processing range
  - [PR 321](https://github.com/sot/mica/pull/321) (Jean Connelly): Remove centroid dashboard/reports processing
  - [PR 319](https://github.com/sot/mica/pull/319) (Jean Connelly): New ruff fixes
- **ska3-core:** 2025.4 -> 2025.5
- **ska_dbi:** 5.1.1 -> 5.2.0 (5.1.1 -> 5.2.0)
  - [PR 28](https://github.com/sot/ska_dbi/pull/28) (Jean Connelly): Sqsh output looks to be latin-1 so fix decoding
- **ska_helpers:** 0.18.0 -> 0.19.0 (0.18.0 -> 0.19.0)
  - [PR 63](https://github.com/sot/ska_helpers/pull/63) (Javier Gonzalez): Fix test_docs after #62
  - [PR 62](https://github.com/sot/ska_helpers/pull/62) (Tom Aldcroft): Improve sphinx docs base conf.py
- **ska_shell:** 4.1.0 -> 4.1.1 (4.1.0 -> 4.1.1)
  - [PR 32](https://github.com/sot/ska_shell/pull/32) (Javier Gonzalez): trivial test fix: do not test for zsh
- **starcheck:** 14.13.0 -> 14.14.0 (14.13.0 -> 14.14.0)
  - [PR 454](https://github.com/sot/starcheck/pull/454) (Jean Connelly): Add srdc info statement
  - [PR 453](https://github.com/sot/starcheck/pull/453) (Jean Connelly): Move large dither check before dither-in-obs check again
  - [PR 452](https://github.com/sot/starcheck/pull/452) (Jean Connelly): Add checks for no dither and small dither observations

## ska3-core changes (OSX, 2025.3 -> 2025.5rc6)

### New Packages

- **uncompresspy: 0.4.0**

### Updated Packages

- **astropy:** 7.0.0 -> 7.1.0
- **astropy-base:** 7.0.0 -> 7.1.0
- **astropy-iers-data:** 0.2024.12.30.0.33.36 -> 0.2025.6.9.0.39.3
- **ca-certificates:** 2024.12.14 -> 2025.4.26
- **certifi:** 2024.12.14 -> 2025.1.31
- **libgfortran:** 5.0.0 -> 14.2.0
- **libgfortran5:** 13.2.0 -> 14.2.0
- **openssl:** 3.4.0 -> 3.5.0
- **scipy:** 1.14.1 -> 1.15.2



# Related Issues

#1550 
#1547
