### PR TITLE
set patch instructions to what is currently online

### DIFF
--- a/patch_instructions/linux-64/patch_instructions.json
+++ b/patch_instructions/linux-64/patch_instructions.json
@@ -3,29 +3,11 @@
     "_openmp_mutex-4.5-2_kmp_llvm.tar.bz2": {
       "license_family": "BSD"
     },
-    "brotli-1.0.9-h166bdaf_8.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "brotli-bin-1.0.9-h166bdaf_8.tar.bz2": {
-      "license_family": "MIT"
-    },
     "dbus-1.13.6-h5008d03_3.tar.bz2": {
       "license_family": "GPL"
     },
-    "fontconfig-2.14.1-hc2a2eb6_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "giflib-5.2.1-h36c2ea0_2.tar.bz2": {
-      "license_family": "MIT"
-    },
     "gsl-2.7-he838d99_0.tar.bz2": {
       "license_family": "GPL"
-    },
-    "h5py-3.7.0-nompi_py310h416281c_102.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "icu-70.1-h27087fc_0.tar.bz2": {
-      "license_family": "MIT"
     },
     "kaleido-core-0.2.1-h3644ca4_0.tar.bz2": {
       "depends": [
@@ -40,24 +22,6 @@
         "sqlite >=3.34.0,<4.0a0"
       ]
     },
-    "libblas-3.9.0-16_linux64_mkl.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "libbrotlicommon-1.0.9-h166bdaf_8.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "libbrotlidec-1.0.9-h166bdaf_8.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "libbrotlienc-1.0.9-h166bdaf_8.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "libcblas-3.9.0-16_linux64_mkl.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "libdb-6.2.32-h9c3ff4c_0.tar.bz2": {
-      "license_family": "AGPL"
-    },
     "libedit-3.1.20191231-he28a2e2_2.tar.bz2": {
       "depends": [
         "libgcc-ng >=7.5.0",
@@ -67,935 +31,237 @@
     "libffi-3.4.2-h7f98852_5.tar.bz2": {
       "license_family": "MIT"
     },
-    "libgcc-ng-12.2.0-h65d4601_19.tar.bz2": {
-      "license_family": "GPL"
-    },
-    "libgfortran-ng-12.2.0-h69a702a_19.tar.bz2": {
-      "license_family": "GPL"
-    },
-    "libgfortran5-12.2.0-h337968e_19.tar.bz2": {
-      "license_family": "GPL"
-    },
-    "libhwloc-2.8.0-h32351e8_1.tar.bz2": {
-      "depends": [
-        "libgcc-ng >=12",
-        "libstdcxx-ng >=12",
-        "libxml2 >=2.9.14,<2.11.0a0"
-      ],
-      "license_family": "BSD"
-    },
-    "liblapack-3.9.0-16_linux64_mkl.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "libogg-1.3.4-h7f98852_1.tar.bz2": {
-      "license_family": "BSD"
-    },
     "libopus-1.3.1-h7f98852_1.tar.bz2": {
       "license_family": "BSD"
-    },
-    "libstdcxx-ng-12.2.0-h46fd767_19.tar.bz2": {
-      "license_family": "GPL"
-    },
-    "libuuid-2.32.1-h7f98852_1000.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "libwebp-base-1.2.4-h166bdaf_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "libxkbcommon-1.0.3-he3ba5ed_0.tar.bz2": {
-      "depends": [
-        "libgcc-ng >=7.5.0",
-        "libstdcxx-ng >=7.5.0",
-        "libxml2 >=2.9.10,<2.11.0a0"
-      ]
-    },
-    "libxslt-1.1.37-h873f0b0_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "llvmlite-0.39.1-py310h58363a5_1.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "lz4-c-1.9.3-h9c3ff4c_1.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "mkl_fft-1.3.1-py310h1dd1467_4.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "nb_conda_kernels-2.3.1-py310hff52083_2.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "nodejs-18.12.1-h8839609_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "numexpr-2.7.3-py310hb5077e9_1.tar.bz2": {
-      "license_family": "MIT"
     },
     "patch-2.7.6-h7f98852_1002.tar.bz2": {
       "license_family": "GPL"
     },
-    "pkg-config-0.29.2-h36c2ea0_1008.tar.bz2": {
-      "license_family": "GPL"
-    },
-    "pycosat-0.6.4-py310h5764c6d_1.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "readline-8.1.2-h0f457ee_0.tar.bz2": {
-      "license_family": "GPL"
-    },
-    "ruamel.yaml-0.17.21-py310h5764c6d_2.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "wrapt-1.14.1-py310h5764c6d_1.tar.bz2": {
-      "license_family": "BSD"
-    },
     "yaml-0.2.5-h7f98852_2.tar.bz2": {
       "license_family": "MIT"
-    },
-    "zeromq-4.3.4-h9c3ff4c_1.tar.bz2": {
-      "license_family": "LGPL"
-    },
-    "packages": {
-      "packages": {
-        "_openmp_mutex-4.5-2_kmp_llvm.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "dbus-1.13.6-h5008d03_3.tar.bz2": {
-          "license_family": "GPL"
-        },
-        "kaleido-core-0.2.1-h3644ca4_0.tar.bz2": {
-          "depends": [
-            "__glibc >=2.17,<3.0.a0",
-            "expat >=2.2.10,<3.0.0a0",
-            "fontconfig",
-            "fonts-conda-forge",
-            "libgcc-ng >=9.3.0",
-            "mathjax 2.7.*",
-            "nspr >=4.29,<5.0a0",
-            "nss >=3.62,<4.0a0",
-            "sqlite >=3.34.0,<4.0a0"
-          ]
-        },
-        "libblas-3.9.0-16_linux64_mkl.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "libcblas-3.9.0-16_linux64_mkl.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "libedit-3.1.20191231-he28a2e2_2.tar.bz2": {
-          "depends": [
-            "libgcc-ng >=7.5.0",
-            "ncurses >=6.2,<7.0.0a0"
-          ]
-        },
-        "libffi-3.4.2-h7f98852_5.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "liblapack-3.9.0-16_linux64_mkl.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "libogg-1.3.4-h7f98852_1.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "libopus-1.3.1-h7f98852_1.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "patch-2.7.6-h7f98852_1002.tar.bz2": {
-          "license_family": "GPL"
-        },
-        "yaml-0.2.5-h7f98852_2.tar.bz2": {
-          "license_family": "MIT"
-        }
-      },
-      "packages.conda": {
-        "astropy-6.0.0-py311h1f0f07a_0.conda": {
-          "license_family": "BSD"
-        },
-        "blosc-1.21.5-h0f2a231_0.conda": {
-          "license_family": "BSD"
-        },
-        "brotli-1.1.0-hd590300_1.conda": {
-          "license_family": "MIT"
-        },
-        "brotli-bin-1.1.0-hd590300_1.conda": {
-          "license_family": "MIT"
-        },
-        "brotli-python-1.1.0-py311hb755f60_1.conda": {
-          "license_family": "MIT"
-        },
-        "cffi-1.16.0-py311hb3a22ac_0.conda": {
-          "license_family": "MIT"
-        },
-        "cfitsio-4.2.0-hd9d235c_0.conda": {
-          "depends": [
-            "bzip2 >=1.0.8,<2.0a0",
-            "libcurl >=7.86.0,<9.0a0",
-            "libgcc-ng >=12",
-            "libgfortran-ng",
-            "libgfortran5 >=10.4.0",
-            "libzlib >=1.2.13,<1.3.0a0"
-          ]
-        },
-        "conda-23.11.0-py311h38be061_1.conda": {
-          "license_family": "BSD"
-        },
-        "contourpy-1.2.0-py311h9547e67_0.conda": {
-          "license_family": "BSD"
-        },
-        "coverage-7.4.3-py311h459d7ec_1.conda": {
-          "license_family": "APACHE"
-        },
-        "cython-3.0.8-py311hb755f60_0.conda": {
-          "license_family": "APACHE"
-        },
-        "fontconfig-2.14.2-h14ed4e7_0.conda": {
-          "license_family": "MIT"
-        },
-        "giflib-5.2.1-h0b41bf4_3.conda": {
-          "license_family": "MIT"
-        },
-        "gst-plugins-base-1.22.9-h8e1006c_0.conda": {
-          "license_family": "LGPL"
-        },
-        "gstreamer-1.22.9-h98fc4e7_0.conda": {
-          "license_family": "LGPL"
-        },
-        "h5py-3.10.0-nompi_py311hebc2b07_101.conda": {
-          "license_family": "BSD"
-        },
-        "harfbuzz-8.3.0-h3d44ed6_0.conda": {
-          "license_family": "MIT"
-        },
-        "icu-73.2-h59595ed_0.conda": {
-          "license_family": "MIT"
-        },
-        "jsonpointer-2.4-py311h38be061_3.conda": {
-          "license_family": "BSD"
-        },
-        "krb5-1.21.2-h659d440_0.conda": {
-          "license_family": "MIT"
-        },
-        "ld_impl_linux-64-2.40-h41732ed_0.conda": {
-          "license_family": "GPL"
-        },
-        "libarchive-3.7.2-h2aa1ff5_1.conda": {
-          "depends": [
-            "bzip2 >=1.0.8,<2.0a0",
-            "libgcc-ng >=12",
-            "libxml2 >=2.12.2,<3.0.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "lz4-c >=1.9.3,<1.10.0a0",
-            "lzo >=2.10,<3.0a0",
-            "openssl >=3.2.0,<4.0a0",
-            "xz >=5.2.6,<6.0a0",
-            "zstd >=1.5.5,<1.6.0a0"
-          ]
-        },
-        "libbrotlicommon-1.1.0-hd590300_1.conda": {
-          "license_family": "MIT"
-        },
-        "libbrotlidec-1.1.0-hd590300_1.conda": {
-          "license_family": "MIT"
-        },
-        "libbrotlienc-1.1.0-hd590300_1.conda": {
-          "license_family": "MIT"
-        },
-        "libdeflate-1.19-hd590300_0.conda": {
-          "license_family": "MIT"
-        },
-        "libgcc-ng-13.2.0-h807b86a_5.conda": {
-          "license_family": "GPL"
-        },
-        "libgfortran-ng-13.2.0-h69a702a_5.conda": {
-          "license_family": "GPL"
-        },
-        "libgfortran5-13.2.0-ha4646dd_5.conda": {
-          "license_family": "GPL"
-        },
-        "libhwloc-2.9.3-default_h554bfaf_1009.conda": {
-          "depends": [
-            "libgcc-ng >=12",
-            "libstdcxx-ng >=12",
-            "libxml2 >=2.11.5,<3.0.0a0"
-          ],
-          "license_family": "BSD"
-        },
-        "libllvm15-15.0.7-hb3ce162_4.conda": {
-          "depends": [
-            "libgcc-ng >=12",
-            "libstdcxx-ng >=12",
-            "libxml2 >=2.12.1,<3.0.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "zstd >=1.5.5,<1.6.0a0"
-          ]
-        },
-        "libstdcxx-ng-13.2.0-h7e041cc_5.conda": {
-          "license_family": "GPL"
-        },
-        "libuuid-2.38.1-h0b41bf4_0.conda": {
-          "license_family": "BSD"
-        },
-        "libwebp-1.3.2-h658648e_1.conda": {
-          "license_family": "BSD"
-        },
-        "libwebp-base-1.3.2-hd590300_0.conda": {
-          "license_family": "BSD"
-        },
-        "libxkbcommon-1.6.0-hd429924_1.conda": {
-          "depends": [
-            "libgcc-ng >=12",
-            "libstdcxx-ng >=12",
-            "libxcb >=1.15,<1.16.0a0",
-            "libxml2 >=2.12.1,<3.0.0a0",
-            "xkeyboard-config",
-            "xorg-libxau >=1.0.11,<2.0a0"
-          ]
-        },
-        "libxslt-1.1.39-h76b75d6_0.conda": {
-          "depends": [
-            "libgcc-ng >=12",
-            "libxml2 >=2.12.1,<3.0.0a0"
-          ],
-          "license_family": "MIT"
-        },
-        "llvm-openmp-17.0.6-h4dfa4b3_0.conda": {
-          "license_family": "APACHE"
-        },
-        "llvmlite-0.42.0-py311ha6695c7_1.conda": {
-          "license_family": "BSD"
-        },
-        "lxml-5.1.0-py311h9691dec_0.conda": {
-          "depends": [
-            "libgcc-ng >=12",
-            "libxml2 >=2.12.3,<3.0.0a0",
-            "libxslt >=1.1.39,<2.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "python >=3.11,<3.12.0a0",
-            "python_abi 3.11.* *_cp311"
-          ]
-        },
-        "lz4-c-1.9.4-hcb278e6_0.conda": {
-          "license_family": "BSD"
-        },
-        "mkl_fft-1.3.8-py311h8e1fd07_0.conda": {
-          "license_family": "BSD"
-        },
-        "nodejs-20.9.0-hb753e55_0.conda": {
-          "license_family": "MIT"
-        },
-        "nspr-4.35-h27087fc_0.conda": {
-          "license_family": "MOZILLA"
-        },
-        "nss-3.98-h1d7d5a4_0.conda": {
-          "license_family": "MOZILLA"
-        },
-        "numexpr-2.8.4-mkl_py311hbaa3ca7_1.conda": {
-          "license_family": "MIT"
-        },
-        "numpy-1.26.4-py311h64a7726_0.conda": {
-          "license_family": "BSD"
-        },
-        "openjpeg-2.5.1-h488ebb8_0.conda": {
-          "license_family": "BSD"
-        },
-        "pandas-2.2.1-py311h320fe9a_0.conda": {
-          "license_family": "BSD"
-        },
-        "patchelf-0.17.2-h58526e2_0.conda": {
-          "license_family": "GPL"
-        },
-        "pixman-0.43.2-h59595ed_0.conda": {
-          "license_family": "MIT"
-        },
-        "pycosat-0.6.6-py311h459d7ec_0.conda": {
-          "license_family": "MIT"
-        },
-        "pytables-3.8.0-py311h10c7f7f_4.conda": {
-          "depends": [
-            "blosc >=1.21.5,<2.0a0",
-            "bzip2 >=1.0.8,<2.0a0",
-            "c-blosc2 >=2.10.2,<3.0a0",
-            "hdf5 >=1.14.2,<1.14.4.0a0",
-            "libgcc-ng >=12",
-            "libstdcxx-ng >=12",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "lzo >=2.10,<3.0a0",
-            "numexpr",
-            "numpy >=1.23.5,<2.0a0",
-            "packaging",
-            "py-cpuinfo",
-            "python >=3.11,<3.12.0a0",
-            "python_abi 3.11.* *_cp311"
-          ],
-          "license_family": "BSD"
-        },
-        "pytables-3.9.2-py311h10c7f7f_1.conda": {
-          "depends": [
-            "blosc >=1.21.5,<2.0a0",
-            "bzip2 >=1.0.8,<2.0a0",
-            "c-blosc2 >=2.11.3,<3.0a0",
-            "hdf5 >=1.14.2,<1.14.4.0a0",
-            "libgcc-ng >=12",
-            "libstdcxx-ng >=12",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "lzo >=2.10,<3.0a0",
-            "numexpr",
-            "numpy >=1.23.5,<2.0a0",
-            "packaging",
-            "py-cpuinfo",
-            "python >=3.11,<3.12.0a0",
-            "python_abi 3.11.* *_cp311"
-          ],
-          "license_family": "BSD"
-        },
-        "qt-5.15.8-hf11cfaa_0.conda": {
-          "license_family": "LGPL"
-        },
-        "qt-main-5.15.8-h5810be5_19.conda": {
-          "license_family": "LGPL"
-        },
-        "qt-webengine-5.15.8-h7517aa4_5.conda": {
-          "depends": [
-            "__glibc >=2.17,<3.0.a0",
-            "alsa-lib >=1.2.10,<1.2.11.0a0",
-            "dbus >=1.13.6,<2.0a0",
-            "fontconfig >=2.14.2,<3.0a0",
-            "fonts-conda-ecosystem",
-            "freetype >=2.12.1,<3.0a0",
-            "gst-plugins-base >=1.22.7,<1.23.0a0",
-            "gstreamer >=1.22.7,<1.23.0a0",
-            "harfbuzz >=8.3.0,<9.0a0",
-            "libcups >=2.3.3,<2.4.0a0",
-            "libevent >=2.1.12,<2.1.13.0a0",
-            "libexpat >=2.5.0,<3.0a0",
-            "libgcc-ng >=12",
-            "libglib >=2.78.3,<3.0a0",
-            "libiconv >=1.17,<2.0a0",
-            "libjpeg-turbo >=3.0.0,<4.0a0",
-            "libopus >=1.3.1,<2.0a0",
-            "libpng >=1.6.39,<1.7.0a0",
-            "libsqlite >=3.44.2,<4.0a0",
-            "libstdcxx-ng >=12",
-            "libwebp",
-            "libwebp-base >=1.3.2,<2.0a0",
-            "libxcb >=1.15,<1.16.0a0",
-            "libxkbcommon >=1.6.0,<2.0a0",
-            "libxml2 >=2.12.3,<3.0.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "nspr >=4.35,<5.0a0",
-            "nss >=3.96,<4.0a0",
-            "pulseaudio-client >=16.1,<16.2.0a0",
-            "qt-main >=5.15.8,<5.16.0a0",
-            "xorg-libx11 >=1.8.7,<2.0a0",
-            "xorg-libxcomposite",
-            "xorg-libxdamage",
-            "xorg-libxext >=1.3.4,<2.0a0",
-            "xorg-libxfixes",
-            "xorg-libxrandr",
-            "xorg-libxrender >=0.9.11,<0.10.0a0",
-            "xorg-libxtst"
-          ],
-          "license_family": "LGPL"
-        },
-        "readline-8.2-h8228510_1.conda": {
-          "license_family": "GPL"
-        },
-        "reproc-14.2.4.post0-hd590300_1.conda": {
-          "license_family": "MIT"
-        },
-        "reproc-cpp-14.2.4.post0-h59595ed_1.conda": {
-          "license_family": "MIT"
-        },
-        "rpds-py-0.18.0-py311h46250e7_0.conda": {
-          "license_family": "MIT"
-        },
-        "ruamel.yaml-0.18.6-py311h459d7ec_0.conda": {
-          "license_family": "MIT"
-        },
-        "scikit-learn-1.4.1.post1-py311hc009520_0.conda": {
-          "license_family": "BSD"
-        },
-        "scipy-1.12.0-py311h64a7726_2.conda": {
-          "license_family": "BSD"
-        },
-        "tbb-2021.11.0-h00ab1b0_1.conda": {
-          "license_family": "APACHE"
-        },
-        "zstandard-0.22.0-py311haa97af0_0.conda": {
-          "license_family": "BSD"
-        },
-        "zstd-1.5.5-hfc55251_0.conda": {
-          "license_family": "BSD"
-        }
-      },
-      "patch_instructions_version": 1,
-      "remove": [],
-      "revoke": []
-    },
-    "packages.conda": {
-      "astropy-6.0.0-py311h1f0f07a_0.conda": {
-        "license_family": "BSD"
-      },
-      "blosc-1.21.5-h0f2a231_0.conda": {
-        "license_family": "BSD"
-      },
-      "brotli-1.1.0-hd590300_1.conda": {
-        "license_family": "MIT"
-      },
-      "brotli-bin-1.1.0-hd590300_1.conda": {
-        "license_family": "MIT"
-      },
-      "brotli-python-1.1.0-py311hb755f60_1.conda": {
-        "license_family": "MIT"
-      },
-      "cffi-1.16.0-py311hb3a22ac_0.conda": {
-        "license_family": "MIT"
-      },
-      "cfitsio-4.2.0-hd9d235c_0.conda": {
-        "depends": [
-          "bzip2 >=1.0.8,<2.0a0",
-          "libcurl >=7.86.0,<9.0a0",
-          "libgcc-ng >=12",
-          "libgfortran-ng",
-          "libgfortran5 >=10.4.0",
-          "libzlib >=1.2.13,<1.3.0a0"
-        ]
-      },
-      "conda-23.11.0-py311h38be061_1.conda": {
-        "license_family": "BSD"
-      },
-      "contourpy-1.2.0-py311h9547e67_0.conda": {
-        "license_family": "BSD"
-      },
-      "coverage-7.4.3-py311h459d7ec_1.conda": {
-        "license_family": "APACHE"
-      },
-      "cython-3.0.8-py311hb755f60_0.conda": {
-        "license_family": "APACHE"
-      },
-      "fontconfig-2.14.2-h14ed4e7_0.conda": {
-        "license_family": "MIT"
-      },
-      "giflib-5.2.1-h0b41bf4_3.conda": {
-        "license_family": "MIT"
-      },
-      "gst-plugins-base-1.22.9-h8e1006c_0.conda": {
-        "license_family": "LGPL"
-      },
-      "gstreamer-1.22.9-h98fc4e7_0.conda": {
-        "license_family": "LGPL"
-      },
-      "h5py-3.10.0-nompi_py311hebc2b07_101.conda": {
-        "license_family": "BSD"
-      },
-      "harfbuzz-8.3.0-h3d44ed6_0.conda": {
-        "license_family": "MIT"
-      },
-      "icu-73.2-h59595ed_0.conda": {
-        "license_family": "MIT"
-      },
-      "jsonpointer-2.4-py311h38be061_3.conda": {
-        "license_family": "BSD"
-      },
-      "krb5-1.21.2-h659d440_0.conda": {
-        "license_family": "MIT"
-      },
-      "ld_impl_linux-64-2.40-h41732ed_0.conda": {
-        "license_family": "GPL"
-      },
-      "libarchive-3.7.2-h2aa1ff5_1.conda": {
-        "depends": [
-          "bzip2 >=1.0.8,<2.0a0",
-          "libgcc-ng >=12",
-          "libxml2 >=2.12.2,<3.0.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "lz4-c >=1.9.3,<1.10.0a0",
-          "lzo >=2.10,<3.0a0",
-          "openssl >=3.2.0,<4.0a0",
-          "xz >=5.2.6,<6.0a0",
-          "zstd >=1.5.5,<1.6.0a0"
-        ]
-      },
-      "libbrotlicommon-1.1.0-hd590300_1.conda": {
-        "license_family": "MIT"
-      },
-      "libbrotlidec-1.1.0-hd590300_1.conda": {
-        "license_family": "MIT"
-      },
-      "libbrotlienc-1.1.0-hd590300_1.conda": {
-        "license_family": "MIT"
-      },
-      "libdeflate-1.19-hd590300_0.conda": {
-        "license_family": "MIT"
-      },
-      "libgcc-ng-13.2.0-h807b86a_5.conda": {
-        "license_family": "GPL"
-      },
-      "libgfortran-ng-13.2.0-h69a702a_5.conda": {
-        "license_family": "GPL"
-      },
-      "libgfortran5-13.2.0-ha4646dd_5.conda": {
-        "license_family": "GPL"
-      },
-      "libhwloc-2.9.3-default_h554bfaf_1009.conda": {
-        "depends": [
-          "libgcc-ng >=12",
-          "libstdcxx-ng >=12",
-          "libxml2 >=2.11.5,<3.0.0a0"
-        ],
-        "license_family": "BSD"
-      },
-      "libllvm15-15.0.7-hb3ce162_4.conda": {
-        "depends": [
-          "libgcc-ng >=12",
-          "libstdcxx-ng >=12",
-          "libxml2 >=2.12.1,<3.0.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "zstd >=1.5.5,<1.6.0a0"
-        ]
-      },
-      "libstdcxx-ng-13.2.0-h7e041cc_5.conda": {
-        "license_family": "GPL"
-      },
-      "libuuid-2.38.1-h0b41bf4_0.conda": {
-        "license_family": "BSD"
-      },
-      "libwebp-1.3.2-h658648e_1.conda": {
-        "license_family": "BSD"
-      },
-      "libwebp-base-1.3.2-hd590300_0.conda": {
-        "license_family": "BSD"
-      },
-      "libxkbcommon-1.6.0-hd429924_1.conda": {
-        "depends": [
-          "libgcc-ng >=12",
-          "libstdcxx-ng >=12",
-          "libxcb >=1.15,<1.16.0a0",
-          "libxml2 >=2.12.1,<3.0.0a0",
-          "xkeyboard-config",
-          "xorg-libxau >=1.0.11,<2.0a0"
-        ]
-      },
-      "libxslt-1.1.39-h76b75d6_0.conda": {
-        "depends": [
-          "libgcc-ng >=12",
-          "libxml2 >=2.12.1,<3.0.0a0"
-        ],
-        "license_family": "MIT"
-      },
-      "llvm-openmp-17.0.6-h4dfa4b3_0.conda": {
-        "license_family": "APACHE"
-      },
-      "llvmlite-0.42.0-py311ha6695c7_1.conda": {
-        "license_family": "BSD"
-      },
-      "lxml-5.1.0-py311h9691dec_0.conda": {
-        "depends": [
-          "libgcc-ng >=12",
-          "libxml2 >=2.12.3,<3.0.0a0",
-          "libxslt >=1.1.39,<2.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "python >=3.11,<3.12.0a0",
-          "python_abi 3.11.* *_cp311"
-        ]
-      },
-      "lz4-c-1.9.4-hcb278e6_0.conda": {
-        "license_family": "BSD"
-      },
-      "mkl_fft-1.3.8-py311h8e1fd07_0.conda": {
-        "license_family": "BSD"
-      },
-      "nodejs-20.9.0-hb753e55_0.conda": {
-        "license_family": "MIT"
-      },
-      "nspr-4.35-h27087fc_0.conda": {
-        "license_family": "MOZILLA"
-      },
-      "nss-3.98-h1d7d5a4_0.conda": {
-        "license_family": "MOZILLA"
-      },
-      "numexpr-2.8.4-mkl_py311hbaa3ca7_1.conda": {
-        "license_family": "MIT"
-      },
-      "numpy-1.26.4-py311h64a7726_0.conda": {
-        "license_family": "BSD"
-      },
-      "openjpeg-2.5.1-h488ebb8_0.conda": {
-        "license_family": "BSD"
-      },
-      "pandas-2.2.1-py311h320fe9a_0.conda": {
-        "license_family": "BSD"
-      },
-      "patchelf-0.17.2-h58526e2_0.conda": {
-        "license_family": "GPL"
-      },
-      "pixman-0.43.2-h59595ed_0.conda": {
-        "license_family": "MIT"
-      },
-      "pycosat-0.6.6-py311h459d7ec_0.conda": {
-        "license_family": "MIT"
-      },
-      "pytables-3.8.0-py311h10c7f7f_4.conda": {
-        "depends": [
-          "blosc >=1.21.5,<2.0a0",
-          "bzip2 >=1.0.8,<2.0a0",
-          "c-blosc2 >=2.10.2,<3.0a0",
-          "hdf5 >=1.14.2,<1.14.4.0a0",
-          "libgcc-ng >=12",
-          "libstdcxx-ng >=12",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "lzo >=2.10,<3.0a0",
-          "numexpr",
-          "numpy >=1.23.5,<2.0a0",
-          "packaging",
-          "py-cpuinfo",
-          "python >=3.11,<3.12.0a0",
-          "python_abi 3.11.* *_cp311"
-        ],
-        "license_family": "BSD"
-      },
-      "pytables-3.9.2-py311h10c7f7f_1.conda": {
-        "depends": [
-          "blosc >=1.21.5,<2.0a0",
-          "bzip2 >=1.0.8,<2.0a0",
-          "c-blosc2 >=2.11.3,<3.0a0",
-          "hdf5 >=1.14.2,<1.14.4.0a0",
-          "libgcc-ng >=12",
-          "libstdcxx-ng >=12",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "lzo >=2.10,<3.0a0",
-          "numexpr",
-          "numpy >=1.23.5,<2.0a0",
-          "packaging",
-          "py-cpuinfo",
-          "python >=3.11,<3.12.0a0",
-          "python_abi 3.11.* *_cp311"
-        ],
-        "license_family": "BSD"
-      },
-      "qt-5.15.8-hf11cfaa_0.conda": {
-        "license_family": "LGPL"
-      },
-      "qt-main-5.15.8-h5810be5_19.conda": {
-        "license_family": "LGPL"
-      },
-      "qt-webengine-5.15.8-h7517aa4_5.conda": {
-        "depends": [
-          "__glibc >=2.17,<3.0.a0",
-          "alsa-lib >=1.2.10,<1.2.11.0a0",
-          "dbus >=1.13.6,<2.0a0",
-          "fontconfig >=2.14.2,<3.0a0",
-          "fonts-conda-ecosystem",
-          "freetype >=2.12.1,<3.0a0",
-          "gst-plugins-base >=1.22.7,<1.23.0a0",
-          "gstreamer >=1.22.7,<1.23.0a0",
-          "harfbuzz >=8.3.0,<9.0a0",
-          "libcups >=2.3.3,<2.4.0a0",
-          "libevent >=2.1.12,<2.1.13.0a0",
-          "libexpat >=2.5.0,<3.0a0",
-          "libgcc-ng >=12",
-          "libglib >=2.78.3,<3.0a0",
-          "libiconv >=1.17,<2.0a0",
-          "libjpeg-turbo >=3.0.0,<4.0a0",
-          "libopus >=1.3.1,<2.0a0",
-          "libpng >=1.6.39,<1.7.0a0",
-          "libsqlite >=3.44.2,<4.0a0",
-          "libstdcxx-ng >=12",
-          "libwebp",
-          "libwebp-base >=1.3.2,<2.0a0",
-          "libxcb >=1.15,<1.16.0a0",
-          "libxkbcommon >=1.6.0,<2.0a0",
-          "libxml2 >=2.12.3,<3.0.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "nspr >=4.35,<5.0a0",
-          "nss >=3.96,<4.0a0",
-          "pulseaudio-client >=16.1,<16.2.0a0",
-          "qt-main >=5.15.8,<5.16.0a0",
-          "xorg-libx11 >=1.8.7,<2.0a0",
-          "xorg-libxcomposite",
-          "xorg-libxdamage",
-          "xorg-libxext >=1.3.4,<2.0a0",
-          "xorg-libxfixes",
-          "xorg-libxrandr",
-          "xorg-libxrender >=0.9.11,<0.10.0a0",
-          "xorg-libxtst"
-        ],
-        "license_family": "LGPL"
-      },
-      "readline-8.2-h8228510_1.conda": {
-        "license_family": "GPL"
-      },
-      "reproc-14.2.4.post0-hd590300_1.conda": {
-        "license_family": "MIT"
-      },
-      "reproc-cpp-14.2.4.post0-h59595ed_1.conda": {
-        "license_family": "MIT"
-      },
-      "rpds-py-0.18.0-py311h46250e7_0.conda": {
-        "license_family": "MIT"
-      },
-      "ruamel.yaml-0.18.6-py311h459d7ec_0.conda": {
-        "license_family": "MIT"
-      },
-      "scikit-learn-1.4.1.post1-py311hc009520_0.conda": {
-        "license_family": "BSD"
-      },
-      "scipy-1.12.0-py311h64a7726_2.conda": {
-        "license_family": "BSD"
-      },
-      "tbb-2021.11.0-h00ab1b0_1.conda": {
-        "license_family": "APACHE"
-      },
-      "zstandard-0.22.0-py311haa97af0_0.conda": {
-        "license_family": "BSD"
-      },
-      "zstd-1.5.5-hfc55251_0.conda": {
-        "license_family": "BSD"
-      }
-    },
-    "patch_instructions_version": 1,
-    "remove": [],
-    "revoke": []
+    }
   },
   "packages.conda": {
-    "astropy-6.0.0-py311h1f0f07a_0.conda": {
+    "astropy-base-7.0.0-py312h3f257a2_3.conda": {
       "license_family": "BSD"
     },
-    "blosc-1.21.5-h0f2a231_0.conda": {
+    "blas-2.126-mkl.conda": {
       "license_family": "BSD"
     },
-    "brotli-1.1.0-hd590300_1.conda": {
-      "license_family": "MIT"
-    },
-    "brotli-bin-1.1.0-hd590300_1.conda": {
-      "license_family": "MIT"
-    },
-    "brotli-python-1.1.0-py311hb755f60_1.conda": {
-      "license_family": "MIT"
-    },
-    "cffi-1.16.0-py311hb3a22ac_0.conda": {
-      "license_family": "MIT"
-    },
-    "cfitsio-4.2.0-hd9d235c_0.conda": {
-      "depends": [
-        "bzip2 >=1.0.8,<2.0a0",
-        "libcurl >=7.86.0,<9.0a0",
-        "libgcc-ng >=12",
-        "libgfortran-ng",
-        "libgfortran5 >=10.4.0",
-        "libzlib >=1.2.13,<1.3.0a0"
-      ]
-    },
-    "conda-23.11.0-py311h38be061_1.conda": {
+    "blas-devel-3.9.0-26_linux64_mkl.conda": {
       "license_family": "BSD"
     },
-    "contourpy-1.2.0-py311h9547e67_0.conda": {
+    "blosc-1.21.6-he440d0b_1.conda": {
       "license_family": "BSD"
     },
-    "coverage-7.4.3-py311h459d7ec_1.conda": {
+    "brotli-1.1.0-hb9d3cd8_2.conda": {
+      "license_family": "MIT"
+    },
+    "brotli-bin-1.1.0-hb9d3cd8_2.conda": {
+      "license_family": "MIT"
+    },
+    "brotli-python-1.1.0-py312h2ec8cdc_2.conda": {
+      "license_family": "MIT"
+    },
+    "cffi-1.17.1-py312h06ac9bb_0.conda": {
+      "license_family": "MIT"
+    },
+    "conda-24.11.2-py312h7900ff3_0.conda": {
+      "license_family": "BSD"
+    },
+    "contourpy-1.3.1-py312h68727a3_0.conda": {
+      "license_family": "BSD"
+    },
+    "coverage-7.6.10-py312h178313f_0.conda": {
       "license_family": "APACHE"
     },
-    "cython-3.0.8-py311hb755f60_0.conda": {
+    "cython-3.0.11-py312h8fd2918_3.conda": {
       "license_family": "APACHE"
     },
-    "fontconfig-2.14.2-h14ed4e7_0.conda": {
+    "fontconfig-2.15.0-h7e30c49_1.conda": {
       "license_family": "MIT"
     },
-    "giflib-5.2.1-h0b41bf4_3.conda": {
-      "license_family": "MIT"
-    },
-    "gst-plugins-base-1.22.9-h8e1006c_0.conda": {
-      "license_family": "LGPL"
-    },
-    "gstreamer-1.22.9-h98fc4e7_0.conda": {
-      "license_family": "LGPL"
-    },
-    "h5py-3.10.0-nompi_py311hebc2b07_101.conda": {
-      "license_family": "BSD"
-    },
-    "harfbuzz-8.3.0-h3d44ed6_0.conda": {
-      "license_family": "MIT"
-    },
-    "icu-73.2-h59595ed_0.conda": {
-      "license_family": "MIT"
-    },
-    "jsonpointer-2.4-py311h38be061_3.conda": {
-      "license_family": "BSD"
-    },
-    "krb5-1.21.2-h659d440_0.conda": {
-      "license_family": "MIT"
-    },
-    "ld_impl_linux-64-2.40-h41732ed_0.conda": {
-      "license_family": "GPL"
-    },
-    "libarchive-3.7.2-h2aa1ff5_1.conda": {
+    "freetype-2.12.1-h267a509_2.conda": {
       "depends": [
-        "bzip2 >=1.0.8,<2.0a0",
         "libgcc-ng >=12",
-        "libxml2 >=2.12.2,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "lz4-c >=1.9.3,<1.10.0a0",
-        "lzo >=2.10,<3.0a0",
-        "openssl >=3.2.0,<4.0a0",
-        "xz >=5.2.6,<6.0a0",
-        "zstd >=1.5.5,<1.6.0a0"
+        "libpng >=1.6.39,<1.7.0a0",
+        "libzlib >=1.2.13,<2.0.0a0"
       ]
     },
-    "libbrotlicommon-1.1.0-hd590300_1.conda": {
-      "license_family": "MIT"
+    "frozenlist-1.5.0-py312h66e93f0_0.conda": {
+      "license_family": "APACHE"
     },
-    "libbrotlidec-1.1.0-hd590300_1.conda": {
-      "license_family": "MIT"
-    },
-    "libbrotlienc-1.1.0-hd590300_1.conda": {
-      "license_family": "MIT"
-    },
-    "libdeflate-1.19-hd590300_0.conda": {
-      "license_family": "MIT"
-    },
-    "libgcc-ng-13.2.0-h807b86a_5.conda": {
+    "gettext-tools-0.22.5-he02047a_3.conda": {
       "license_family": "GPL"
     },
-    "libgfortran-ng-13.2.0-h69a702a_5.conda": {
+    "gflags-2.2.2-h5888daf_1005.conda": {
+      "license_family": "BSD"
+    },
+    "giflib-5.2.2-hd590300_0.conda": {
+      "license_family": "MIT"
+    },
+    "glog-0.7.1-hbabe93e_0.conda": {
+      "license_family": "BSD"
+    },
+    "graphite2-1.3.13-h59595ed_1003.conda": {
+      "license_family": "LGPL"
+    },
+    "gst-plugins-base-1.24.7-h0a52356_0.conda": {
+      "depends": [
+        "__glibc >=2.17,<3.0.a0",
+        "alsa-lib >=1.2.12,<1.3.0a0",
+        "gstreamer 1.24.7 hf3bb09a_0",
+        "libexpat >=2.6.2,<3.0a0",
+        "libgcc >=13",
+        "libglib >=2.80.3,<3.0a0",
+        "libogg >=1.3.5,<1.4.0a0",
+        "libopus >=1.3.1,<2.0a0",
+        "libpng >=1.6.43,<1.7.0a0",
+        "libstdcxx >=13",
+        "libvorbis >=1.3.7,<1.4.0a0",
+        "libxcb >=1.16,<2.0.0a0",
+        "libzlib >=1.3.1,<2.0a0",
+        "xorg-libx11 >=1.8.9,<2.0a0",
+        "xorg-libxau >=1.0.11,<2.0a0",
+        "xorg-libxext >=1.3.4,<2.0a0",
+        "xorg-libxrender >=0.9.11,<0.10.0a0",
+        "xorg-libxxf86vm >=1.1.5,<2.0a0"
+      ],
+      "license_family": "LGPL"
+    },
+    "gstreamer-1.24.7-hf3bb09a_0.conda": {
+      "license_family": "LGPL"
+    },
+    "h5py-3.12.1-nompi_py312hd203070_103.conda": {
+      "license_family": "BSD"
+    },
+    "harfbuzz-9.0.0-hda332d3_1.conda": {
+      "license_family": "MIT"
+    },
+    "icu-75.1-he02047a_0.conda": {
+      "license_family": "MIT"
+    },
+    "jsonpointer-3.0.0-py312h7900ff3_1.conda": {
+      "license_family": "BSD"
+    },
+    "krb5-1.21.3-h659f571_0.conda": {
+      "license_family": "MIT"
+    },
+    "lcms2-2.16-hb7c19ff_0.conda": {
+      "depends": [
+        "libgcc-ng >=12",
+        "libjpeg-turbo >=3.0.0,<4.0a0",
+        "libtiff >=4.6.0,<4.8.0a0"
+      ]
+    },
+    "ld_impl_linux-64-2.43-h712a8e2_2.conda": {
       "license_family": "GPL"
     },
-    "libgfortran5-13.2.0-ha4646dd_5.conda": {
+    "libblas-3.9.0-26_linux64_mkl.conda": {
+      "license_family": "BSD"
+    },
+    "libbrotlicommon-1.1.0-hb9d3cd8_2.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlidec-1.1.0-hb9d3cd8_2.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlienc-1.1.0-hb9d3cd8_2.conda": {
+      "license_family": "MIT"
+    },
+    "libcblas-3.9.0-26_linux64_mkl.conda": {
+      "license_family": "BSD"
+    },
+    "libcups-2.3.3-h4637d8d_4.conda": {
+      "depends": [
+        "krb5 >=1.21.1,<1.22.0a0",
+        "libgcc-ng >=12",
+        "libstdcxx-ng >=12",
+        "libzlib >=1.2.13,<2.0.0a0"
+      ]
+    },
+    "libdeflate-1.23-h4ddbbb0_0.conda": {
+      "license_family": "MIT"
+    },
+    "libgcc-14.2.0-h77fa898_1.conda": {
       "license_family": "GPL"
     },
-    "libhwloc-2.9.3-default_h554bfaf_1009.conda": {
+    "libgcc-ng-14.2.0-h69a702a_1.conda": {
+      "license_family": "GPL"
+    },
+    "libgettextpo-0.22.5-he02047a_3.conda": {
+      "license_family": "GPL"
+    },
+    "libgettextpo-devel-0.22.5-he02047a_3.conda": {
+      "license_family": "GPL"
+    },
+    "libgfortran-14.2.0-h69a702a_1.conda": {
+      "license_family": "GPL"
+    },
+    "libgfortran5-14.2.0-hd5240d6_1.conda": {
+      "license_family": "GPL"
+    },
+    "libgomp-14.2.0-h77fa898_1.conda": {
+      "license_family": "GPL"
+    },
+    "libhwloc-2.11.2-default_h0d58e46_1001.conda": {
+      "license_family": "BSD"
+    },
+    "liblapack-3.9.0-26_linux64_mkl.conda": {
+      "license_family": "BSD"
+    },
+    "liblapacke-3.9.0-26_linux64_mkl.conda": {
+      "license_family": "BSD"
+    },
+    "libllvm14-14.0.6-hcd5def8_4.conda": {
       "depends": [
         "libgcc-ng >=12",
         "libstdcxx-ng >=12",
-        "libxml2 >=2.11.5,<3.0.0a0"
-      ],
-      "license_family": "BSD"
+        "libzlib >=1.2.13,<2.0.0a0"
+      ]
     },
     "libllvm15-15.0.7-hb3ce162_4.conda": {
       "depends": [
         "libgcc-ng >=12",
         "libstdcxx-ng >=12",
         "libxml2 >=2.12.1,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
         "zstd >=1.5.5,<1.6.0a0"
       ]
     },
-    "libstdcxx-ng-13.2.0-h7e041cc_5.conda": {
+    "libogg-1.3.5-h4ab18f5_0.conda": {
+      "license_family": "BSD"
+    },
+    "libopenblas-0.3.28-pthreads_h94d23a6_1.conda": {
+      "license_family": "BSD"
+    },
+    "libre2-11-2024.07.02-hbbce691_2.conda": {
+      "license_family": "BSD"
+    },
+    "libstdcxx-14.2.0-hc0a3c3a_1.conda": {
       "license_family": "GPL"
+    },
+    "libstdcxx-ng-14.2.0-h4852527_1.conda": {
+      "license_family": "GPL"
+    },
+    "libthrift-0.21.0-h0e7cc3e_0.conda": {
+      "license_family": "APACHE"
     },
     "libuuid-2.38.1-h0b41bf4_0.conda": {
       "license_family": "BSD"
     },
-    "libwebp-1.3.2-h658648e_1.conda": {
+    "libwebp-1.5.0-hae8dbeb_0.conda": {
       "license_family": "BSD"
     },
-    "libwebp-base-1.3.2-hd590300_0.conda": {
+    "libwebp-base-1.5.0-h851e524_0.conda": {
       "license_family": "BSD"
     },
-    "libxkbcommon-1.6.0-hd429924_1.conda": {
+    "libxkbcommon-1.7.0-h2c5496b_1.conda": {
       "depends": [
         "libgcc-ng >=12",
         "libstdcxx-ng >=12",
-        "libxcb >=1.15,<1.16.0a0",
-        "libxml2 >=2.12.1,<3.0.0a0",
+        "libxcb >=1.16,<2.0.0a0",
+        "libxml2 >=2.12.7,<3.0a0",
         "xkeyboard-config",
         "xorg-libxau >=1.0.11,<2.0a0"
       ]
@@ -1007,135 +273,123 @@
       ],
       "license_family": "MIT"
     },
-    "llvm-openmp-17.0.6-h4dfa4b3_0.conda": {
+    "llvm-openmp-19.1.6-h024ca30_0.conda": {
       "license_family": "APACHE"
     },
-    "llvmlite-0.42.0-py311ha6695c7_1.conda": {
-      "license_family": "BSD"
-    },
-    "lxml-5.1.0-py311h9691dec_0.conda": {
+    "llvmlite-0.42.0-py312hb06c811_1.conda": {
       "depends": [
         "libgcc-ng >=12",
-        "libxml2 >=2.12.3,<3.0.0a0",
-        "libxslt >=1.1.39,<2.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "python >=3.11,<3.12.0a0",
-        "python_abi 3.11.* *_cp311"
-      ]
-    },
-    "lz4-c-1.9.4-hcb278e6_0.conda": {
+        "libllvm14 >=14.0.6,<14.1.0a0",
+        "libstdcxx-ng >=12",
+        "libzlib >=1.2.13,<2.0.0a0",
+        "python >=3.12,<3.13.0a0",
+        "python_abi 3.12.* *_cp312"
+      ],
       "license_family": "BSD"
     },
-    "mkl_fft-1.3.8-py311h8e1fd07_0.conda": {
+    "llvmlite-0.43.0-py312h374181b_1.conda": {
       "license_family": "BSD"
     },
-    "nodejs-20.9.0-hb753e55_0.conda": {
+    "lz4-c-1.10.0-h5888daf_1.conda": {
+      "license_family": "BSD"
+    },
+    "mkl_fft-1.3.11-py312hb970456_0.conda": {
+      "license_family": "BSD"
+    },
+    "multidict-6.1.0-py312h178313f_2.conda": {
+      "license_family": "APACHE"
+    },
+    "mysql-common-9.0.1-h266115a_4.conda": {
+      "license_family": "GPL"
+    },
+    "mysql-libs-9.0.1-he0572af_4.conda": {
+      "license_family": "GPL"
+    },
+    "nodejs-22.12.0-hf235a45_0.conda": {
       "license_family": "MIT"
     },
-    "nspr-4.35-h27087fc_0.conda": {
+    "nspr-4.36-h5888daf_0.conda": {
       "license_family": "MOZILLA"
     },
-    "nss-3.98-h1d7d5a4_0.conda": {
+    "nss-3.107-hdf54f9c_0.conda": {
       "license_family": "MOZILLA"
     },
-    "numexpr-2.8.4-mkl_py311hbaa3ca7_1.conda": {
+    "numexpr-2.10.2-mkl_py312hacae085_0.conda": {
       "license_family": "MIT"
     },
-    "numpy-1.26.4-py311h64a7726_0.conda": {
+    "numpy-1.26.4-py312heda63a1_0.conda": {
       "license_family": "BSD"
     },
-    "openjpeg-2.5.1-h488ebb8_0.conda": {
+    "openjpeg-2.5.3-h5fbd93e_0.conda": {
       "license_family": "BSD"
     },
-    "pandas-2.2.1-py311h320fe9a_0.conda": {
+    "pandas-2.2.3-py312hf9745cd_1.conda": {
       "license_family": "BSD"
     },
     "patchelf-0.17.2-h58526e2_0.conda": {
       "license_family": "GPL"
     },
-    "pixman-0.43.2-h59595ed_0.conda": {
+    "pixman-0.44.2-h29eaf8c_0.conda": {
       "license_family": "MIT"
     },
-    "pycosat-0.6.6-py311h459d7ec_0.conda": {
+    "pkg-config-0.29.2-h4bc722e_1009.conda": {
+      "license_family": "GPL"
+    },
+    "propcache-0.2.1-py312h66e93f0_0.conda": {
+      "license_family": "APACHE"
+    },
+    "pyarrow-18.1.0-py312h7900ff3_0.conda": {
+      "license_family": "APACHE"
+    },
+    "pyarrow-core-18.1.0-py312h01725c0_0_cpu.conda": {
+      "license_family": "APACHE"
+    },
+    "pycosat-0.6.6-py312h66e93f0_2.conda": {
       "license_family": "MIT"
     },
-    "pytables-3.8.0-py311h10c7f7f_4.conda": {
-      "depends": [
-        "blosc >=1.21.5,<2.0a0",
-        "bzip2 >=1.0.8,<2.0a0",
-        "c-blosc2 >=2.10.2,<3.0a0",
-        "hdf5 >=1.14.2,<1.14.4.0a0",
-        "libgcc-ng >=12",
-        "libstdcxx-ng >=12",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "lzo >=2.10,<3.0a0",
-        "numexpr",
-        "numpy >=1.23.5,<2.0a0",
-        "packaging",
-        "py-cpuinfo",
-        "python >=3.11,<3.12.0a0",
-        "python_abi 3.11.* *_cp311"
-      ],
+    "pytables-3.10.1-py312hf8651a9_4.conda": {
       "license_family": "BSD"
     },
-    "pytables-3.9.2-py311h10c7f7f_1.conda": {
-      "depends": [
-        "blosc >=1.21.5,<2.0a0",
-        "bzip2 >=1.0.8,<2.0a0",
-        "c-blosc2 >=2.11.3,<3.0a0",
-        "hdf5 >=1.14.2,<1.14.4.0a0",
-        "libgcc-ng >=12",
-        "libstdcxx-ng >=12",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "lzo >=2.10,<3.0a0",
-        "numexpr",
-        "numpy >=1.23.5,<2.0a0",
-        "packaging",
-        "py-cpuinfo",
-        "python >=3.11,<3.12.0a0",
-        "python_abi 3.11.* *_cp311"
-      ],
+    "pyzmq-26.2.0-py312hbf22597_3.conda": {
       "license_family": "BSD"
     },
     "qt-5.15.8-hf11cfaa_0.conda": {
       "license_family": "LGPL"
     },
-    "qt-main-5.15.8-h5810be5_19.conda": {
+    "qt-main-5.15.8-h374914d_26.conda": {
       "license_family": "LGPL"
     },
-    "qt-webengine-5.15.8-h7517aa4_5.conda": {
+    "qt-webengine-5.15.8-h8f589be_8.conda": {
       "depends": [
         "__glibc >=2.17,<3.0.a0",
-        "alsa-lib >=1.2.10,<1.2.11.0a0",
+        "alsa-lib >=1.2.12,<1.3.0a0",
         "dbus >=1.13.6,<2.0a0",
         "fontconfig >=2.14.2,<3.0a0",
         "fonts-conda-ecosystem",
         "freetype >=2.12.1,<3.0a0",
-        "gst-plugins-base >=1.22.7,<1.23.0a0",
-        "gstreamer >=1.22.7,<1.23.0a0",
-        "harfbuzz >=8.3.0,<9.0a0",
+        "harfbuzz >=9.0.0,<10.0a0",
         "libcups >=2.3.3,<2.4.0a0",
         "libevent >=2.1.12,<2.1.13.0a0",
-        "libexpat >=2.5.0,<3.0a0",
+        "libexpat >=2.6.2,<3.0a0",
         "libgcc-ng >=12",
-        "libglib >=2.78.3,<3.0a0",
+        "libglib >=2.80.3,<3.0a0",
         "libiconv >=1.17,<2.0a0",
         "libjpeg-turbo >=3.0.0,<4.0a0",
         "libopus >=1.3.1,<2.0a0",
-        "libpng >=1.6.39,<1.7.0a0",
-        "libsqlite >=3.44.2,<4.0a0",
+        "libpng >=1.6.43,<1.7.0a0",
+        "libsqlite >=3.46.0,<4.0a0",
         "libstdcxx-ng >=12",
         "libwebp",
-        "libwebp-base >=1.3.2,<2.0a0",
-        "libxcb >=1.15,<1.16.0a0",
-        "libxkbcommon >=1.6.0,<2.0a0",
-        "libxml2 >=2.12.3,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
+        "libwebp-base >=1.4.0,<2.0a0",
+        "libxcb >=1.16,<2.0.0a0",
+        "libxkbcommon >=1.7.0,<2.0a0",
+        "libxml2 >=2.12.7,<3.0a0",
+        "libzlib >=1.3.1,<2.0a0",
         "nspr >=4.35,<5.0a0",
-        "nss >=3.96,<4.0a0",
-        "pulseaudio-client >=16.1,<16.2.0a0",
+        "nss >=3.102,<4.0a0",
+        "pulseaudio-client >=17.0,<17.1.0a0",
         "qt-main >=5.15.8,<5.16.0a0",
-        "xorg-libx11 >=1.8.7,<2.0a0",
+        "xorg-libx11 >=1.8.9,<2.0a0",
         "xorg-libxcomposite",
         "xorg-libxdamage",
         "xorg-libxext >=1.3.4,<2.0a0",
@@ -1146,34 +400,104 @@
       ],
       "license_family": "LGPL"
     },
+    "re2-2024.07.02-h9925aae_2.conda": {
+      "license_family": "BSD"
+    },
     "readline-8.2-h8228510_1.conda": {
       "license_family": "GPL"
     },
-    "reproc-14.2.4.post0-hd590300_1.conda": {
+    "reproc-14.2.5.post0-hb9d3cd8_0.conda": {
       "license_family": "MIT"
     },
-    "reproc-cpp-14.2.4.post0-h59595ed_1.conda": {
+    "reproc-cpp-14.2.5.post0-h5888daf_0.conda": {
       "license_family": "MIT"
     },
-    "rpds-py-0.18.0-py311h46250e7_0.conda": {
+    "rpds-py-0.22.3-py312h12e396e_0.conda": {
       "license_family": "MIT"
     },
-    "ruamel.yaml-0.18.6-py311h459d7ec_0.conda": {
+    "ruamel.yaml-0.18.6-py312h66e93f0_1.conda": {
       "license_family": "MIT"
     },
-    "scikit-learn-1.4.1.post1-py311hc009520_0.conda": {
+    "scikit-learn-1.6.0-py312h7a48858_0.conda": {
       "license_family": "BSD"
     },
-    "scipy-1.12.0-py311h64a7726_2.conda": {
+    "scipy-1.14.1-py312h62794b6_2.conda": {
       "license_family": "BSD"
     },
-    "tbb-2021.11.0-h00ab1b0_1.conda": {
+    "simdjson-3.11.3-h84d6215_0.conda": {
       "license_family": "APACHE"
     },
-    "zstandard-0.22.0-py311haa97af0_0.conda": {
+    "sqlalchemy-2.0.36-py312h66e93f0_0.conda": {
+      "license_family": "MIT"
+    },
+    "tbb-2021.13.0-hceb3a55_1.conda": {
+      "license_family": "APACHE"
+    },
+    "tk-8.6.13-noxft_h4845f30_101.conda": {
+      "depends": [
+        "libgcc-ng >=12",
+        "libzlib >=1.2.13,<2.0.0a0"
+      ]
+    },
+    "wayland-1.23.1-h3e06ad9_0.conda": {
+      "license_family": "MIT"
+    },
+    "wrapt-1.17.0-py312h66e93f0_0.conda": {
       "license_family": "BSD"
     },
-    "zstd-1.5.5-hfc55251_0.conda": {
+    "xcb-util-0.4.1-hb711507_2.conda": {
+      "depends": [
+        "libgcc-ng >=12",
+        "libxcb >=1.16,<2.0.0a0"
+      ]
+    },
+    "xcb-util-cursor-0.1.5-hb9d3cd8_0.conda": {
+      "depends": [
+        "__glibc >=2.17,<3.0.a0",
+        "libgcc >=13",
+        "libxcb >=1.13",
+        "libxcb >=1.16,<2.0.0a0",
+        "xcb-util-image >=0.4.0,<0.5.0a0",
+        "xcb-util-renderutil >=0.3.10,<0.4.0a0"
+      ]
+    },
+    "xcb-util-image-0.4.0-hb711507_2.conda": {
+      "depends": [
+        "libgcc-ng >=12",
+        "libxcb >=1.16,<2.0.0a0",
+        "xcb-util >=0.4.1,<0.5.0a0"
+      ]
+    },
+    "xcb-util-keysyms-0.4.1-hb711507_0.conda": {
+      "depends": [
+        "libgcc-ng >=12",
+        "libxcb >=1.16,<2.0.0a0"
+      ]
+    },
+    "xcb-util-renderutil-0.3.10-hb711507_0.conda": {
+      "depends": [
+        "libgcc-ng >=12",
+        "libxcb >=1.16,<2.0.0a0"
+      ]
+    },
+    "xcb-util-wm-0.4.2-hb711507_0.conda": {
+      "depends": [
+        "libgcc-ng >=12",
+        "libxcb >=1.16,<2.0.0a0"
+      ]
+    },
+    "zeromq-4.3.5-h3b0a872_7.conda": {
+      "license_family": "MOZILLA"
+    },
+    "zstandard-0.23.0-py312hef9b889_1.conda": {
+      "license_family": "BSD"
+    },
+    "zstd-1.5.6-ha6fb4c9_0.conda": {
+      "depends": [
+        "libgcc-ng >=12",
+        "libstdcxx-ng >=12",
+        "libzlib >=1.2.13,<2.0.0a0"
+      ],
       "license_family": "BSD"
     }
   },

--- a/patch_instructions/noarch/patch_instructions.json
+++ b/patch_instructions/noarch/patch_instructions.json
@@ -1,46 +1,16 @@
 {
   "packages": {
-    "astroquery-0.4.6-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "colorama-0.4.6-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "decorator-5.1.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
     "django-3.1.7-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
-    },
-    "entrypoints-0.4-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MOZILLA"
     },
     "imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "MIT"
     },
-    "isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
+    "locket-1.0.0-pyhd8ed1ab_0.tar.bz2": {
+      "license_family": "BSD"
     },
     "pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
-    },
-    "pickleshare-0.7.5-py_1003.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "pycparser-2.21-pyhd8ed1ab_0.tar.bz2": {
-      "depends": [
-        "python ==2.7.*|>=3.4"
-      ],
-      "license_family": "BSD"
-    },
-    "python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "APACHE"
-    },
-    "rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
     },
     "rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2": {
       "license_family": "MIT"
@@ -51,929 +21,343 @@
     "snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
     },
-    "tomli-2.0.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2": {
+    "sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "APACHE"
     },
-    "appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "babel-2.11.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "blinker-1.5-pyhd8ed1ab_0.tar.bz2": {
+    "traittypes-0.2.1-pyh9f0ad1d_2.tar.bz2": {
       "depends": [
-        "python ==2.7.*|>=3.5"
+        "python",
+        "traitlets >=4.2.2"
       ],
-      "license_family": "MIT"
-    },
-    "charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "cycler-0.11.0-pyhd8ed1ab_0.tar.bz2": {
       "license_family": "BSD"
     },
-    "glob2-0.7-py_0.tar.bz2": {
+    "nomkl-1.0-h5ca1d4c_0.tar.bz2": {
       "license_family": "BSD"
-    },
-    "idna-3.4-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "jira-3.4.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "joblib-1.2.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "jplephem-2.18-pyh78acc04_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "jupyter_console-6.4.4-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "nbclassic-0.4.8-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "notebook-shim-0.2.2-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "numpydoc-1.5.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "python-docx-0.8.11-pyhd8ed1ab_0.tar.bz2": {
-      "depends": [
-        "lxml >=2.3.2",
-        "python ==2.7.*|>=3.4"
-      ],
-      "license_family": "MIT"
-    },
-    "qtconsole-5.4.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "qtconsole-base-5.4.0-pyha770c72_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "qtpy-2.3.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "requests-toolbelt-0.10.1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "APACHE"
-    },
-    "smmap-3.0.5-pyh44b312d_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "sphinx-argparse-0.3.1-pyhd8ed1ab_0.tar.bz2": {
-      "depends": [
-        "commonmark >=0.5.6",
-        "python ==2.7.*|>=3.6",
-        "sphinx"
-      ],
-      "license_family": "MIT"
-    },
-    "sqlparse-0.4.3-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "tenacity-8.1.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "APACHE"
-    },
-    "terminado-0.17.0-pyh08f2357_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "toolz-0.12.0-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "websocket-client-1.4.2-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "APACHE"
-    },
-    "wheel-0.38.4-pyhd8ed1ab_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "packages": {
-      "packages": {
-        "astroquery-0.4.6-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "colorama-0.4.6-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "decorator-5.1.1-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "django-3.1.7-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "entrypoints-0.4-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "MOZILLA"
-        },
-        "imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "pickleshare-0.7.5-py_1003.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "pycparser-2.21-pyhd8ed1ab_0.tar.bz2": {
-          "depends": [
-            "python ==2.7.*|>=3.4"
-          ],
-          "license_family": "BSD"
-        },
-        "python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "APACHE"
-        },
-        "rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "smmap-5.0.0-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "tomli-2.0.1-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2": {
-          "license_family": "APACHE"
-        }
-      },
-      "packages.conda": {
-        "alabaster-0.7.16-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "astropy-iers-data-0.2024.2.26.0.28.55-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "astropy-sphinx-theme-1.1-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "async-lru-2.0.4-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "babel-2.14.0-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "backports-1.0-pyhd8ed1ab_3.conda": {
-          "license_family": "BSD"
-        },
-        "blinker-1.7.0-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "boltons-23.1.1-pyhd8ed1ab_0.conda": {
-          "depends": [
-            "python ==2.7.*|>=3.7"
-          ],
-          "license_family": "BSD"
-        },
-        "charset-normalizer-3.3.2-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "cloudpickle-3.0.0-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "conda-index-0.4.0-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "conda-package-streaming-0.9.0-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "configobj-5.0.8-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "cycler-0.12.1-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "distro-1.9.0-pyhd8ed1ab_0.conda": {
-          "license_family": "APACHE"
-        },
-        "gitdb-4.0.11-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "idna-3.6-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "importlib_resources-6.1.2-pyhd8ed1ab_0.conda": {
-          "license_family": "APACHE"
-        },
-        "isort-5.13.2-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "jinja2-3.1.3-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "jira-3.6.0-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "joblib-1.3.2-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "jplephem-2.21-pyh864a33b_0.conda": {
-          "license_family": "MIT"
-        },
-        "json5-0.9.17-pyhd8ed1ab_0.conda": {
-          "license_family": "APACHE"
-        },
-        "jsonschema-4.21.1-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "jupyter_console-6.6.3-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "jupyter_server_terminals-0.5.2-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "jupyterlab_server-2.25.3-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "mpld3-0.5.10-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "nb_conda_kernels-2.3.1-pyh707e725_4.conda": {
-          "license_family": "BSD"
-        },
-        "nb_conda_kernels-2.3.1-pyh7428d3b_4.conda": {
-          "license_family": "BSD"
-        },
-        "nbclassic-1.0.0-pyhb4ecaf3_1.conda": {
-          "license_family": "BSD"
-        },
-        "nbconvert-7.16.1-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "nbconvert-core-7.16.1-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "nbformat-5.9.2-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "notebook-shim-0.2.4-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "numpydoc-1.6.0-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "packaging-23.2-pyhd8ed1ab_0.conda": {
-          "license_family": "APACHE"
-        },
-        "pathspec-0.12.1-pyhd8ed1ab_0.conda": {
-          "license_family": "MOZILLA"
-        },
-        "platformdirs-4.2.0-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "plotly-5.19.0-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "prompt-toolkit-3.0.42-pyha770c72_0.conda": {
-          "license_family": "BSD"
-        },
-        "prompt_toolkit-3.0.42-hd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "pyflakes-3.2.0-pyhd8ed1ab_0.conda": {
-          "depends": [
-            "python ==2.7.*|>=3.5"
-          ]
-        },
-        "pygments-2.17.2-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "pylint-3.1.0-pyhd8ed1ab_0.conda": {
-          "license_family": "GPL"
-        },
-        "pyparsing-3.1.1-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "pytest-7.4.4-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "pytest-8.0.2-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "pytest-timeout-2.2.0-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "python-docx-1.1.0-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "python-tzdata-2024.1-pyhd8ed1ab_0.conda": {
-          "license_family": "APACHE"
-        },
-        "pytoolconfig-1.2.5-pyhd8ed1ab_0.conda": {
-          "license_family": "LGPL"
-        },
-        "pytz-2024.1-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "qtconsole-5.5.1-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "qtconsole-base-5.5.1-pyha770c72_0.conda": {
-          "license_family": "BSD"
-        },
-        "qtpy-2.4.1-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "referencing-0.33.0-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "requests-2.31.0-pyhd8ed1ab_0.conda": {
-          "license_family": "APACHE"
-        },
-        "requests-toolbelt-1.0.0-pyhd8ed1ab_0.conda": {
-          "license_family": "APACHE"
-        },
-        "rope-1.12.0-pyhd8ed1ab_0.conda": {
-          "license_family": "LGPL"
-        },
-        "setuptools-scm-8.0.4-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "setuptools_scm-8.0.4-hd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "soupsieve-2.5-pyhd8ed1ab_1.conda": {
-          "license_family": "MIT"
-        },
-        "sphinx-7.2.6-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "sphinx-argparse-0.4.0-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "sqlparse-0.4.4-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "tenacity-8.2.3-pyhd8ed1ab_0.conda": {
-          "license_family": "APACHE"
-        },
-        "terminado-0.18.0-pyh0d859eb_0.conda": {
-          "license_family": "BSD"
-        },
-        "terminado-0.18.0-pyh31c8845_0.conda": {
-          "license_family": "BSD"
-        },
-        "terminado-0.18.0-pyh5737063_0.conda": {
-          "license_family": "BSD"
-        },
-        "traitlets-5.14.1-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "truststore-0.8.0-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "wcwidth-0.2.13-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        },
-        "webcolors-1.13-pyhd8ed1ab_0.conda": {
-          "license_family": "BSD"
-        },
-        "webencodings-0.5.1-pyhd8ed1ab_2.conda": {
-          "license_family": "BSD"
-        },
-        "websocket-client-1.7.0-pyhd8ed1ab_0.conda": {
-          "license_family": "APACHE"
-        },
-        "wheel-0.42.0-pyhd8ed1ab_0.conda": {
-          "license_family": "MIT"
-        }
-      },
-      "patch_instructions_version": 1,
-      "remove": [],
-      "revoke": []
-    },
-    "packages.conda": {
-      "alabaster-0.7.16-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "astropy-iers-data-0.2024.2.26.0.28.55-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "astropy-sphinx-theme-1.1-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "async-lru-2.0.4-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "babel-2.14.0-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "backports-1.0-pyhd8ed1ab_3.conda": {
-        "license_family": "BSD"
-      },
-      "blinker-1.7.0-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "boltons-23.1.1-pyhd8ed1ab_0.conda": {
-        "depends": [
-          "python ==2.7.*|>=3.7"
-        ],
-        "license_family": "BSD"
-      },
-      "charset-normalizer-3.3.2-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "cloudpickle-3.0.0-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "conda-index-0.4.0-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "conda-package-streaming-0.9.0-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "configobj-5.0.8-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "cycler-0.12.1-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "distro-1.9.0-pyhd8ed1ab_0.conda": {
-        "license_family": "APACHE"
-      },
-      "gitdb-4.0.11-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "idna-3.6-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "importlib_resources-6.1.2-pyhd8ed1ab_0.conda": {
-        "license_family": "APACHE"
-      },
-      "isort-5.13.2-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "jinja2-3.1.3-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "jira-3.6.0-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "joblib-1.3.2-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "jplephem-2.21-pyh864a33b_0.conda": {
-        "license_family": "MIT"
-      },
-      "json5-0.9.17-pyhd8ed1ab_0.conda": {
-        "license_family": "APACHE"
-      },
-      "jsonschema-4.21.1-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "jupyter_console-6.6.3-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "jupyter_server_terminals-0.5.2-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "jupyterlab_server-2.25.3-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "mpld3-0.5.10-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "nb_conda_kernels-2.3.1-pyh707e725_4.conda": {
-        "license_family": "BSD"
-      },
-      "nb_conda_kernels-2.3.1-pyh7428d3b_4.conda": {
-        "license_family": "BSD"
-      },
-      "nbclassic-1.0.0-pyhb4ecaf3_1.conda": {
-        "license_family": "BSD"
-      },
-      "nbconvert-7.16.1-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "nbconvert-core-7.16.1-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "nbformat-5.9.2-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "notebook-shim-0.2.4-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "numpydoc-1.6.0-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "packaging-23.2-pyhd8ed1ab_0.conda": {
-        "license_family": "APACHE"
-      },
-      "pathspec-0.12.1-pyhd8ed1ab_0.conda": {
-        "license_family": "MOZILLA"
-      },
-      "platformdirs-4.2.0-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "plotly-5.19.0-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "prompt-toolkit-3.0.42-pyha770c72_0.conda": {
-        "license_family": "BSD"
-      },
-      "prompt_toolkit-3.0.42-hd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "pyflakes-3.2.0-pyhd8ed1ab_0.conda": {
-        "depends": [
-          "python ==2.7.*|>=3.5"
-        ]
-      },
-      "pygments-2.17.2-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "pylint-3.1.0-pyhd8ed1ab_0.conda": {
-        "license_family": "GPL"
-      },
-      "pyparsing-3.1.1-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "pytest-7.4.4-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "pytest-8.0.2-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "pytest-timeout-2.2.0-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "python-docx-1.1.0-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "python-tzdata-2024.1-pyhd8ed1ab_0.conda": {
-        "license_family": "APACHE"
-      },
-      "pytoolconfig-1.2.5-pyhd8ed1ab_0.conda": {
-        "license_family": "LGPL"
-      },
-      "pytz-2024.1-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "qtconsole-5.5.1-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "qtconsole-base-5.5.1-pyha770c72_0.conda": {
-        "license_family": "BSD"
-      },
-      "qtpy-2.4.1-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "referencing-0.33.0-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "requests-2.31.0-pyhd8ed1ab_0.conda": {
-        "license_family": "APACHE"
-      },
-      "requests-toolbelt-1.0.0-pyhd8ed1ab_0.conda": {
-        "license_family": "APACHE"
-      },
-      "rope-1.12.0-pyhd8ed1ab_0.conda": {
-        "license_family": "LGPL"
-      },
-      "setuptools-scm-8.0.4-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "setuptools_scm-8.0.4-hd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "soupsieve-2.5-pyhd8ed1ab_1.conda": {
-        "license_family": "MIT"
-      },
-      "sphinx-7.2.6-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "sphinx-argparse-0.4.0-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "sqlparse-0.4.4-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "tenacity-8.2.3-pyhd8ed1ab_0.conda": {
-        "license_family": "APACHE"
-      },
-      "terminado-0.18.0-pyh0d859eb_0.conda": {
-        "license_family": "BSD"
-      },
-      "terminado-0.18.0-pyh31c8845_0.conda": {
-        "license_family": "BSD"
-      },
-      "terminado-0.18.0-pyh5737063_0.conda": {
-        "license_family": "BSD"
-      },
-      "traitlets-5.14.1-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "truststore-0.8.0-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "wcwidth-0.2.13-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      },
-      "webcolors-1.13-pyhd8ed1ab_0.conda": {
-        "license_family": "BSD"
-      },
-      "webencodings-0.5.1-pyhd8ed1ab_2.conda": {
-        "license_family": "BSD"
-      },
-      "websocket-client-1.7.0-pyhd8ed1ab_0.conda": {
-        "license_family": "APACHE"
-      },
-      "wheel-0.42.0-pyhd8ed1ab_0.conda": {
-        "license_family": "MIT"
-      }
-    },
-    "patch_instructions_version": 1,
-    "remove": [],
-    "revoke": []
+    }
   },
   "packages.conda": {
-    "alabaster-0.7.16-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
+    "aiohappyeyeballs-2.4.4-pyhd8ed1ab_1.conda": {
+      "license_family": "PSF"
     },
-    "astropy-iers-data-0.2024.2.26.0.28.55-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "astropy-sphinx-theme-1.1-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "async-lru-2.0.4-pyhd8ed1ab_0.conda": {
-      "license_family": "MIT"
-    },
-    "babel-2.14.0-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "backports-1.0-pyhd8ed1ab_3.conda": {
-      "license_family": "BSD"
-    },
-    "blinker-1.7.0-pyhd8ed1ab_0.conda": {
-      "license_family": "MIT"
-    },
-    "boltons-23.1.1-pyhd8ed1ab_0.conda": {
-      "depends": [
-        "python ==2.7.*|>=3.7"
-      ],
-      "license_family": "BSD"
-    },
-    "charset-normalizer-3.3.2-pyhd8ed1ab_0.conda": {
-      "license_family": "MIT"
-    },
-    "conda-index-0.4.0-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "conda-package-streaming-0.9.0-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "configobj-5.0.8-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "cycler-0.12.1-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "distro-1.9.0-pyhd8ed1ab_0.conda": {
+    "aiosignal-1.3.2-pyhd8ed1ab_0.conda": {
       "license_family": "APACHE"
     },
-    "gitdb-4.0.11-pyhd8ed1ab_0.conda": {
+    "alabaster-1.0.0-pyhd8ed1ab_1.conda": {
       "license_family": "BSD"
     },
-    "idna-3.6-pyhd8ed1ab_0.conda": {
+    "astropy-7.0.0-pyhd8ed1ab_3.conda": {
       "license_family": "BSD"
     },
-    "importlib_resources-6.1.2-pyhd8ed1ab_0.conda": {
+    "astropy-iers-data-0.2024.12.30.0.33.36-pyhd8ed1ab_0.conda": {
+      "license_family": "BSD"
+    },
+    "astropy-sphinx-theme-1.1-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "astroquery-0.4.7-pyhd8ed1ab_2.conda": {
+      "license_family": "BSD"
+    },
+    "async-lru-2.0.4-pyhd8ed1ab_1.conda": {
+      "license_family": "MIT"
+    },
+    "babel-2.16.0-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "backports-1.0-pyhd8ed1ab_5.conda": {
+      "license_family": "BSD"
+    },
+    "backports.tarfile-1.2.0-pyhd8ed1ab_1.conda": {
+      "license_family": "MIT"
+    },
+    "blinker-1.9.0-pyhff2d567_0.conda": {
+      "license_family": "MIT"
+    },
+    "boltons-24.0.0-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "charset-normalizer-3.4.0-pyhd8ed1ab_1.conda": {
+      "license_family": "MIT"
+    },
+    "cloudpickle-3.1.0-pyhd8ed1ab_2.conda": {
+      "license_family": "BSD"
+    },
+    "colorama-0.4.6-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "conda-index-0.5.0-pyhd8ed1ab_0.conda": {
+      "license_family": "BSD"
+    },
+    "conda-package-streaming-0.11.0-pyhd8ed1ab_0.conda": {
+      "license_family": "BSD"
+    },
+    "configobj-5.0.9-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "cycler-0.12.1-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "dask-core-2024.12.1-pyhd8ed1ab_0.conda": {
+      "license_family": "BSD"
+    },
+    "decorator-5.1.1-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "distro-1.9.0-pyhd8ed1ab_1.conda": {
       "license_family": "APACHE"
     },
-    "isort-5.13.2-pyhd8ed1ab_0.conda": {
+    "entrypoints-0.4-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "jinja2-3.1.3-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "jira-3.6.0-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "joblib-1.3.2-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "jplephem-2.21-pyh864a33b_0.conda": {
-      "license_family": "MIT"
-    },
-    "json5-0.9.17-pyhd8ed1ab_0.conda": {
-      "license_family": "APACHE"
-    },
-    "jsonschema-4.21.1-pyhd8ed1ab_0.conda": {
-      "license_family": "MIT"
-    },
-    "jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda": {
-      "license_family": "MIT"
-    },
-    "jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda": {
-      "license_family": "MIT"
-    },
-    "jupyter_console-6.6.3-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "jupyter_server_terminals-0.5.2-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "jupyterlab_server-2.25.3-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "mpld3-0.5.10-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "nb_conda_kernels-2.3.1-pyh707e725_4.conda": {
-      "license_family": "BSD"
-    },
-    "nbclassic-1.0.0-pyhb4ecaf3_1.conda": {
-      "license_family": "BSD"
-    },
-    "nbconvert-7.16.1-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "nbconvert-core-7.16.1-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "nbformat-5.9.2-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "notebook-shim-0.2.4-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "numpydoc-1.6.0-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "packaging-23.2-pyhd8ed1ab_0.conda": {
-      "license_family": "APACHE"
-    },
-    "pathspec-0.12.1-pyhd8ed1ab_0.conda": {
+    "fqdn-1.5.1-pyhd8ed1ab_1.conda": {
       "license_family": "MOZILLA"
     },
-    "platformdirs-4.2.0-pyhd8ed1ab_0.conda": {
+    "fsspec-2024.12.0-pyhd8ed1ab_0.conda": {
+      "license_family": "BSD"
+    },
+    "gitdb-4.0.11-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "httpcore-1.0.7-pyh29332c3_1.conda": {
+      "license_family": "BSD"
+    },
+    "idna-3.10-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "importlib_resources-6.4.5-pyhd8ed1ab_1.conda": {
+      "license_family": "APACHE"
+    },
+    "ipydatagrid-1.4.0-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "isoduration-20.11.0-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "plotly-5.19.0-pyhd8ed1ab_0.conda": {
+    "isort-5.13.2-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "prompt-toolkit-3.0.42-pyha770c72_0.conda": {
+    "jinja2-3.1.5-pyhd8ed1ab_0.conda": {
       "license_family": "BSD"
     },
-    "prompt_toolkit-3.0.42-hd8ed1ab_0.conda": {
+    "jira-3.8.0-hd8ed1ab_1.conda": {
       "license_family": "BSD"
     },
-    "pyflakes-3.2.0-pyhd8ed1ab_0.conda": {
-      "depends": [
-        "python ==2.7.*|>=3.5"
-      ]
-    },
-    "pygments-2.17.2-pyhd8ed1ab_0.conda": {
+    "jira-base-3.8.0-pyhd8ed1ab_1.conda": {
       "license_family": "BSD"
     },
-    "pylint-3.1.0-pyhd8ed1ab_0.conda": {
+    "jira-with-cli-3.8.0-hd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "joblib-1.4.2-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "jplephem-2.21-pyh9b8db34_1.conda": {
+      "license_family": "MIT"
+    },
+    "json5-0.10.0-pyhd8ed1ab_1.conda": {
+      "license_family": "APACHE"
+    },
+    "jsonschema-4.23.0-pyhd8ed1ab_1.conda": {
+      "license_family": "MIT"
+    },
+    "jsonschema-specifications-2024.10.1-pyhd8ed1ab_1.conda": {
+      "license_family": "MIT"
+    },
+    "jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_1.conda": {
+      "license_family": "MIT"
+    },
+    "jupyter_console-6.6.3-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "jupyterlab_widgets-3.0.13-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "mpld3-0.5.10-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "mpmath-1.3.0-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "nb_conda_kernels-2.5.1-pyh707e725_2.conda": {
+      "license_family": "BSD"
+    },
+    "nbclassic-1.1.0-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "nbconvert-7.16.4-hd8ed1ab_3.conda": {
+      "license_family": "BSD"
+    },
+    "nbconvert-core-7.16.4-pyhd8ed1ab_3.conda": {
+      "license_family": "BSD"
+    },
+    "nbconvert-pandoc-7.16.4-hd8ed1ab_3.conda": {
+      "license_family": "BSD"
+    },
+    "nbformat-5.10.4-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "networkx-3.4.2-pyh267e887_2.conda": {
+      "license_family": "BSD"
+    },
+    "notebook-shim-0.2.4-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "numpydoc-1.8.0-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "packaging-24.2-pyhd8ed1ab_2.conda": {
+      "license_family": "APACHE"
+    },
+    "partd-1.4.2-pyhd8ed1ab_0.conda": {
+      "license_family": "BSD"
+    },
+    "pathspec-0.12.1-pyhd8ed1ab_1.conda": {
+      "license_family": "MOZILLA"
+    },
+    "pickleshare-0.7.5-pyhd8ed1ab_1004.conda": {
+      "license_family": "MIT"
+    },
+    "platformdirs-4.3.6-pyhd8ed1ab_1.conda": {
+      "license_family": "MIT"
+    },
+    "plotly-5.24.1-pyhd8ed1ab_1.conda": {
+      "license_family": "MIT"
+    },
+    "prompt-toolkit-3.0.48-pyha770c72_1.conda": {
+      "license_family": "BSD"
+    },
+    "prompt_toolkit-3.0.48-hd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "pycparser-2.22-pyh29332c3_1.conda": {
+      "license_family": "BSD"
+    },
+    "pygments-2.18.0-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "pylint-3.3.3-pyhd8ed1ab_0.conda": {
       "license_family": "GPL"
     },
-    "pyparsing-3.1.1-pyhd8ed1ab_0.conda": {
+    "pytest-8.3.4-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "pytest-7.4.4-pyhd8ed1ab_0.conda": {
+    "pytest-timeout-2.3.1-pyhd8ed1ab_2.conda": {
       "license_family": "MIT"
     },
-    "pytest-timeout-2.2.0-pyhd8ed1ab_0.conda": {
-      "license_family": "MIT"
-    },
-    "python-docx-1.1.0-pyhd8ed1ab_0.conda": {
-      "license_family": "MIT"
-    },
-    "python-tzdata-2024.1-pyhd8ed1ab_0.conda": {
+    "python-dateutil-2.9.0.post0-pyhff2d567_1.conda": {
       "license_family": "APACHE"
     },
-    "pytoolconfig-1.2.5-pyhd8ed1ab_0.conda": {
+    "python-docx-1.1.2-pyhff2d567_1.conda": {
+      "license_family": "MIT"
+    },
+    "python-tzdata-2024.2-pyhd8ed1ab_1.conda": {
+      "license_family": "APACHE"
+    },
+    "pytoolconfig-1.2.5-pyhd8ed1ab_1.conda": {
       "license_family": "LGPL"
     },
-    "pytz-2024.1-pyhd8ed1ab_0.conda": {
+    "pytz-2024.2-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "qtconsole-5.5.1-pyhd8ed1ab_0.conda": {
+    "qtconsole-5.6.1-pyhd8ed1ab_1.conda": {
       "license_family": "BSD"
     },
-    "qtconsole-base-5.5.1-pyha770c72_0.conda": {
+    "qtconsole-base-5.6.1-pyha770c72_1.conda": {
       "license_family": "BSD"
     },
-    "qtpy-2.4.1-pyhd8ed1ab_0.conda": {
+    "qtpy-2.4.2-pyhdecd6ff_0.conda": {
       "license_family": "MIT"
     },
-    "referencing-0.33.0-pyhd8ed1ab_0.conda": {
+    "referencing-0.35.1-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "requests-2.31.0-pyhd8ed1ab_0.conda": {
+    "requests-2.32.3-pyhd8ed1ab_1.conda": {
       "license_family": "APACHE"
     },
-    "requests-toolbelt-1.0.0-pyhd8ed1ab_0.conda": {
+    "requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda": {
       "license_family": "APACHE"
     },
-    "rope-1.12.0-pyhd8ed1ab_0.conda": {
+    "rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda": {
+      "license_family": "MIT"
+    },
+    "rope-1.13.0-pyhd8ed1ab_1.conda": {
       "license_family": "LGPL"
     },
-    "setuptools-scm-8.0.4-pyhd8ed1ab_0.conda": {
+    "s3fs-2024.12.0-pyhd8ed1ab_0.conda": {
+      "license_family": "BSD"
+    },
+    "setuptools-scm-8.1.0-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "setuptools_scm-8.0.4-hd8ed1ab_0.conda": {
+    "setuptools_scm-8.1.0-hd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
     "soupsieve-2.5-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "sphinx-7.2.6-pyhd8ed1ab_0.conda": {
+    "sphinx-8.1.3-pyhd8ed1ab_1.conda": {
       "license_family": "BSD"
     },
-    "sphinx-argparse-0.4.0-pyhd8ed1ab_0.conda": {
+    "sphinx-argparse-0.5.2-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "sqlparse-0.4.4-pyhd8ed1ab_0.conda": {
+    "sqlparse-0.5.3-pyhd8ed1ab_0.conda": {
       "license_family": "BSD"
     },
-    "tenacity-8.2.3-pyhd8ed1ab_0.conda": {
+    "tenacity-9.0.0-pyhd8ed1ab_1.conda": {
       "license_family": "APACHE"
     },
-    "terminado-0.18.0-pyh31c8845_0.conda": {
+    "terminado-0.18.1-pyh31c8845_0.conda": {
       "license_family": "BSD"
     },
-    "traitlets-5.14.1-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "truststore-0.8.0-pyhd8ed1ab_0.conda": {
+    "tomli-2.2.1-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "wcwidth-0.2.13-pyhd8ed1ab_0.conda": {
+    "toolz-1.0.0-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "traitlets-5.14.3-pyhd8ed1ab_1.conda": {
+      "license_family": "BSD"
+    },
+    "truststore-0.10.0-pyhd8ed1ab_0.conda": {
       "license_family": "MIT"
     },
-    "webcolors-1.13-pyhd8ed1ab_0.conda": {
-      "license_family": "BSD"
-    },
-    "webencodings-0.5.1-pyhd8ed1ab_2.conda": {
-      "license_family": "BSD"
-    },
-    "websocket-client-1.7.0-pyhd8ed1ab_0.conda": {
+    "typing_utils-0.1.0-pyhd8ed1ab_1.conda": {
       "license_family": "APACHE"
     },
-    "wheel-0.42.0-pyhd8ed1ab_0.conda": {
+    "wcwidth-0.2.13-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "cloudpickle-3.0.0-pyhd8ed1ab_0.conda": {
+    "webcolors-24.11.1-pyhd8ed1ab_0.conda": {
       "license_family": "BSD"
     },
-    "nb_conda_kernels-2.3.1-pyh7428d3b_4.conda": {
+    "webencodings-0.5.1-pyhd8ed1ab_3.conda": {
       "license_family": "BSD"
     },
-    "pytest-8.0.2-pyhd8ed1ab_0.conda": {
+    "websocket-client-1.8.0-pyhd8ed1ab_1.conda": {
+      "license_family": "APACHE"
+    },
+    "wheel-0.45.1-pyhd8ed1ab_1.conda": {
       "license_family": "MIT"
     },
-    "terminado-0.18.0-pyh0d859eb_0.conda": {
+    "django-5.1.4-pyhd8ed1ab_0.conda": {
       "license_family": "BSD"
     },
-    "terminado-0.18.0-pyh5737063_0.conda": {
+    "pytz-2024.1-pyhd8ed1ab_0.conda": {
+      "license_family": "MIT"
+    },
+    "terminado-0.18.1-pyh0d859eb_0.conda": {
+      "license_family": "BSD"
+    },
+    "terminado-0.18.1-pyh5737063_0.conda": {
+      "license_family": "BSD"
+    },
+    "nb_conda_kernels-2.5.1-pyh7428d3b_2.conda": {
       "license_family": "BSD"
     }
   },

--- a/patch_instructions/osx-64/patch_instructions.json
+++ b/patch_instructions/osx-64/patch_instructions.json
@@ -1,35 +1,5 @@
 {
   "packages": {
-    "brotli-1.0.9-hb7f2c08_8.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "brotli-bin-1.0.9-hb7f2c08_8.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "giflib-5.2.1-hbcb3906_2.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "h5py-3.7.0-nompi_py310h5555e59_102.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "icu-70.1-h96cf925_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "libblas-3.9.0-16_osx64_mkl.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "libbrotlicommon-1.0.9-hb7f2c08_8.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "libbrotlidec-1.0.9-hb7f2c08_8.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "libbrotlienc-1.0.9-hb7f2c08_8.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "libcblas-3.9.0-16_osx64_mkl.tar.bz2": {
-      "license_family": "BSD"
-    },
     "libedit-3.1.20191231-h0678c8f_2.tar.bz2": {
       "depends": [
         "ncurses >=6.2,<7.0.0a0"
@@ -38,707 +8,143 @@
     "libffi-3.4.2-h0d85af4_5.tar.bz2": {
       "license_family": "MIT"
     },
-    "liblapack-3.9.0-16_osx64_mkl.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "libogg-1.3.4-h35c211d_1.tar.bz2": {
-      "license_family": "BSD"
-    },
     "libopus-1.3.1-hc929b4f_1.tar.bz2": {
       "license_family": "BSD"
-    },
-    "libwebp-base-1.2.4-h775f41a_0.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "libxslt-1.1.37-h5d22bc9_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "llvmlite-0.39.1-py310h2bfb868_1.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "lz4-c-1.9.3-he49afe7_1.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "nb_conda_kernels-2.3.1-py310h2ec42d9_2.tar.bz2": {
-      "license_family": "BSD"
-    },
-    "nodejs-18.12.1-hd0c9b3c_0.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "nss-3.78-ha8197d3_0.tar.bz2": {
-      "license_family": "MOZILLA"
-    },
-    "numexpr-2.8.3-py310hecf8f37_1.tar.bz2": {
-      "license_family": "MIT"
     },
     "patch-2.7.6-hbcf498f_1002.tar.bz2": {
       "license_family": "GPL"
     },
-    "pkg-config-0.29.2-ha3d46e9_1008.tar.bz2": {
-      "depends": [
-        "libiconv >=1.16,<2.0.0a0"
-      ],
-      "license_family": "GPL"
-    },
-    "pycosat-0.6.4-py310h90acd4f_1.tar.bz2": {
-      "license_family": "MIT"
-    },
-    "readline-8.1.2-h3899abd_0.tar.bz2": {
-      "license_family": "GPL"
-    },
-    "ruamel.yaml-0.17.21-py310h90acd4f_2.tar.bz2": {
-      "license_family": "MIT"
-    },
     "sigtool-0.1.3-h88f4db0_0.tar.bz2": {
       "license_family": "MIT"
     },
-    "wrapt-1.14.1-py310h90acd4f_1.tar.bz2": {
-      "license_family": "BSD"
-    },
     "yaml-0.2.5-h0d85af4_2.tar.bz2": {
       "license_family": "MIT"
-    },
-    "zeromq-4.3.4-he49afe7_1.tar.bz2": {
-      "license_family": "LGPL"
-    },
-    "packages": {
-      "packages": {
-        "libedit-3.1.20191231-h0678c8f_2.tar.bz2": {
-          "depends": [
-            "ncurses >=6.2,<7.0.0a0"
-          ]
-        },
-        "libffi-3.4.2-h0d85af4_5.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "libogg-1.3.4-h35c211d_1.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "libopus-1.3.1-hc929b4f_1.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "patch-2.7.6-hbcf498f_1002.tar.bz2": {
-          "license_family": "GPL"
-        },
-        "sigtool-0.1.3-h88f4db0_0.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "yaml-0.2.5-h0d85af4_2.tar.bz2": {
-          "license_family": "MIT"
-        }
-      },
-      "packages.conda": {
-        "astropy-6.0.0-py311hc9a392d_0.conda": {
-          "license_family": "BSD"
-        },
-        "blosc-1.21.5-heccf04b_0.conda": {
-          "license_family": "BSD"
-        },
-        "brotli-1.1.0-h0dc2134_1.conda": {
-          "license_family": "MIT"
-        },
-        "brotli-bin-1.1.0-h0dc2134_1.conda": {
-          "license_family": "MIT"
-        },
-        "brotli-python-1.1.0-py311hdf8f085_1.conda": {
-          "license_family": "MIT"
-        },
-        "cffi-1.16.0-py311hc0b63fd_0.conda": {
-          "license_family": "MIT"
-        },
-        "conda-23.11.0-py311h6eed73b_1.conda": {
-          "license_family": "BSD"
-        },
-        "contourpy-1.2.0-py311h7bea37d_0.conda": {
-          "license_family": "BSD"
-        },
-        "coverage-7.4.3-py311he705e18_1.conda": {
-          "license_family": "APACHE"
-        },
-        "cython-3.0.8-py311hdd0406b_0.conda": {
-          "license_family": "APACHE"
-        },
-        "giflib-5.2.1-hb7f2c08_3.conda": {
-          "license_family": "MIT"
-        },
-        "gst-plugins-base-1.22.9-h3fb38fc_0.conda": {
-          "license_family": "LGPL"
-        },
-        "gstreamer-1.22.9-hf63bbb8_0.conda": {
-          "license_family": "LGPL"
-        },
-        "h5py-3.10.0-nompi_py311hf7b785c_101.conda": {
-          "license_family": "BSD"
-        },
-        "icu-73.2-hf5e326d_0.conda": {
-          "license_family": "MIT"
-        },
-        "jsonpointer-2.4-py311h6eed73b_3.conda": {
-          "license_family": "BSD"
-        },
-        "krb5-1.21.2-hb884880_0.conda": {
-          "license_family": "MIT"
-        },
-        "libarchive-3.7.2-hd35d340_1.conda": {
-          "depends": [
-            "bzip2 >=1.0.8,<2.0a0",
-            "libiconv >=1.17,<2.0a0",
-            "libxml2 >=2.12.2,<3.0.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "lz4-c >=1.9.3,<1.10.0a0",
-            "lzo >=2.10,<3.0a0",
-            "openssl >=3.2.0,<4.0a0",
-            "xz >=5.2.6,<6.0a0",
-            "zstd >=1.5.5,<1.6.0a0"
-          ]
-        },
-        "libblas-3.9.0-20_osx64_mkl.conda": {
-          "license_family": "BSD"
-        },
-        "libbrotlicommon-1.1.0-h0dc2134_1.conda": {
-          "license_family": "MIT"
-        },
-        "libbrotlidec-1.1.0-h0dc2134_1.conda": {
-          "license_family": "MIT"
-        },
-        "libbrotlienc-1.1.0-h0dc2134_1.conda": {
-          "license_family": "MIT"
-        },
-        "libcblas-3.9.0-20_osx64_mkl.conda": {
-          "license_family": "BSD"
-        },
-        "libdeflate-1.19-ha4e1b8e_0.conda": {
-          "license_family": "MIT"
-        },
-        "libhwloc-2.9.3-default_h24e0189_1009.conda": {
-          "depends": [
-            "__osx >=10.9",
-            "libcxx >=16.0.6",
-            "libxml2 >=2.11.5,<3.0.0a0"
-          ],
-          "license_family": "BSD"
-        },
-        "liblapack-3.9.0-20_osx64_mkl.conda": {
-          "license_family": "BSD"
-        },
-        "libllvm15-15.0.7-hbedff68_4.conda": {
-          "depends": [
-            "libcxx >=16",
-            "libxml2 >=2.12.1,<3.0.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "zstd >=1.5.5,<1.6.0a0"
-          ]
-        },
-        "libllvm16-16.0.6-hbedff68_3.conda": {
-          "depends": [
-            "libcxx >=16",
-            "libxml2 >=2.12.1,<3.0.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "zstd >=1.5.5,<1.6.0a0"
-          ]
-        },
-        "libwebp-1.3.2-h44782d1_1.conda": {
-          "license_family": "BSD"
-        },
-        "libwebp-base-1.3.2-h0dc2134_0.conda": {
-          "license_family": "BSD"
-        },
-        "libxslt-1.1.39-h03b04e6_0.conda": {
-          "depends": [
-            "libxml2 >=2.12.1,<3.0.0a0"
-          ],
-          "license_family": "MIT"
-        },
-        "llvm-openmp-17.0.6-hb6ac08f_0.conda": {
-          "license_family": "APACHE"
-        },
-        "llvmlite-0.42.0-py311hb5c2e0a_1.conda": {
-          "license_family": "BSD"
-        },
-        "lxml-5.1.0-py311h033124e_0.conda": {
-          "depends": [
-            "libxml2 >=2.12.3,<3.0.0a0",
-            "libxslt >=1.1.39,<2.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "python >=3.11,<3.12.0a0",
-            "python_abi 3.11.* *_cp311"
-          ]
-        },
-        "lz4-c-1.9.4-hf0c8a7f_0.conda": {
-          "license_family": "BSD"
-        },
-        "nodejs-20.9.0-h9adec40_0.conda": {
-          "license_family": "MIT"
-        },
-        "nspr-4.35-hea0b92c_0.conda": {
-          "license_family": "MOZILLA"
-        },
-        "nss-3.98-ha05da47_0.conda": {
-          "license_family": "MOZILLA"
-        },
-        "numexpr-2.8.4-py311hab14417_1.conda": {
-          "license_family": "MIT"
-        },
-        "numpy-1.26.4-py311hc43a94b_0.conda": {
-          "license_family": "BSD"
-        },
-        "openjpeg-2.5.1-h7310d3a_0.conda": {
-          "license_family": "BSD"
-        },
-        "pandas-2.2.1-py311h8f6166a_0.conda": {
-          "license_family": "BSD"
-        },
-        "pycosat-0.6.6-py311h2725bcf_0.conda": {
-          "license_family": "MIT"
-        },
-        "pyobjc-framework-cocoa-10.1-py311h9b70068_0.conda": {
-          "license_family": "MIT"
-        },
-        "pytables-3.8.0-py311h21e7aa0_4.conda": {
-          "depends": [
-            "blosc >=1.21.5,<2.0a0",
-            "bzip2 >=1.0.8,<2.0a0",
-            "c-blosc2 >=2.10.4,<3.0a0",
-            "hdf5 >=1.14.2,<1.14.4.0a0",
-            "libcxx >=15.0.7",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "numexpr",
-            "numpy >=1.23.5,<2.0a0",
-            "packaging",
-            "py-cpuinfo",
-            "python >=3.11,<3.12.0a0",
-            "python_abi 3.11.* *_cp311"
-          ],
-          "license_family": "BSD"
-        },
-        "pytables-3.9.2-py311h3cee394_1.conda": {
-          "depends": [
-            "__osx >=10.9",
-            "blosc >=1.21.5,<2.0a0",
-            "bzip2 >=1.0.8,<2.0a0",
-            "c-blosc2 >=2.11.3,<3.0a0",
-            "hdf5 >=1.14.2,<1.14.4.0a0",
-            "libcxx >=16.0.6",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "numexpr",
-            "numpy >=1.23.5,<2.0a0",
-            "packaging",
-            "py-cpuinfo",
-            "python >=3.11,<3.12.0a0",
-            "python_abi 3.11.* *_cp311"
-          ],
-          "license_family": "BSD"
-        },
-        "qt-5.15.8-h93fa01e_0.conda": {
-          "license_family": "LGPL"
-        },
-        "qt-main-5.15.8-h4385fff_19.conda": {
-          "license_family": "LGPL"
-        },
-        "qt-webengine-5.15.8-h5f65913_4.conda": {
-          "license_family": "LGPL"
-        },
-        "readline-8.2-h9e318b2_1.conda": {
-          "license_family": "GPL"
-        },
-        "reproc-14.2.4.post0-h10d778d_1.conda": {
-          "license_family": "MIT"
-        },
-        "reproc-cpp-14.2.4.post0-h93d8f39_1.conda": {
-          "license_family": "MIT"
-        },
-        "rpds-py-0.18.0-py311hd64b9fd_0.conda": {
-          "license_family": "MIT"
-        },
-        "ruamel.yaml-0.18.6-py311he705e18_0.conda": {
-          "license_family": "MIT"
-        },
-        "scikit-learn-1.4.1.post1-py311he2b4599_0.conda": {
-          "license_family": "BSD"
-        },
-        "scipy-1.12.0-py311h86d0cd9_2.conda": {
-          "license_family": "BSD"
-        },
-        "tbb-2021.11.0-h7728843_1.conda": {
-          "license_family": "APACHE"
-        },
-        "zeromq-4.3.5-h93d8f39_0.conda": {
-          "license_family": "MOZILLA"
-        },
-        "zstandard-0.22.0-py311hed14148_0.conda": {
-          "license_family": "BSD"
-        },
-        "zstd-1.5.5-h829000d_0.conda": {
-          "license_family": "BSD"
-        }
-      },
-      "patch_instructions_version": 1,
-      "remove": [],
-      "revoke": []
-    },
-    "packages.conda": {
-      "astropy-6.0.0-py311hc9a392d_0.conda": {
-        "license_family": "BSD"
-      },
-      "blosc-1.21.5-heccf04b_0.conda": {
-        "license_family": "BSD"
-      },
-      "brotli-1.1.0-h0dc2134_1.conda": {
-        "license_family": "MIT"
-      },
-      "brotli-bin-1.1.0-h0dc2134_1.conda": {
-        "license_family": "MIT"
-      },
-      "brotli-python-1.1.0-py311hdf8f085_1.conda": {
-        "license_family": "MIT"
-      },
-      "cffi-1.16.0-py311hc0b63fd_0.conda": {
-        "license_family": "MIT"
-      },
-      "conda-23.11.0-py311h6eed73b_1.conda": {
-        "license_family": "BSD"
-      },
-      "contourpy-1.2.0-py311h7bea37d_0.conda": {
-        "license_family": "BSD"
-      },
-      "coverage-7.4.3-py311he705e18_1.conda": {
-        "license_family": "APACHE"
-      },
-      "cython-3.0.8-py311hdd0406b_0.conda": {
-        "license_family": "APACHE"
-      },
-      "giflib-5.2.1-hb7f2c08_3.conda": {
-        "license_family": "MIT"
-      },
-      "gst-plugins-base-1.22.9-h3fb38fc_0.conda": {
-        "license_family": "LGPL"
-      },
-      "gstreamer-1.22.9-hf63bbb8_0.conda": {
-        "license_family": "LGPL"
-      },
-      "h5py-3.10.0-nompi_py311hf7b785c_101.conda": {
-        "license_family": "BSD"
-      },
-      "icu-73.2-hf5e326d_0.conda": {
-        "license_family": "MIT"
-      },
-      "jsonpointer-2.4-py311h6eed73b_3.conda": {
-        "license_family": "BSD"
-      },
-      "krb5-1.21.2-hb884880_0.conda": {
-        "license_family": "MIT"
-      },
-      "libarchive-3.7.2-hd35d340_1.conda": {
-        "depends": [
-          "bzip2 >=1.0.8,<2.0a0",
-          "libiconv >=1.17,<2.0a0",
-          "libxml2 >=2.12.2,<3.0.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "lz4-c >=1.9.3,<1.10.0a0",
-          "lzo >=2.10,<3.0a0",
-          "openssl >=3.2.0,<4.0a0",
-          "xz >=5.2.6,<6.0a0",
-          "zstd >=1.5.5,<1.6.0a0"
-        ]
-      },
-      "libblas-3.9.0-20_osx64_mkl.conda": {
-        "license_family": "BSD"
-      },
-      "libbrotlicommon-1.1.0-h0dc2134_1.conda": {
-        "license_family": "MIT"
-      },
-      "libbrotlidec-1.1.0-h0dc2134_1.conda": {
-        "license_family": "MIT"
-      },
-      "libbrotlienc-1.1.0-h0dc2134_1.conda": {
-        "license_family": "MIT"
-      },
-      "libcblas-3.9.0-20_osx64_mkl.conda": {
-        "license_family": "BSD"
-      },
-      "libdeflate-1.19-ha4e1b8e_0.conda": {
-        "license_family": "MIT"
-      },
-      "libhwloc-2.9.3-default_h24e0189_1009.conda": {
-        "depends": [
-          "__osx >=10.9",
-          "libcxx >=16.0.6",
-          "libxml2 >=2.11.5,<3.0.0a0"
-        ],
-        "license_family": "BSD"
-      },
-      "liblapack-3.9.0-20_osx64_mkl.conda": {
-        "license_family": "BSD"
-      },
-      "libllvm15-15.0.7-hbedff68_4.conda": {
-        "depends": [
-          "libcxx >=16",
-          "libxml2 >=2.12.1,<3.0.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "zstd >=1.5.5,<1.6.0a0"
-        ]
-      },
-      "libllvm16-16.0.6-hbedff68_3.conda": {
-        "depends": [
-          "libcxx >=16",
-          "libxml2 >=2.12.1,<3.0.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "zstd >=1.5.5,<1.6.0a0"
-        ]
-      },
-      "libwebp-1.3.2-h44782d1_1.conda": {
-        "license_family": "BSD"
-      },
-      "libwebp-base-1.3.2-h0dc2134_0.conda": {
-        "license_family": "BSD"
-      },
-      "libxslt-1.1.39-h03b04e6_0.conda": {
-        "depends": [
-          "libxml2 >=2.12.1,<3.0.0a0"
-        ],
-        "license_family": "MIT"
-      },
-      "llvm-openmp-17.0.6-hb6ac08f_0.conda": {
-        "license_family": "APACHE"
-      },
-      "llvmlite-0.42.0-py311hb5c2e0a_1.conda": {
-        "license_family": "BSD"
-      },
-      "lxml-5.1.0-py311h033124e_0.conda": {
-        "depends": [
-          "libxml2 >=2.12.3,<3.0.0a0",
-          "libxslt >=1.1.39,<2.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "python >=3.11,<3.12.0a0",
-          "python_abi 3.11.* *_cp311"
-        ]
-      },
-      "lz4-c-1.9.4-hf0c8a7f_0.conda": {
-        "license_family": "BSD"
-      },
-      "nodejs-20.9.0-h9adec40_0.conda": {
-        "license_family": "MIT"
-      },
-      "nspr-4.35-hea0b92c_0.conda": {
-        "license_family": "MOZILLA"
-      },
-      "nss-3.98-ha05da47_0.conda": {
-        "license_family": "MOZILLA"
-      },
-      "numexpr-2.8.4-py311hab14417_1.conda": {
-        "license_family": "MIT"
-      },
-      "numpy-1.26.4-py311hc43a94b_0.conda": {
-        "license_family": "BSD"
-      },
-      "openjpeg-2.5.1-h7310d3a_0.conda": {
-        "license_family": "BSD"
-      },
-      "pandas-2.2.1-py311h8f6166a_0.conda": {
-        "license_family": "BSD"
-      },
-      "pycosat-0.6.6-py311h2725bcf_0.conda": {
-        "license_family": "MIT"
-      },
-      "pyobjc-framework-cocoa-10.1-py311h9b70068_0.conda": {
-        "license_family": "MIT"
-      },
-      "pytables-3.8.0-py311h21e7aa0_4.conda": {
-        "depends": [
-          "blosc >=1.21.5,<2.0a0",
-          "bzip2 >=1.0.8,<2.0a0",
-          "c-blosc2 >=2.10.4,<3.0a0",
-          "hdf5 >=1.14.2,<1.14.4.0a0",
-          "libcxx >=15.0.7",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "numexpr",
-          "numpy >=1.23.5,<2.0a0",
-          "packaging",
-          "py-cpuinfo",
-          "python >=3.11,<3.12.0a0",
-          "python_abi 3.11.* *_cp311"
-        ],
-        "license_family": "BSD"
-      },
-      "pytables-3.9.2-py311h3cee394_1.conda": {
-        "depends": [
-          "__osx >=10.9",
-          "blosc >=1.21.5,<2.0a0",
-          "bzip2 >=1.0.8,<2.0a0",
-          "c-blosc2 >=2.11.3,<3.0a0",
-          "hdf5 >=1.14.2,<1.14.4.0a0",
-          "libcxx >=16.0.6",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "numexpr",
-          "numpy >=1.23.5,<2.0a0",
-          "packaging",
-          "py-cpuinfo",
-          "python >=3.11,<3.12.0a0",
-          "python_abi 3.11.* *_cp311"
-        ],
-        "license_family": "BSD"
-      },
-      "qt-5.15.8-h93fa01e_0.conda": {
-        "license_family": "LGPL"
-      },
-      "qt-main-5.15.8-h4385fff_19.conda": {
-        "license_family": "LGPL"
-      },
-      "qt-webengine-5.15.8-h5f65913_4.conda": {
-        "license_family": "LGPL"
-      },
-      "readline-8.2-h9e318b2_1.conda": {
-        "license_family": "GPL"
-      },
-      "reproc-14.2.4.post0-h10d778d_1.conda": {
-        "license_family": "MIT"
-      },
-      "reproc-cpp-14.2.4.post0-h93d8f39_1.conda": {
-        "license_family": "MIT"
-      },
-      "rpds-py-0.18.0-py311hd64b9fd_0.conda": {
-        "license_family": "MIT"
-      },
-      "ruamel.yaml-0.18.6-py311he705e18_0.conda": {
-        "license_family": "MIT"
-      },
-      "scikit-learn-1.4.1.post1-py311he2b4599_0.conda": {
-        "license_family": "BSD"
-      },
-      "scipy-1.12.0-py311h86d0cd9_2.conda": {
-        "license_family": "BSD"
-      },
-      "tbb-2021.11.0-h7728843_1.conda": {
-        "license_family": "APACHE"
-      },
-      "zeromq-4.3.5-h93d8f39_0.conda": {
-        "license_family": "MOZILLA"
-      },
-      "zstandard-0.22.0-py311hed14148_0.conda": {
-        "license_family": "BSD"
-      },
-      "zstd-1.5.5-h829000d_0.conda": {
-        "license_family": "BSD"
-      }
-    },
-    "patch_instructions_version": 1,
-    "remove": [],
-    "revoke": []
+    }
   },
   "packages.conda": {
-    "astropy-6.0.0-py311hc9a392d_0.conda": {
+    "astropy-base-7.0.0-py312h7322dab_3.conda": {
       "license_family": "BSD"
     },
-    "blosc-1.21.5-heccf04b_0.conda": {
+    "blosc-1.21.6-hd145fbb_1.conda": {
       "license_family": "BSD"
     },
-    "brotli-1.1.0-h0dc2134_1.conda": {
+    "brotli-1.1.0-h00291cd_2.conda": {
       "license_family": "MIT"
     },
-    "brotli-bin-1.1.0-h0dc2134_1.conda": {
+    "brotli-bin-1.1.0-h00291cd_2.conda": {
       "license_family": "MIT"
     },
-    "brotli-python-1.1.0-py311hdf8f085_1.conda": {
+    "brotli-python-1.1.0-py312h5861a67_2.conda": {
       "license_family": "MIT"
     },
-    "cffi-1.16.0-py311hc0b63fd_0.conda": {
+    "cffi-1.17.1-py312hf857d28_0.conda": {
       "license_family": "MIT"
     },
-    "conda-23.11.0-py311h6eed73b_1.conda": {
+    "conda-24.11.2-py312hb401068_0.conda": {
       "license_family": "BSD"
     },
-    "contourpy-1.2.0-py311h7bea37d_0.conda": {
+    "contourpy-1.3.1-py312hc47a885_0.conda": {
       "license_family": "BSD"
     },
-    "coverage-7.4.3-py311he705e18_1.conda": {
+    "coverage-7.6.10-py312h3520af0_0.conda": {
       "license_family": "APACHE"
     },
-    "cython-3.0.8-py311hdd0406b_0.conda": {
+    "cython-3.0.11-py312h6891801_3.conda": {
       "license_family": "APACHE"
     },
-    "giflib-5.2.1-hb7f2c08_3.conda": {
-      "license_family": "MIT"
-    },
-    "gst-plugins-base-1.22.9-h3fb38fc_0.conda": {
-      "license_family": "LGPL"
-    },
-    "gstreamer-1.22.9-hf63bbb8_0.conda": {
-      "license_family": "LGPL"
-    },
-    "h5py-3.10.0-nompi_py311hf7b785c_101.conda": {
-      "license_family": "BSD"
-    },
-    "icu-73.2-hf5e326d_0.conda": {
-      "license_family": "MIT"
-    },
-    "jsonpointer-2.4-py311h6eed73b_3.conda": {
-      "license_family": "BSD"
-    },
-    "krb5-1.21.2-hb884880_0.conda": {
-      "license_family": "MIT"
-    },
-    "libarchive-3.7.2-hd35d340_1.conda": {
+    "freetype-2.12.1-h60636b9_2.conda": {
       "depends": [
-        "bzip2 >=1.0.8,<2.0a0",
-        "libiconv >=1.17,<2.0a0",
-        "libxml2 >=2.12.2,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "lz4-c >=1.9.3,<1.10.0a0",
-        "lzo >=2.10,<3.0a0",
-        "openssl >=3.2.0,<4.0a0",
-        "xz >=5.2.6,<6.0a0",
-        "zstd >=1.5.5,<1.6.0a0"
+        "libpng >=1.6.39,<1.7.0a0",
+        "libzlib >=1.2.13,<2.0.0a0"
       ]
     },
-    "libblas-3.9.0-20_osx64_mkl.conda": {
+    "frozenlist-1.5.0-py312h3d0f464_0.conda": {
+      "license_family": "APACHE"
+    },
+    "gflags-2.2.2-hac325c4_1005.conda": {
       "license_family": "BSD"
     },
-    "libbrotlicommon-1.1.0-h0dc2134_1.conda": {
+    "giflib-5.2.2-h10d778d_0.conda": {
       "license_family": "MIT"
     },
-    "libbrotlidec-1.1.0-h0dc2134_1.conda": {
-      "license_family": "MIT"
-    },
-    "libbrotlienc-1.1.0-h0dc2134_1.conda": {
-      "license_family": "MIT"
-    },
-    "libcblas-3.9.0-20_osx64_mkl.conda": {
+    "glog-0.7.1-h2790a97_0.conda": {
       "license_family": "BSD"
     },
-    "libdeflate-1.19-ha4e1b8e_0.conda": {
+    "gst-plugins-base-1.24.7-h0ee1d58_0.conda": {
+      "license_family": "LGPL"
+    },
+    "gstreamer-1.24.7-h3271b85_0.conda": {
+      "license_family": "LGPL"
+    },
+    "h5py-3.12.1-nompi_py312hf5b0cce_103.conda": {
+      "license_family": "BSD"
+    },
+    "icu-75.1-h120a0e1_0.conda": {
       "license_family": "MIT"
     },
-    "libhwloc-2.9.3-default_h24e0189_1009.conda": {
+    "jsonpointer-3.0.0-py312hb401068_1.conda": {
+      "license_family": "BSD"
+    },
+    "krb5-1.21.3-h37d8d59_0.conda": {
+      "license_family": "MIT"
+    },
+    "lcms2-2.16-ha2f27b4_0.conda": {
       "depends": [
-        "__osx >=10.9",
-        "libcxx >=16.0.6",
-        "libxml2 >=2.11.5,<3.0.0a0"
-      ],
+        "libjpeg-turbo >=3.0.0,<4.0a0",
+        "libtiff >=4.6.0,<4.8.0a0"
+      ]
+    },
+    "libblas-3.9.0-26_osx64_openblas.conda": {
       "license_family": "BSD"
     },
-    "liblapack-3.9.0-20_osx64_mkl.conda": {
+    "libbrotlicommon-1.1.0-h00291cd_2.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlidec-1.1.0-h00291cd_2.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlienc-1.1.0-h00291cd_2.conda": {
+      "license_family": "MIT"
+    },
+    "libcblas-3.9.0-26_osx64_openblas.conda": {
       "license_family": "BSD"
+    },
+    "libdeflate-1.23-he65b83e_0.conda": {
+      "license_family": "MIT"
+    },
+    "liblapack-3.9.0-26_osx64_openblas.conda": {
+      "license_family": "BSD"
+    },
+    "libllvm14-14.0.6-hc8e404f_4.conda": {
+      "depends": [
+        "libcxx >=15",
+        "libzlib >=1.2.13,<2.0.0a0"
+      ]
     },
     "libllvm15-15.0.7-hbedff68_4.conda": {
       "depends": [
         "libcxx >=16",
         "libxml2 >=2.12.1,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
         "zstd >=1.5.5,<1.6.0a0"
       ]
     },
-    "libllvm16-16.0.6-hbedff68_3.conda": {
-      "depends": [
-        "libcxx >=16",
-        "libxml2 >=2.12.1,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "zstd >=1.5.5,<1.6.0a0"
-      ]
-    },
-    "libwebp-1.3.2-h44782d1_1.conda": {
+    "libogg-1.3.5-hfdf4475_0.conda": {
       "license_family": "BSD"
     },
-    "libwebp-base-1.3.2-h0dc2134_0.conda": {
+    "libopenblas-0.3.28-openmp_hbf64a52_1.conda": {
+      "license_family": "BSD"
+    },
+    "libre2-11-2024.07.02-h0e468a2_2.conda": {
+      "license_family": "BSD"
+    },
+    "libthrift-0.21.0-h75589b3_0.conda": {
+      "license_family": "APACHE"
+    },
+    "libwebp-1.5.0-h2bf92d2_0.conda": {
+      "license_family": "BSD"
+    },
+    "libwebp-base-1.5.0-h6cf52b4_0.conda": {
       "license_family": "BSD"
     },
     "libxslt-1.1.39-h03b04e6_0.conda": {
@@ -747,127 +153,174 @@
       ],
       "license_family": "MIT"
     },
-    "llvm-openmp-17.0.6-hb6ac08f_0.conda": {
+    "llvm-openmp-19.1.6-ha54dae1_0.conda": {
       "license_family": "APACHE"
     },
-    "llvmlite-0.42.0-py311hb5c2e0a_1.conda": {
-      "license_family": "BSD"
-    },
-    "lxml-5.1.0-py311h033124e_0.conda": {
+    "llvmlite-0.42.0-py312h534208b_1.conda": {
       "depends": [
-        "libxml2 >=2.12.3,<3.0.0a0",
-        "libxslt >=1.1.39,<2.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "python >=3.11,<3.12.0a0",
-        "python_abi 3.11.* *_cp311"
-      ]
-    },
-    "lz4-c-1.9.4-hf0c8a7f_0.conda": {
-      "license_family": "BSD"
-    },
-    "nodejs-20.9.0-h9adec40_0.conda": {
-      "license_family": "MIT"
-    },
-    "nspr-4.35-hea0b92c_0.conda": {
-      "license_family": "MOZILLA"
-    },
-    "nss-3.98-ha05da47_0.conda": {
-      "license_family": "MOZILLA"
-    },
-    "numexpr-2.8.4-py311hab14417_1.conda": {
-      "license_family": "MIT"
-    },
-    "numpy-1.26.4-py311hc43a94b_0.conda": {
-      "license_family": "BSD"
-    },
-    "openjpeg-2.5.1-h7310d3a_0.conda": {
-      "license_family": "BSD"
-    },
-    "pandas-2.2.1-py311h8f6166a_0.conda": {
-      "license_family": "BSD"
-    },
-    "pycosat-0.6.6-py311h2725bcf_0.conda": {
-      "license_family": "MIT"
-    },
-    "pyobjc-framework-cocoa-10.1-py311h9b70068_0.conda": {
-      "license_family": "MIT"
-    },
-    "pytables-3.8.0-py311h21e7aa0_4.conda": {
-      "depends": [
-        "blosc >=1.21.5,<2.0a0",
-        "bzip2 >=1.0.8,<2.0a0",
-        "c-blosc2 >=2.10.4,<3.0a0",
-        "hdf5 >=1.14.2,<1.14.4.0a0",
-        "libcxx >=15.0.7",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "numexpr",
-        "numpy >=1.23.5,<2.0a0",
-        "packaging",
-        "py-cpuinfo",
-        "python >=3.11,<3.12.0a0",
-        "python_abi 3.11.* *_cp311"
+        "libcxx >=16",
+        "libllvm14 >=14.0.6,<14.1.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
+        "python >=3.12,<3.13.0a0",
+        "python_abi 3.12.* *_cp312"
       ],
+      "license_family": "BSD"
+    },
+    "llvmlite-0.43.0-py312hcc8fd36_1.conda": {
+      "license_family": "BSD"
+    },
+    "lz4-c-1.10.0-h240833e_1.conda": {
+      "license_family": "BSD"
+    },
+    "multidict-6.1.0-py312h6f3313d_1.conda": {
+      "license_family": "APACHE"
+    },
+    "mysql-common-9.0.1-h4d37847_4.conda": {
+      "license_family": "GPL"
+    },
+    "mysql-libs-9.0.1-h2381dc1_4.conda": {
+      "license_family": "GPL"
+    },
+    "nodejs-22.12.0-hffbc63d_0.conda": {
+      "license_family": "MIT"
+    },
+    "nspr-4.36-h97d8b74_0.conda": {
+      "license_family": "MOZILLA"
+    },
+    "nss-3.107-h81a00e3_0.conda": {
+      "license_family": "MOZILLA"
+    },
+    "numexpr-2.10.2-py312ha51eba0_0.conda": {
+      "license_family": "MIT"
+    },
+    "numpy-1.26.4-py312he3a82b2_0.conda": {
+      "license_family": "BSD"
+    },
+    "openjpeg-2.5.3-h7fd6d84_0.conda": {
+      "license_family": "BSD"
+    },
+    "pandas-2.2.2-py312h1171441_1.conda": {
+      "license_family": "BSD"
+    },
+    "pkg-config-0.29.2-hf7e621a_1009.conda": {
+      "license_family": "GPL"
+    },
+    "propcache-0.2.1-py312h01d7ebd_0.conda": {
+      "license_family": "APACHE"
+    },
+    "pyarrow-18.1.0-py312hb401068_0.conda": {
+      "license_family": "APACHE"
+    },
+    "pyarrow-core-18.1.0-py312h5157fe3_0_cpu.conda": {
+      "license_family": "APACHE"
+    },
+    "pycosat-0.6.6-py312h01d7ebd_2.conda": {
+      "license_family": "MIT"
+    },
+    "pyobjc-framework-cocoa-10.3.2-py312h2365019_0.conda": {
+      "license_family": "MIT"
+    },
+    "pytables-3.10.1-py312h3276d9a_4.conda": {
+      "license_family": "BSD"
+    },
+    "pyzmq-26.2.0-py312h1060d5c_3.conda": {
       "license_family": "BSD"
     },
     "qt-5.15.8-h93fa01e_0.conda": {
       "license_family": "LGPL"
     },
-    "qt-main-5.15.8-h4385fff_19.conda": {
+    "qt-main-5.15.8-h63f3aef_26.conda": {
       "license_family": "LGPL"
     },
     "qt-webengine-5.15.8-h5f65913_4.conda": {
+      "depends": [
+        "__osx >=10.9",
+        "libcxx >=15.0.7",
+        "libiconv >=1.17,<2.0a0",
+        "libjpeg-turbo >=3.0.0,<4.0a0",
+        "libpng >=1.6.39,<1.7.0a0",
+        "libsqlite >=3.44.0,<4.0a0",
+        "libwebp",
+        "libwebp-base >=1.3.2,<2.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
+        "nspr >=4.35,<5.0a0",
+        "nss >=3.94,<4.0a0",
+        "qt-main >=5.15.8,<5.16.0a0"
+      ],
       "license_family": "LGPL"
+    },
+    "re2-2024.07.02-ha5e900a_2.conda": {
+      "license_family": "BSD"
     },
     "readline-8.2-h9e318b2_1.conda": {
       "license_family": "GPL"
     },
-    "reproc-14.2.4.post0-h10d778d_1.conda": {
+    "reproc-14.2.5.post0-h6e16a3a_0.conda": {
       "license_family": "MIT"
     },
-    "reproc-cpp-14.2.4.post0-h93d8f39_1.conda": {
+    "reproc-cpp-14.2.5.post0-h240833e_0.conda": {
       "license_family": "MIT"
     },
-    "rpds-py-0.18.0-py311hd64b9fd_0.conda": {
+    "rpds-py-0.22.3-py312h0d0de52_0.conda": {
       "license_family": "MIT"
     },
-    "ruamel.yaml-0.18.6-py311he705e18_0.conda": {
+    "ruamel.yaml-0.18.6-py312h3d0f464_1.conda": {
       "license_family": "MIT"
     },
-    "scikit-learn-1.4.1.post1-py311he2b4599_0.conda": {
+    "scikit-learn-1.6.0-py312he1a5313_0.conda": {
       "license_family": "BSD"
     },
-    "scipy-1.12.0-py311h86d0cd9_2.conda": {
+    "scipy-1.14.1-py312h3b0f538_2.conda": {
       "license_family": "BSD"
     },
-    "tbb-2021.11.0-h7728843_1.conda": {
+    "simdjson-3.11.3-h9275861_0.conda": {
       "license_family": "APACHE"
     },
-    "zeromq-4.3.5-h93d8f39_0.conda": {
+    "sqlalchemy-2.0.36-py312h3d0f464_0.conda": {
+      "license_family": "MIT"
+    },
+    "tk-8.6.13-h1abcd95_1.conda": {
+      "depends": [
+        "libzlib >=1.2.13,<2.0.0a0"
+      ]
+    },
+    "wrapt-1.17.0-py312h01d7ebd_0.conda": {
+      "license_family": "BSD"
+    },
+    "zeromq-4.3.5-h7130eaa_7.conda": {
       "license_family": "MOZILLA"
     },
-    "zstandard-0.22.0-py311hed14148_0.conda": {
+    "zstandard-0.23.0-py312h7122b0e_1.conda": {
       "license_family": "BSD"
     },
-    "zstd-1.5.5-h829000d_0.conda": {
-      "license_family": "BSD"
-    },
-    "pytables-3.9.2-py311h3cee394_1.conda": {
+    "zstd-1.5.6-h915ae27_0.conda": {
       "depends": [
         "__osx >=10.9",
-        "blosc >=1.21.5,<2.0a0",
-        "bzip2 >=1.0.8,<2.0a0",
-        "c-blosc2 >=2.11.3,<3.0a0",
-        "hdf5 >=1.14.2,<1.14.4.0a0",
-        "libcxx >=16.0.6",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "numexpr",
-        "numpy >=1.23.5,<2.0a0",
-        "packaging",
-        "py-cpuinfo",
-        "python >=3.11,<3.12.0a0",
-        "python_abi 3.11.* *_cp311"
+        "libzlib >=1.2.13,<2.0.0a0"
       ],
       "license_family": "BSD"
+    },
+    "nodejs-16.20.2-hb52e3ad_3.conda": {
+      "license_family": "MIT"
+    },
+    "pandas-2.2.3-py312h98e817e_1.conda": {
+      "license_family": "BSD"
+    },
+    "libllvm17-17.0.6-hbedff68_1.conda": {
+      "depends": [
+        "libcxx >=16",
+        "libxml2 >=2.12.1,<3.0.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
+        "zstd >=1.5.5,<1.6.0a0"
+      ]
+    },
+    "llvm-tools-17.0.6-hbedff68_1.conda": {
+      "depends": [
+        "libllvm17 17.0.6 hbedff68_1",
+        "libxml2 >=2.12.1,<3.0.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
+        "zstd >=1.5.5,<1.6.0a0"
+      ]
     }
   },
   "remove": [],

--- a/patch_instructions/osx-arm64/patch_instructions.json
+++ b/patch_instructions/osx-arm64/patch_instructions.json
@@ -8,20 +8,11 @@
     "libffi-3.4.2-h3422bc3_5.tar.bz2": {
       "license_family": "MIT"
     },
-    "libogg-1.3.4-h27ca646_1.tar.bz2": {
-      "license_family": "BSD"
-    },
     "libopus-1.3.1-h27ca646_1.tar.bz2": {
       "license_family": "BSD"
     },
     "patch-2.7.6-h27ca646_1002.tar.bz2": {
       "license_family": "GPL"
-    },
-    "pkg-config-0.29.2-hab62308_1008.tar.bz2": {
-      "depends": [
-        "libglib >=2.70.2,<3.0a0",
-        "libiconv >=1.16,<2.0.0a0"
-      ]
     },
     "sigtool-0.1.3-h44b9a77_0.tar.bz2": {
       "license_family": "MIT"
@@ -31,156 +22,128 @@
     }
   },
   "packages.conda": {
-    "astropy-6.0.0-py311h9ea6feb_0.conda": {
+    "astropy-base-7.0.0-py312h0d8ad5c_3.conda": {
       "license_family": "BSD"
     },
-    "blosc-1.21.5-hc338f07_0.conda": {
-      "depends": [
-        "libcxx >=15.0.7",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "lz4-c >=1.9.3,<1.10.0a0",
-        "snappy >=1.1.10,<1.2.0a0",
-        "zstd >=1.5.5,<1.6.0a0"
-      ],
+    "blosc-1.21.6-h7dd00d9_1.conda": {
       "license_family": "BSD"
     },
-    "brotli-1.1.0-hb547adb_1.conda": {
+    "brotli-1.1.0-hd74edd7_2.conda": {
       "license_family": "MIT"
     },
-    "brotli-bin-1.1.0-hb547adb_1.conda": {
+    "brotli-bin-1.1.0-hd74edd7_2.conda": {
       "license_family": "MIT"
     },
-    "brotli-python-1.1.0-py311ha891d26_1.conda": {
+    "brotli-python-1.1.0-py312hde4cb15_2.conda": {
       "license_family": "MIT"
     },
-    "cffi-1.16.0-py311h4a08483_0.conda": {
+    "cffi-1.17.1-py312h0fad829_0.conda": {
       "license_family": "MIT"
     },
-    "conda-23.11.0-py311h267d04e_1.conda": {
+    "conda-24.11.2-py312h81bd7bf_0.conda": {
       "license_family": "BSD"
     },
-    "conda-build-24.1.2-py311h267d04e_0.conda": {
-      "depends": [
-        "beautifulsoup4",
-        "cctools",
-        "chardet",
-        "conda >=22.11.0,<24.3.0a0",
-        "conda-index >=0.4.0",
-        "conda-package-handling >=1.3",
-        "filelock",
-        "jinja2",
-        "jsonschema >=4.19",
-        "menuinst >=2",
-        "packaging",
-        "patch >=2.6",
-        "pkginfo",
-        "psutil",
-        "py-lief <0.14.0a0",
-        "python >=3.11,<3.12.0a0",
-        "python >=3.11,<3.12.0a0 *_cpython",
-        "python-libarchive-c",
-        "python_abi 3.11.* *_cp311",
-        "pytz",
-        "pyyaml",
-        "requests",
-        "ripgrep",
-        "tqdm"
-      ]
-    },
-    "contourpy-1.2.0-py311hcc98501_1.conda": {
+    "contourpy-1.3.1-py312hb23fbb9_0.conda": {
       "license_family": "BSD"
     },
-    "coverage-7.4.3-py311h05b510d_1.conda": {
+    "coverage-7.6.10-py312h998013c_0.conda": {
       "license_family": "APACHE"
     },
-    "cython-3.0.8-py311h92babd0_0.conda": {
+    "cython-3.0.11-py312hde4cb15_2.conda": {
       "license_family": "APACHE"
     },
-    "giflib-5.2.1-h1a8c8d9_3.conda": {
-      "license_family": "MIT"
-    },
-    "gst-plugins-base-1.22.9-h09b4b5e_0.conda": {
-      "license_family": "LGPL"
-    },
-    "gstreamer-1.22.9-h551c6ff_0.conda": {
-      "license_family": "LGPL"
-    },
-    "h5py-3.10.0-nompi_py311hd00467f_101.conda": {
-      "license_family": "BSD"
-    },
-    "icu-73.2-hc8870d7_0.conda": {
-      "license_family": "MIT"
-    },
-    "jsonpointer-2.4-py311h267d04e_3.conda": {
-      "license_family": "BSD"
-    },
-    "krb5-1.21.2-h92f50d5_0.conda": {
-      "license_family": "MIT"
-    },
-    "libarchive-3.7.2-hcacb583_1.conda": {
+    "freetype-2.12.1-hadb7bae_2.conda": {
       "depends": [
-        "bzip2 >=1.0.8,<2.0a0",
-        "libiconv >=1.17,<2.0a0",
-        "libxml2 >=2.12.2,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "lz4-c >=1.9.3,<1.10.0a0",
-        "lzo >=2.10,<3.0a0",
-        "openssl >=3.2.0,<4.0a0",
-        "xz >=5.2.6,<6.0a0",
-        "zstd >=1.5.5,<1.6.0a0"
+        "libpng >=1.6.39,<1.7.0a0",
+        "libzlib >=1.2.13,<2.0.0a0"
       ]
     },
-    "libblas-3.9.0-22_osxarm64_openblas.conda": {
+    "frozenlist-1.5.0-py312h0bf5046_0.conda": {
+      "license_family": "APACHE"
+    },
+    "gflags-2.2.2-hf9b8971_1005.conda": {
       "license_family": "BSD"
     },
-    "libbrotlicommon-1.1.0-hb547adb_1.conda": {
+    "giflib-5.2.2-h93a5062_0.conda": {
       "license_family": "MIT"
     },
-    "libbrotlidec-1.1.0-hb547adb_1.conda": {
-      "license_family": "MIT"
-    },
-    "libbrotlienc-1.1.0-hb547adb_1.conda": {
-      "license_family": "MIT"
-    },
-    "libcblas-3.9.0-22_osxarm64_openblas.conda": {
+    "glog-0.7.1-heb240a5_0.conda": {
       "license_family": "BSD"
     },
-    "libdeflate-1.19-hb547adb_0.conda": {
+    "gst-plugins-base-1.24.7-hb49d354_0.conda": {
+      "license_family": "LGPL"
+    },
+    "gstreamer-1.24.7-hc3f5269_0.conda": {
+      "license_family": "LGPL"
+    },
+    "h5py-3.12.1-nompi_py312h34530d4_103.conda": {
+      "license_family": "BSD"
+    },
+    "icu-75.1-hfee45f7_0.conda": {
       "license_family": "MIT"
     },
-    "libhwloc-2.9.3-default_h4394839_1009.conda": {
+    "jsonpointer-3.0.0-py312h81bd7bf_1.conda": {
+      "license_family": "BSD"
+    },
+    "krb5-1.21.3-h237132a_0.conda": {
+      "license_family": "MIT"
+    },
+    "lcms2-2.16-ha0e7c42_0.conda": {
       "depends": [
-        "__osx >=10.9",
-        "libcxx >=16.0.6",
-        "libxml2 >=2.11.5,<3.0.0a0"
-      ],
+        "libjpeg-turbo >=3.0.0,<4.0a0",
+        "libtiff >=4.6.0,<4.8.0a0"
+      ]
+    },
+    "libblas-3.9.0-26_osxarm64_openblas.conda": {
       "license_family": "BSD"
     },
-    "liblapack-3.9.0-22_osxarm64_openblas.conda": {
+    "libbrotlicommon-1.1.0-hd74edd7_2.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlidec-1.1.0-hd74edd7_2.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlienc-1.1.0-hd74edd7_2.conda": {
+      "license_family": "MIT"
+    },
+    "libcblas-3.9.0-26_osxarm64_openblas.conda": {
       "license_family": "BSD"
+    },
+    "libdeflate-1.23-hec38601_0.conda": {
+      "license_family": "MIT"
+    },
+    "liblapack-3.9.0-26_osxarm64_openblas.conda": {
+      "license_family": "BSD"
+    },
+    "libllvm14-14.0.6-hd1a9a77_4.conda": {
+      "depends": [
+        "libcxx >=15",
+        "libzlib >=1.2.13,<2.0.0a0"
+      ]
     },
     "libllvm15-15.0.7-h2621b3d_4.conda": {
       "depends": [
         "libcxx >=16",
         "libxml2 >=2.12.1,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0"
+        "libzlib >=1.2.13,<2.0.0a0"
       ]
     },
-    "libllvm16-16.0.6-haab561b_3.conda": {
-      "depends": [
-        "libcxx >=16",
-        "libxml2 >=2.12.1,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "zstd >=1.5.5,<1.6.0a0"
-      ]
-    },
-    "libopenblas-0.3.27-openmp_h6c19121_0.conda": {
+    "libogg-1.3.5-h99b78c6_0.conda": {
       "license_family": "BSD"
     },
-    "libwebp-1.3.2-hf30222e_1.conda": {
+    "libopenblas-0.3.28-openmp_hf332438_1.conda": {
       "license_family": "BSD"
     },
-    "libwebp-base-1.3.2-h93a5062_1.conda": {
+    "libre2-11-2024.07.02-h07bc746_2.conda": {
+      "license_family": "BSD"
+    },
+    "libthrift-0.21.0-h64651cc_0.conda": {
+      "license_family": "APACHE"
+    },
+    "libwebp-1.5.0-h1618228_0.conda": {
+      "license_family": "BSD"
+    },
+    "libwebp-base-1.5.0-h2471fea_0.conda": {
       "license_family": "BSD"
     },
     "libxslt-1.1.39-h223e5b9_0.conda": {
@@ -189,110 +152,152 @@
       ],
       "license_family": "MIT"
     },
-    "llvm-openmp-17.0.6-hcd81f8e_0.conda": {
+    "llvm-openmp-19.1.6-hdb05f8b_0.conda": {
       "license_family": "APACHE"
     },
-    "llvmlite-0.42.0-py311hf5d242d_1.conda": {
-      "license_family": "BSD"
-    },
-    "lxml-5.1.0-py311h85df328_0.conda": {
+    "llvmlite-0.42.0-py312h17030e7_1.conda": {
       "depends": [
-        "libxml2 >=2.12.3,<3.0.0a0",
-        "libxslt >=1.1.39,<2.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "python >=3.11,<3.12.0a0",
-        "python >=3.11,<3.12.0a0 *_cpython",
-        "python_abi 3.11.* *_cp311"
-      ]
-    },
-    "lz4-c-1.9.4-hb7217d7_0.conda": {
-      "license_family": "BSD"
-    },
-    "nodejs-20.9.0-h0950e01_0.conda": {
-      "license_family": "MIT"
-    },
-    "nspr-4.35-hb7217d7_0.conda": {
-      "license_family": "MOZILLA"
-    },
-    "nss-3.98-h5ce2875_0.conda": {
-      "license_family": "MOZILLA"
-    },
-    "numexpr-2.8.4-py311h9e438b8_1.conda": {
-      "license_family": "MIT"
-    },
-    "numpy-1.26.4-py311h7125741_0.conda": {
-      "license_family": "BSD"
-    },
-    "openjpeg-2.5.1-h9f1df11_0.conda": {
-      "license_family": "BSD"
-    },
-    "pandas-2.2.1-py311hfbe21a1_0.conda": {
-      "license_family": "BSD"
-    },
-    "pycosat-0.6.6-py311heffc1b2_0.conda": {
-      "license_family": "MIT"
-    },
-    "pyobjc-framework-cocoa-10.1-py311h665608e_0.conda": {
-      "license_family": "MIT"
-    },
-    "pytables-3.8.0-py311h5f09214_4.conda": {
-      "depends": [
-        "blosc >=1.21.5,<2.0a0",
-        "bzip2 >=1.0.8,<2.0a0",
-        "c-blosc2 >=2.10.4,<2.13.0a0",
-        "hdf5 >=1.14.2,<1.14.4.0a0",
-        "libcxx >=15.0.7",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "numexpr",
-        "numpy >=1.23.5,<2.0a0",
-        "packaging",
-        "py-cpuinfo",
-        "python >=3.11,<3.12.0a0",
-        "python >=3.11,<3.12.0a0 *_cpython",
-        "python_abi 3.11.* *_cp311"
+        "libcxx >=16",
+        "libllvm14 >=14.0.6,<14.1.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
+        "python >=3.12,<3.13.0a0",
+        "python >=3.12,<3.13.0a0 *_cpython",
+        "python_abi 3.12.* *_cp312"
       ],
+      "license_family": "BSD"
+    },
+    "llvmlite-0.43.0-py312ha9ca408_1.conda": {
+      "license_family": "BSD"
+    },
+    "lz4-c-1.10.0-h286801f_1.conda": {
+      "license_family": "BSD"
+    },
+    "multidict-6.1.0-py312hdb8e49c_1.conda": {
+      "license_family": "APACHE"
+    },
+    "mysql-common-9.0.1-hd7719f6_4.conda": {
+      "license_family": "GPL"
+    },
+    "mysql-libs-9.0.1-ha8be5b7_4.conda": {
+      "license_family": "GPL"
+    },
+    "nodejs-22.12.0-h02a13b7_0.conda": {
+      "license_family": "MIT"
+    },
+    "nspr-4.36-h5833ebf_0.conda": {
+      "license_family": "MOZILLA"
+    },
+    "nss-3.107-hc555b47_0.conda": {
+      "license_family": "MOZILLA"
+    },
+    "numexpr-2.10.2-py312hbbbb429_0.conda": {
+      "license_family": "MIT"
+    },
+    "numpy-1.26.4-py312h8442bc7_0.conda": {
+      "license_family": "BSD"
+    },
+    "openjpeg-2.5.3-h8a3d83b_0.conda": {
+      "license_family": "BSD"
+    },
+    "pandas-2.2.3-py312hcd31e36_1.conda": {
+      "license_family": "BSD"
+    },
+    "pkg-config-0.29.2-hde07d2e_1009.conda": {
+      "license_family": "GPL"
+    },
+    "propcache-0.2.1-py312hea69d52_0.conda": {
+      "license_family": "APACHE"
+    },
+    "pyarrow-18.1.0-py312h1f38498_0.conda": {
+      "license_family": "APACHE"
+    },
+    "pyarrow-core-18.1.0-py312hc40f475_0_cpu.conda": {
+      "license_family": "APACHE"
+    },
+    "pycosat-0.6.6-py312hea69d52_2.conda": {
+      "license_family": "MIT"
+    },
+    "pyobjc-framework-cocoa-10.3.2-py312hb9d441b_0.conda": {
+      "license_family": "MIT"
+    },
+    "pytables-3.10.1-py312h4b6ede8_4.conda": {
+      "license_family": "BSD"
+    },
+    "pyzmq-26.2.0-py312hf8a1cbd_3.conda": {
       "license_family": "BSD"
     },
     "qt-5.15.8-h13919d0_0.conda": {
       "license_family": "LGPL"
     },
-    "qt-main-5.15.8-h6bf1bb6_19.conda": {
+    "qt-main-5.15.8-h1c95b31_26.conda": {
       "license_family": "LGPL"
     },
     "qt-webengine-5.15.8-h850e111_4.conda": {
+      "depends": [
+        "__osx >=10.9",
+        "libcxx >=15.0.7",
+        "libiconv >=1.17,<2.0a0",
+        "libjpeg-turbo >=3.0.0,<4.0a0",
+        "libpng >=1.6.39,<1.7.0a0",
+        "libsqlite >=3.44.0,<4.0a0",
+        "libwebp",
+        "libwebp-base >=1.3.2,<2.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
+        "nspr >=4.35,<5.0a0",
+        "nss >=3.94,<4.0a0",
+        "qt-main >=5.15.8,<5.16.0a0"
+      ],
       "license_family": "LGPL"
+    },
+    "re2-2024.07.02-h6589ca4_2.conda": {
+      "license_family": "BSD"
     },
     "readline-8.2-h92ec313_1.conda": {
       "license_family": "GPL"
     },
-    "reproc-14.2.4.post0-h93a5062_1.conda": {
+    "reproc-14.2.5.post0-h5505292_0.conda": {
       "license_family": "MIT"
     },
-    "reproc-cpp-14.2.4.post0-h965bd2d_1.conda": {
+    "reproc-cpp-14.2.5.post0-h286801f_0.conda": {
       "license_family": "MIT"
     },
-    "rpds-py-0.18.0-py311ha958965_0.conda": {
+    "rpds-py-0.22.3-py312hcd83bfe_0.conda": {
       "license_family": "MIT"
     },
-    "ruamel.yaml-0.18.6-py311h05b510d_0.conda": {
+    "ruamel.yaml-0.18.6-py312h0bf5046_1.conda": {
       "license_family": "MIT"
     },
-    "scikit-learn-1.4.1.post1-py311h696fe38_0.conda": {
+    "scikit-learn-1.6.0-py312h39203ce_0.conda": {
       "license_family": "BSD"
     },
-    "scipy-1.12.0-py311h4f9446f_2.conda": {
+    "scipy-1.14.1-py312h6bb24ec_2.conda": {
       "license_family": "BSD"
     },
-    "tbb-2021.11.0-h2ffa867_1.conda": {
+    "simdjson-3.11.3-ha393de7_0.conda": {
       "license_family": "APACHE"
     },
-    "zeromq-4.3.5-h5119023_3.conda": {
-      "license_family": "MOZILLA"
+    "sqlalchemy-2.0.36-py312h0bf5046_0.conda": {
+      "license_family": "MIT"
     },
-    "zstandard-0.22.0-py311h67b91a1_0.conda": {
+    "tk-8.6.13-h5083fa2_1.conda": {
+      "depends": [
+        "libzlib >=1.2.13,<2.0.0a0"
+      ]
+    },
+    "wrapt-1.17.0-py312hea69d52_0.conda": {
       "license_family": "BSD"
     },
-    "zstd-1.5.5-h4f39d0f_0.conda": {
+    "zeromq-4.3.5-hc1bb282_7.conda": {
+      "license_family": "MOZILLA"
+    },
+    "zstandard-0.23.0-py312h15fbf35_1.conda": {
+      "license_family": "BSD"
+    },
+    "zstd-1.5.6-hb46c0d2_0.conda": {
+      "depends": [
+        "__osx >=11.0",
+        "libzlib >=1.2.13,<2.0.0a0"
+      ],
       "license_family": "BSD"
     }
   },

--- a/patch_instructions/win-64/patch_instructions.json
+++ b/patch_instructions/win-64/patch_instructions.json
@@ -1,641 +1,216 @@
 {
   "packages": {
-    "libhwloc-2.8.0-h039e092_1.tar.bz2": {
+    "libffi-3.4.2-h8ffe710_5.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "qt-webengine-5.15.8-h4bf5c4e_4.tar.bz2": {
       "depends": [
-        "libxml2 >=2.9.14,<2.11.0a0",
-        "pthreads-win32",
-        "vc >=14.2,<15",
-        "vs2015_runtime >=14.29.30139"
-      ],
-      "license_family": "BSD"
-    },
-    "packages": {
-      "packages": {
-        "libffi-3.4.2-h8ffe710_5.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "libogg-1.3.4-h8ffe710_1.tar.bz2": {
-          "license_family": "BSD"
-        },
-        "qt-webengine-5.15.8-h5b1ea0b_0.tar.bz2": {
-          "license_family": "LGPL"
-        },
-        "ripgrep-11.0.2-1.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "ucrt-10.0.22621.0-h57928b3_0.tar.bz2": {
-          "license_family": "PROPRIETARY"
-        },
-        "winpty-0.4.3-4.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "yaml-0.2.5-h8ffe710_2.tar.bz2": {
-          "license_family": "MIT"
-        },
-        "zeromq-4.3.4-h0e60522_1.tar.bz2": {
-          "license_family": "LGPL"
-        }
-      },
-      "packages.conda": {
-        "astropy-6.0.0-py311h59ca53f_0.conda": {
-          "license_family": "BSD"
-        },
-        "blosc-1.21.5-hdccc3a2_0.conda": {
-          "license_family": "BSD"
-        },
-        "brotli-1.1.0-hcfcfb64_1.conda": {
-          "license_family": "MIT"
-        },
-        "brotli-bin-1.1.0-hcfcfb64_1.conda": {
-          "license_family": "MIT"
-        },
-        "brotli-python-1.1.0-py311h12c1d0e_1.conda": {
-          "license_family": "MIT"
-        },
-        "cffi-1.16.0-py311ha68e1ae_0.conda": {
-          "license_family": "MIT"
-        },
-        "conda-23.11.0-py311h1ea47a8_1.conda": {
-          "license_family": "BSD"
-        },
-        "contourpy-1.2.0-py311h005e61a_0.conda": {
-          "license_family": "BSD"
-        },
-        "coverage-7.4.3-py311ha68e1ae_1.conda": {
-          "license_family": "APACHE"
-        },
-        "cython-3.0.8-py311h12c1d0e_0.conda": {
-          "license_family": "APACHE"
-        },
-        "gst-plugins-base-1.22.9-h001b923_0.conda": {
-          "license_family": "LGPL"
-        },
-        "gstreamer-1.22.9-hb4038d2_0.conda": {
-          "license_family": "LGPL"
-        },
-        "h5py-3.10.0-nompi_py311h7195302_101.conda": {
-          "license_family": "BSD"
-        },
-        "icu-73.2-h63175ca_0.conda": {
-          "license_family": "MIT"
-        },
-        "jsonpointer-2.4-py311h1ea47a8_3.conda": {
-          "license_family": "BSD"
-        },
-        "krb5-1.21.2-heb0366b_0.conda": {
-          "license_family": "MIT"
-        },
-        "libarchive-3.7.2-h313118b_1.conda": {
-          "depends": [
-            "bzip2 >=1.0.8,<2.0a0",
-            "libxml2 >=2.12.2,<3.0.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "lz4-c >=1.9.3,<1.10.0a0",
-            "lzo >=2.10,<3.0a0",
-            "openssl >=3.2.0,<4.0a0",
-            "ucrt >=10.0.20348.0",
-            "vc >=14.2,<15",
-            "vc14_runtime >=14.29.30139",
-            "xz >=5.2.6,<6.0a0",
-            "zstd >=1.5.5,<1.6.0a0"
-          ]
-        },
-        "libblas-3.9.0-18_win64_mkl.conda": {
-          "license_family": "BSD"
-        },
-        "libbrotlicommon-1.1.0-hcfcfb64_1.conda": {
-          "license_family": "MIT"
-        },
-        "libbrotlidec-1.1.0-hcfcfb64_1.conda": {
-          "license_family": "MIT"
-        },
-        "libbrotlienc-1.1.0-hcfcfb64_1.conda": {
-          "license_family": "MIT"
-        },
-        "libcblas-3.9.0-18_win64_mkl.conda": {
-          "license_family": "BSD"
-        },
-        "libclang-15.0.7-default_hde6756a_4.conda": {
-          "depends": [
-            "libclang13 15.0.7 default_h85b4d89_4",
-            "libxml2 >=2.12.1,<3.0.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "ucrt >=10.0.20348.0",
-            "vc >=14.2,<15",
-            "vc14_runtime >=14.29.30139",
-            "zstd >=1.5.5,<1.6.0a0"
-          ]
-        },
-        "libdeflate-1.18-hcfcfb64_0.conda": {
-          "license_family": "MIT"
-        },
-        "libhwloc-2.9.3-default_haede6df_1009.conda": {
-          "depends": [
-            "libxml2 >=2.11.5,<3.0.0a0",
-            "pthreads-win32",
-            "ucrt >=10.0.20348.0",
-            "vc >=14.2,<15",
-            "vc14_runtime >=14.29.30139"
-          ],
-          "license_family": "BSD"
-        },
-        "liblapack-3.9.0-18_win64_mkl.conda": {
-          "license_family": "BSD"
-        },
-        "libwebp-1.3.2-hcfcfb64_1.conda": {
-          "license_family": "BSD"
-        },
-        "libwebp-base-1.3.2-hcfcfb64_0.conda": {
-          "license_family": "BSD"
-        },
-        "libxslt-1.1.39-h3df6e99_0.conda": {
-          "depends": [
-            "libxml2 >=2.12.1,<3.0.0a0",
-            "ucrt >=10.0.20348.0",
-            "vc >=14.2,<15",
-            "vc14_runtime >=14.29.30139"
-          ],
-          "license_family": "MIT"
-        },
-        "llvmlite-0.42.0-py311h5bc0dda_1.conda": {
-          "license_family": "BSD"
-        },
-        "lxml-5.1.0-py311h064e5ff_0.conda": {
-          "depends": [
-            "libxml2 >=2.12.3,<3.0.0a0",
-            "libxslt >=1.1.39,<2.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "python >=3.11,<3.12.0a0",
-            "python_abi 3.11.* *_cp311",
-            "ucrt >=10.0.20348.0",
-            "vc >=14.2,<15",
-            "vc14_runtime >=14.29.30139"
-          ]
-        },
-        "lz4-c-1.9.4-hcfcfb64_0.conda": {
-          "license_family": "BSD"
-        },
-        "m2-conda-epoch-20230914-0_x86_64.conda": {
-          "license_family": "BSD"
-        },
-        "nodejs-20.9.0-h57928b3_0.conda": {
-          "license_family": "MIT"
-        },
-        "numexpr-2.8.4-mkl_py311h9a3bfb6_1.conda": {
-          "license_family": "MIT"
-        },
-        "numpy-1.26.4-py311h0b4df5a_0.conda": {
-          "license_family": "BSD"
-        },
-        "openjpeg-2.5.0-ha2aaf27_2.conda": {
-          "license_family": "BSD"
-        },
-        "pandas-2.2.1-py311hf63dbb6_0.conda": {
-          "license_family": "BSD"
-        },
-        "pycosat-0.6.6-py311ha68e1ae_0.conda": {
-          "license_family": "MIT"
-        },
-        "pytables-3.8.0-py311heec7198_4.conda": {
-          "depends": [
-            "blosc >=1.21.5,<2.0a0",
-            "bzip2 >=1.0.8,<2.0a0",
-            "c-blosc2 >=2.10.4,<3.0a0",
-            "hdf5 >=1.14.2,<1.14.4.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "numexpr",
-            "numpy >=1.23.5,<2.0a0",
-            "packaging",
-            "py-cpuinfo",
-            "python >=3.11,<3.12.0a0",
-            "python_abi 3.11.* *_cp311",
-            "ucrt >=10.0.20348.0",
-            "vc >=14.2,<15",
-            "vc14_runtime >=14.29.30139"
-          ],
-          "license_family": "BSD"
-        },
-        "pytables-3.9.2-py311heec7198_1.conda": {
-          "depends": [
-            "blosc >=1.21.5,<2.0a0",
-            "bzip2 >=1.0.8,<2.0a0",
-            "c-blosc2 >=2.11.3,<3.0a0",
-            "hdf5 >=1.14.2,<1.14.4.0a0",
-            "libzlib >=1.2.13,<1.3.0a0",
-            "numexpr",
-            "numpy >=1.23.5,<2.0a0",
-            "packaging",
-            "py-cpuinfo",
-            "python >=3.11,<3.12.0a0",
-            "python_abi 3.11.* *_cp311",
-            "ucrt >=10.0.20348.0",
-            "vc >=14.2,<15",
-            "vc14_runtime >=14.29.30139"
-          ],
-          "license_family": "BSD"
-        },
-        "pywin32-306-py311h12c1d0e_2.conda": {
-          "license_family": "PSF"
-        },
-        "pywinpty-2.0.13-py311h12c1d0e_0.conda": {
-          "license_family": "MIT"
-        },
-        "qt-5.15.8-h91493d7_0.conda": {
-          "license_family": "LGPL"
-        },
-        "qt-main-5.15.8-he5a7383_16.conda": {
-          "license_family": "LGPL"
-        },
-        "reproc-14.2.4.post0-hcfcfb64_1.conda": {
-          "license_family": "MIT"
-        },
-        "reproc-cpp-14.2.4.post0-h63175ca_1.conda": {
-          "license_family": "MIT"
-        },
-        "rpds-py-0.18.0-py311hc37eb10_0.conda": {
-          "license_family": "MIT"
-        },
-        "ruamel.yaml-0.18.6-py311ha68e1ae_0.conda": {
-          "license_family": "MIT"
-        },
-        "scikit-learn-1.4.1.post1-py311h142b183_0.conda": {
-          "license_family": "BSD"
-        },
-        "scipy-1.12.0-py311h0b4df5a_2.conda": {
-          "license_family": "BSD"
-        },
-        "sqlalchemy-2.0.27-py311ha68e1ae_0.conda": {
-          "license_family": "MIT"
-        },
-        "tbb-2021.11.0-h91493d7_1.conda": {
-          "license_family": "APACHE"
-        },
-        "zstandard-0.22.0-py311he5d195f_0.conda": {
-          "license_family": "BSD"
-        },
-        "zstd-1.5.5-h12be248_0.conda": {
-          "license_family": "BSD"
-        }
-      },
-      "patch_instructions_version": 1,
-      "remove": [],
-      "revoke": []
-    },
-    "packages.conda": {
-      "astropy-6.0.0-py311h59ca53f_0.conda": {
-        "license_family": "BSD"
-      },
-      "blosc-1.21.5-hdccc3a2_0.conda": {
-        "license_family": "BSD"
-      },
-      "brotli-1.1.0-hcfcfb64_1.conda": {
-        "license_family": "MIT"
-      },
-      "brotli-bin-1.1.0-hcfcfb64_1.conda": {
-        "license_family": "MIT"
-      },
-      "brotli-python-1.1.0-py311h12c1d0e_1.conda": {
-        "license_family": "MIT"
-      },
-      "cffi-1.16.0-py311ha68e1ae_0.conda": {
-        "license_family": "MIT"
-      },
-      "conda-23.11.0-py311h1ea47a8_1.conda": {
-        "license_family": "BSD"
-      },
-      "contourpy-1.2.0-py311h005e61a_0.conda": {
-        "license_family": "BSD"
-      },
-      "coverage-7.4.3-py311ha68e1ae_1.conda": {
-        "license_family": "APACHE"
-      },
-      "cython-3.0.8-py311h12c1d0e_0.conda": {
-        "license_family": "APACHE"
-      },
-      "gst-plugins-base-1.22.9-h001b923_0.conda": {
-        "license_family": "LGPL"
-      },
-      "gstreamer-1.22.9-hb4038d2_0.conda": {
-        "license_family": "LGPL"
-      },
-      "h5py-3.10.0-nompi_py311h7195302_101.conda": {
-        "license_family": "BSD"
-      },
-      "icu-73.2-h63175ca_0.conda": {
-        "license_family": "MIT"
-      },
-      "jsonpointer-2.4-py311h1ea47a8_3.conda": {
-        "license_family": "BSD"
-      },
-      "krb5-1.21.2-heb0366b_0.conda": {
-        "license_family": "MIT"
-      },
-      "libarchive-3.7.2-h313118b_1.conda": {
-        "depends": [
-          "bzip2 >=1.0.8,<2.0a0",
-          "libxml2 >=2.12.2,<3.0.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "lz4-c >=1.9.3,<1.10.0a0",
-          "lzo >=2.10,<3.0a0",
-          "openssl >=3.2.0,<4.0a0",
-          "ucrt >=10.0.20348.0",
-          "vc >=14.2,<15",
-          "vc14_runtime >=14.29.30139",
-          "xz >=5.2.6,<6.0a0",
-          "zstd >=1.5.5,<1.6.0a0"
-        ]
-      },
-      "libblas-3.9.0-18_win64_mkl.conda": {
-        "license_family": "BSD"
-      },
-      "libbrotlicommon-1.1.0-hcfcfb64_1.conda": {
-        "license_family": "MIT"
-      },
-      "libbrotlidec-1.1.0-hcfcfb64_1.conda": {
-        "license_family": "MIT"
-      },
-      "libbrotlienc-1.1.0-hcfcfb64_1.conda": {
-        "license_family": "MIT"
-      },
-      "libcblas-3.9.0-18_win64_mkl.conda": {
-        "license_family": "BSD"
-      },
-      "libclang-15.0.7-default_hde6756a_4.conda": {
-        "depends": [
-          "libclang13 15.0.7 default_h85b4d89_4",
-          "libxml2 >=2.12.1,<3.0.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "ucrt >=10.0.20348.0",
-          "vc >=14.2,<15",
-          "vc14_runtime >=14.29.30139",
-          "zstd >=1.5.5,<1.6.0a0"
-        ]
-      },
-      "libdeflate-1.18-hcfcfb64_0.conda": {
-        "license_family": "MIT"
-      },
-      "libhwloc-2.9.3-default_haede6df_1009.conda": {
-        "depends": [
-          "libxml2 >=2.11.5,<3.0.0a0",
-          "pthreads-win32",
-          "ucrt >=10.0.20348.0",
-          "vc >=14.2,<15",
-          "vc14_runtime >=14.29.30139"
-        ],
-        "license_family": "BSD"
-      },
-      "liblapack-3.9.0-18_win64_mkl.conda": {
-        "license_family": "BSD"
-      },
-      "libwebp-1.3.2-hcfcfb64_1.conda": {
-        "license_family": "BSD"
-      },
-      "libwebp-base-1.3.2-hcfcfb64_0.conda": {
-        "license_family": "BSD"
-      },
-      "libxslt-1.1.39-h3df6e99_0.conda": {
-        "depends": [
-          "libxml2 >=2.12.1,<3.0.0a0",
-          "ucrt >=10.0.20348.0",
-          "vc >=14.2,<15",
-          "vc14_runtime >=14.29.30139"
-        ],
-        "license_family": "MIT"
-      },
-      "llvmlite-0.42.0-py311h5bc0dda_1.conda": {
-        "license_family": "BSD"
-      },
-      "lxml-5.1.0-py311h064e5ff_0.conda": {
-        "depends": [
-          "libxml2 >=2.12.3,<3.0.0a0",
-          "libxslt >=1.1.39,<2.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "python >=3.11,<3.12.0a0",
-          "python_abi 3.11.* *_cp311",
-          "ucrt >=10.0.20348.0",
-          "vc >=14.2,<15",
-          "vc14_runtime >=14.29.30139"
-        ]
-      },
-      "lz4-c-1.9.4-hcfcfb64_0.conda": {
-        "license_family": "BSD"
-      },
-      "m2-conda-epoch-20230914-0_x86_64.conda": {
-        "license_family": "BSD"
-      },
-      "nodejs-20.9.0-h57928b3_0.conda": {
-        "license_family": "MIT"
-      },
-      "numexpr-2.8.4-mkl_py311h9a3bfb6_1.conda": {
-        "license_family": "MIT"
-      },
-      "numpy-1.26.4-py311h0b4df5a_0.conda": {
-        "license_family": "BSD"
-      },
-      "openjpeg-2.5.0-ha2aaf27_2.conda": {
-        "license_family": "BSD"
-      },
-      "pandas-2.2.1-py311hf63dbb6_0.conda": {
-        "license_family": "BSD"
-      },
-      "pycosat-0.6.6-py311ha68e1ae_0.conda": {
-        "license_family": "MIT"
-      },
-      "pytables-3.8.0-py311heec7198_4.conda": {
-        "depends": [
-          "blosc >=1.21.5,<2.0a0",
-          "bzip2 >=1.0.8,<2.0a0",
-          "c-blosc2 >=2.10.4,<3.0a0",
-          "hdf5 >=1.14.2,<1.14.4.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "numexpr",
-          "numpy >=1.23.5,<2.0a0",
-          "packaging",
-          "py-cpuinfo",
-          "python >=3.11,<3.12.0a0",
-          "python_abi 3.11.* *_cp311",
-          "ucrt >=10.0.20348.0",
-          "vc >=14.2,<15",
-          "vc14_runtime >=14.29.30139"
-        ],
-        "license_family": "BSD"
-      },
-      "pytables-3.9.2-py311heec7198_1.conda": {
-        "depends": [
-          "blosc >=1.21.5,<2.0a0",
-          "bzip2 >=1.0.8,<2.0a0",
-          "c-blosc2 >=2.11.3,<3.0a0",
-          "hdf5 >=1.14.2,<1.14.4.0a0",
-          "libzlib >=1.2.13,<1.3.0a0",
-          "numexpr",
-          "numpy >=1.23.5,<2.0a0",
-          "packaging",
-          "py-cpuinfo",
-          "python >=3.11,<3.12.0a0",
-          "python_abi 3.11.* *_cp311",
-          "ucrt >=10.0.20348.0",
-          "vc >=14.2,<15",
-          "vc14_runtime >=14.29.30139"
-        ],
-        "license_family": "BSD"
-      },
-      "pywin32-306-py311h12c1d0e_2.conda": {
-        "license_family": "PSF"
-      },
-      "pywinpty-2.0.13-py311h12c1d0e_0.conda": {
-        "license_family": "MIT"
-      },
-      "qt-5.15.8-h91493d7_0.conda": {
-        "license_family": "LGPL"
-      },
-      "qt-main-5.15.8-he5a7383_16.conda": {
-        "license_family": "LGPL"
-      },
-      "reproc-14.2.4.post0-hcfcfb64_1.conda": {
-        "license_family": "MIT"
-      },
-      "reproc-cpp-14.2.4.post0-h63175ca_1.conda": {
-        "license_family": "MIT"
-      },
-      "rpds-py-0.18.0-py311hc37eb10_0.conda": {
-        "license_family": "MIT"
-      },
-      "ruamel.yaml-0.18.6-py311ha68e1ae_0.conda": {
-        "license_family": "MIT"
-      },
-      "scikit-learn-1.4.1.post1-py311h142b183_0.conda": {
-        "license_family": "BSD"
-      },
-      "scipy-1.12.0-py311h0b4df5a_2.conda": {
-        "license_family": "BSD"
-      },
-      "sqlalchemy-2.0.27-py311ha68e1ae_0.conda": {
-        "license_family": "MIT"
-      },
-      "tbb-2021.11.0-h91493d7_1.conda": {
-        "license_family": "APACHE"
-      },
-      "zstandard-0.22.0-py311he5d195f_0.conda": {
-        "license_family": "BSD"
-      },
-      "zstd-1.5.5-h12be248_0.conda": {
-        "license_family": "BSD"
-      }
-    },
-    "patch_instructions_version": 1,
-    "remove": [],
-    "revoke": []
-  },
-  "packages.conda": {
-    "astropy-6.0.0-py311h59ca53f_0.conda": {
-      "license_family": "BSD"
-    },
-    "blosc-1.21.5-hdccc3a2_0.conda": {
-      "license_family": "BSD"
-    },
-    "brotli-1.1.0-hcfcfb64_1.conda": {
-      "license_family": "MIT"
-    },
-    "brotli-bin-1.1.0-hcfcfb64_1.conda": {
-      "license_family": "MIT"
-    },
-    "brotli-python-1.1.0-py311h12c1d0e_1.conda": {
-      "license_family": "MIT"
-    },
-    "cffi-1.16.0-py311ha68e1ae_0.conda": {
-      "license_family": "MIT"
-    },
-    "conda-23.11.0-py311h1ea47a8_1.conda": {
-      "license_family": "BSD"
-    },
-    "contourpy-1.2.0-py311h005e61a_0.conda": {
-      "license_family": "BSD"
-    },
-    "coverage-7.4.3-py311ha68e1ae_1.conda": {
-      "license_family": "APACHE"
-    },
-    "cython-3.0.8-py311h12c1d0e_0.conda": {
-      "license_family": "APACHE"
-    },
-    "gst-plugins-base-1.22.9-h001b923_0.conda": {
-      "license_family": "LGPL"
-    },
-    "gstreamer-1.22.9-hb4038d2_0.conda": {
-      "license_family": "LGPL"
-    },
-    "h5py-3.10.0-nompi_py311h7195302_101.conda": {
-      "license_family": "BSD"
-    },
-    "icu-73.2-h63175ca_0.conda": {
-      "license_family": "MIT"
-    },
-    "jsonpointer-2.4-py311h1ea47a8_3.conda": {
-      "license_family": "BSD"
-    },
-    "krb5-1.21.2-heb0366b_0.conda": {
-      "license_family": "MIT"
-    },
-    "libarchive-3.7.2-h313118b_1.conda": {
-      "depends": [
-        "bzip2 >=1.0.8,<2.0a0",
-        "libxml2 >=2.12.2,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "lz4-c >=1.9.3,<1.10.0a0",
-        "lzo >=2.10,<3.0a0",
-        "openssl >=3.2.0,<4.0a0",
-        "ucrt >=10.0.20348.0",
-        "vc >=14.2,<15",
-        "vc14_runtime >=14.29.30139",
-        "xz >=5.2.6,<6.0a0",
-        "zstd >=1.5.5,<1.6.0a0"
-      ]
-    },
-    "libblas-3.9.0-18_win64_mkl.conda": {
-      "license_family": "BSD"
-    },
-    "libbrotlicommon-1.1.0-hcfcfb64_1.conda": {
-      "license_family": "MIT"
-    },
-    "libbrotlidec-1.1.0-hcfcfb64_1.conda": {
-      "license_family": "MIT"
-    },
-    "libbrotlienc-1.1.0-hcfcfb64_1.conda": {
-      "license_family": "MIT"
-    },
-    "libcblas-3.9.0-18_win64_mkl.conda": {
-      "license_family": "BSD"
-    },
-    "libclang-15.0.7-default_hde6756a_4.conda": {
-      "depends": [
-        "libclang13 15.0.7 default_h85b4d89_4",
-        "libxml2 >=2.12.1,<3.0.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "ucrt >=10.0.20348.0",
-        "vc >=14.2,<15",
-        "vc14_runtime >=14.29.30139",
-        "zstd >=1.5.5,<1.6.0a0"
-      ]
-    },
-    "libdeflate-1.18-hcfcfb64_0.conda": {
-      "license_family": "MIT"
-    },
-    "libhwloc-2.9.3-default_haede6df_1009.conda": {
-      "depends": [
-        "libxml2 >=2.11.5,<3.0.0a0",
-        "pthreads-win32",
+        "libiconv >=1.17,<2.0a0",
+        "libjpeg-turbo >=3.0.0,<4.0a0",
+        "libpng >=1.6.39,<1.7.0a0",
+        "libsqlite >=3.44.0,<4.0a0",
+        "libwebp",
+        "libwebp-base >=1.3.2,<2.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
+        "qt-main >=5.15.8,<5.16.0a0",
         "ucrt >=10.0.20348.0",
         "vc >=14.2,<15",
         "vc14_runtime >=14.29.30139"
       ],
+      "license_family": "LGPL"
+    },
+    "winpty-0.4.3-4.tar.bz2": {
+      "license_family": "MIT"
+    },
+    "yaml-0.2.5-h8ffe710_2.tar.bz2": {
+      "license_family": "MIT"
+    }
+  },
+  "packages.conda": {
+    "brotli-1.1.0-h2466b09_2.conda": {
+      "license_family": "MIT"
+    },
+    "cffi-1.17.1-py312h4389bb4_0.conda": {
+      "license_family": "MIT"
+    },
+    "conda-24.11.2-py312h2e8e312_0.conda": {
       "license_family": "BSD"
     },
-    "liblapack-3.9.0-18_win64_mkl.conda": {
+    "contourpy-1.3.1-py312hd5eb7cc_0.conda": {
       "license_family": "BSD"
     },
-    "libwebp-1.3.2-hcfcfb64_1.conda": {
+    "coverage-7.6.10-py312h31fea79_0.conda": {
+      "license_family": "APACHE"
+    },
+    "cython-3.0.11-py312h6018fb9_3.conda": {
+      "license_family": "APACHE"
+    },
+    "frozenlist-1.5.0-py312h4389bb4_0.conda": {
+      "license_family": "APACHE"
+    },
+    "h5py-3.12.1-nompi_py312h0db4ba1_103.conda": {
       "license_family": "BSD"
     },
-    "libwebp-base-1.3.2-hcfcfb64_0.conda": {
+    "jsonpointer-3.0.0-py312h2e8e312_1.conda": {
+      "license_family": "BSD"
+    },
+    "llvmlite-0.42.0-py312h7894644_1.conda": {
+      "depends": [
+        "libzlib >=1.2.13,<2.0.0a0",
+        "python >=3.12,<3.13.0a0",
+        "python_abi 3.12.* *_cp312",
+        "ucrt >=10.0.20348.0",
+        "vc >=14.2,<15",
+        "vc14_runtime >=14.29.30139",
+        "vs2015_runtime"
+      ],
+      "license_family": "BSD"
+    },
+    "llvmlite-0.43.0-py312h1f7db74_1.conda": {
+      "license_family": "BSD"
+    },
+    "multidict-6.1.0-py312h31fea79_1.conda": {
+      "license_family": "APACHE"
+    },
+    "numpy-1.26.4-py312h8753938_0.conda": {
+      "license_family": "BSD"
+    },
+    "pandas-2.2.3-py312h72972c8_1.conda": {
+      "license_family": "BSD"
+    },
+    "propcache-0.2.1-py312h4389bb4_0.conda": {
+      "license_family": "APACHE"
+    },
+    "pyarrow-18.1.0-py312h2e8e312_0.conda": {
+      "license_family": "APACHE"
+    },
+    "pycosat-0.6.6-py312h4389bb4_2.conda": {
+      "license_family": "MIT"
+    },
+    "pywin32-307-py312h275cf98_3.conda": {
+      "license_family": "PSF"
+    },
+    "pywinpty-2.0.14-py312h275cf98_0.conda": {
+      "license_family": "MIT"
+    },
+    "pyzmq-26.2.0-py312hd7027bb_3.conda": {
+      "license_family": "BSD"
+    },
+    "rpds-py-0.22.3-py312h2615798_0.conda": {
+      "license_family": "MIT"
+    },
+    "scikit-learn-1.6.0-py312h816cc57_0.conda": {
+      "license_family": "BSD"
+    },
+    "scipy-1.14.1-py312h337df96_2.conda": {
+      "license_family": "BSD"
+    },
+    "sqlalchemy-2.0.36-py312h4389bb4_0.conda": {
+      "license_family": "MIT"
+    },
+    "wrapt-1.17.0-py312h4389bb4_0.conda": {
+      "license_family": "BSD"
+    },
+    "zstandard-0.23.0-py312h7606c53_1.conda": {
+      "license_family": "BSD"
+    },
+    "_openmp_mutex-4.5-2_gnu.conda": {
+      "license_family": "BSD"
+    },
+    "astropy-base-7.0.0-py312hce9986f_3.conda": {
+      "license_family": "BSD"
+    },
+    "blosc-1.21.6-hfd34d9b_1.conda": {
+      "license_family": "BSD"
+    },
+    "brotli-bin-1.1.0-h2466b09_2.conda": {
+      "license_family": "MIT"
+    },
+    "brotli-python-1.1.0-py312h275cf98_2.conda": {
+      "license_family": "MIT"
+    },
+    "fontconfig-2.15.0-h765892d_1.conda": {
+      "license_family": "MIT"
+    },
+    "freetype-2.12.1-hdaf720e_2.conda": {
+      "depends": [
+        "libpng >=1.6.39,<1.7.0a0",
+        "libzlib >=1.2.13,<2.0.0a0",
+        "ucrt >=10.0.20348.0",
+        "vc >=14.2,<15",
+        "vc14_runtime >=14.29.30139"
+      ]
+    },
+    "graphite2-1.3.13-h63175ca_1003.conda": {
+      "license_family": "LGPL"
+    },
+    "gst-plugins-base-1.24.7-hb0a98b8_0.conda": {
+      "license_family": "LGPL"
+    },
+    "gstreamer-1.24.7-h5006eae_0.conda": {
+      "license_family": "LGPL"
+    },
+    "harfbuzz-10.1.0-ha6ce084_0.conda": {
+      "license_family": "MIT"
+    },
+    "icu-75.1-he0c23c2_0.conda": {
+      "license_family": "MIT"
+    },
+    "krb5-1.21.3-hdf4eb48_0.conda": {
+      "license_family": "MIT"
+    },
+    "lcms2-2.16-h67d730c_0.conda": {
+      "depends": [
+        "libjpeg-turbo >=3.0.0,<4.0a0",
+        "libtiff >=4.6.0,<4.8.0a0",
+        "ucrt >=10.0.20348.0",
+        "vc >=14.2,<15",
+        "vc14_runtime >=14.29.30139"
+      ]
+    },
+    "libblas-3.9.0-26_win64_openblas.conda": {
+      "license_family": "BSD"
+    },
+    "libbrotlicommon-1.1.0-h2466b09_2.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlidec-1.1.0-h2466b09_2.conda": {
+      "license_family": "MIT"
+    },
+    "libbrotlienc-1.1.0-h2466b09_2.conda": {
+      "license_family": "MIT"
+    },
+    "libcblas-3.9.0-26_win64_openblas.conda": {
+      "license_family": "BSD"
+    },
+    "libdeflate-1.23-h9062f6e_0.conda": {
+      "license_family": "MIT"
+    },
+    "libgcc-14.2.0-h1383e82_1.conda": {
+      "license_family": "GPL"
+    },
+    "libgomp-14.2.0-h1383e82_1.conda": {
+      "license_family": "GPL"
+    },
+    "liblapack-3.9.0-26_win64_openblas.conda": {
+      "license_family": "BSD"
+    },
+    "libogg-1.3.5-h2466b09_0.conda": {
+      "license_family": "BSD"
+    },
+    "libopenblas-0.3.28-pthreads_head3c61_1.conda": {
+      "license_family": "BSD"
+    },
+    "libre2-11-2024.07.02-h4eb7d71_2.conda": {
+      "license_family": "BSD"
+    },
+    "libthrift-0.21.0-hbe90ef8_0.conda": {
+      "license_family": "APACHE"
+    },
+    "libwebp-1.5.0-h3b0e114_0.conda": {
+      "license_family": "BSD"
+    },
+    "libwebp-base-1.5.0-h3b0e114_0.conda": {
       "license_family": "BSD"
     },
     "libxslt-1.1.39-h3df6e99_0.conda": {
@@ -647,123 +222,61 @@
       ],
       "license_family": "MIT"
     },
-    "llvmlite-0.42.0-py311h5bc0dda_1.conda": {
-      "license_family": "BSD"
-    },
-    "lxml-5.1.0-py311h064e5ff_0.conda": {
-      "depends": [
-        "libxml2 >=2.12.3,<3.0.0a0",
-        "libxslt >=1.1.39,<2.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "python >=3.11,<3.12.0a0",
-        "python_abi 3.11.* *_cp311",
-        "ucrt >=10.0.20348.0",
-        "vc >=14.2,<15",
-        "vc14_runtime >=14.29.30139"
-      ]
-    },
-    "lz4-c-1.9.4-hcfcfb64_0.conda": {
+    "lz4-c-1.10.0-h2466b09_1.conda": {
       "license_family": "BSD"
     },
     "m2-conda-epoch-20230914-0_x86_64.conda": {
       "license_family": "BSD"
     },
-    "nodejs-20.9.0-h57928b3_0.conda": {
+    "nodejs-22.12.0-hfeaa22a_0.conda": {
       "license_family": "MIT"
     },
-    "numexpr-2.8.4-mkl_py311h9a3bfb6_1.conda": {
+    "numexpr-2.10.2-py312h4f83d31_100.conda": {
       "license_family": "MIT"
     },
-    "numpy-1.26.4-py311h0b4df5a_0.conda": {
+    "openjpeg-2.5.3-h4d64b90_0.conda": {
       "license_family": "BSD"
     },
-    "openjpeg-2.5.0-ha2aaf27_2.conda": {
-      "license_family": "BSD"
-    },
-    "pandas-2.2.1-py311hf63dbb6_0.conda": {
-      "license_family": "BSD"
-    },
-    "pycosat-0.6.6-py311ha68e1ae_0.conda": {
+    "pixman-0.44.2-had0cd8c_0.conda": {
       "license_family": "MIT"
     },
-    "pytables-3.8.0-py311heec7198_4.conda": {
-      "depends": [
-        "blosc >=1.21.5,<2.0a0",
-        "bzip2 >=1.0.8,<2.0a0",
-        "c-blosc2 >=2.10.4,<3.0a0",
-        "hdf5 >=1.14.2,<1.14.4.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "numexpr",
-        "numpy >=1.23.5,<2.0a0",
-        "packaging",
-        "py-cpuinfo",
-        "python >=3.11,<3.12.0a0",
-        "python_abi 3.11.* *_cp311",
-        "ucrt >=10.0.20348.0",
-        "vc >=14.2,<15",
-        "vc14_runtime >=14.29.30139"
-      ],
+    "pyarrow-core-18.1.0-py312h6a9c419_0_cpu.conda": {
+      "license_family": "APACHE"
+    },
+    "pytables-3.10.1-py312h9287a31_4.conda": {
       "license_family": "BSD"
-    },
-    "pytables-3.9.2-py311heec7198_1.conda": {
-      "depends": [
-        "blosc >=1.21.5,<2.0a0",
-        "bzip2 >=1.0.8,<2.0a0",
-        "c-blosc2 >=2.11.3,<3.0a0",
-        "hdf5 >=1.14.2,<1.14.4.0a0",
-        "libzlib >=1.2.13,<1.3.0a0",
-        "numexpr",
-        "numpy >=1.23.5,<2.0a0",
-        "packaging",
-        "py-cpuinfo",
-        "python >=3.11,<3.12.0a0",
-        "python_abi 3.11.* *_cp311",
-        "ucrt >=10.0.20348.0",
-        "vc >=14.2,<15",
-        "vc14_runtime >=14.29.30139"
-      ],
-      "license_family": "BSD"
-    },
-    "pywin32-306-py311h12c1d0e_2.conda": {
-      "license_family": "PSF"
-    },
-    "pywinpty-2.0.13-py311h12c1d0e_0.conda": {
-      "license_family": "MIT"
     },
     "qt-5.15.8-h91493d7_0.conda": {
       "license_family": "LGPL"
     },
-    "qt-main-5.15.8-he5a7383_16.conda": {
+    "qt-main-5.15.8-h264fbc2_26.conda": {
       "license_family": "LGPL"
     },
-    "reproc-14.2.4.post0-hcfcfb64_1.conda": {
-      "license_family": "MIT"
-    },
-    "reproc-cpp-14.2.4.post0-h63175ca_1.conda": {
-      "license_family": "MIT"
-    },
-    "rpds-py-0.18.0-py311hc37eb10_0.conda": {
-      "license_family": "MIT"
-    },
-    "ruamel.yaml-0.18.6-py311ha68e1ae_0.conda": {
-      "license_family": "MIT"
-    },
-    "scikit-learn-1.4.1.post1-py311h142b183_0.conda": {
+    "re2-2024.07.02-haf4117d_2.conda": {
       "license_family": "BSD"
     },
-    "scipy-1.12.0-py311h0b4df5a_2.conda": {
-      "license_family": "BSD"
-    },
-    "sqlalchemy-2.0.27-py311ha68e1ae_0.conda": {
+    "reproc-14.2.5.post0-h2466b09_0.conda": {
       "license_family": "MIT"
     },
-    "tbb-2021.11.0-h91493d7_1.conda": {
+    "reproc-cpp-14.2.5.post0-he0c23c2_0.conda": {
+      "license_family": "MIT"
+    },
+    "ruamel.yaml-0.18.6-py312h4389bb4_1.conda": {
+      "license_family": "MIT"
+    },
+    "simdjson-3.11.3-hc790b64_0.conda": {
       "license_family": "APACHE"
     },
-    "zstandard-0.22.0-py311he5d195f_0.conda": {
-      "license_family": "BSD"
+    "zeromq-4.3.5-ha9f60a1_7.conda": {
+      "license_family": "MOZILLA"
     },
-    "zstd-1.5.5-h12be248_0.conda": {
+    "zstd-1.5.6-h0ea2cb4_0.conda": {
+      "depends": [
+        "libzlib >=1.2.13,<2.0.0a0",
+        "ucrt >=10.0.20348.0",
+        "vc >=14.2,<15",
+        "vc14_runtime >=14.29.30139"
+      ],
       "license_family": "BSD"
     }
   },


### PR DESCRIPTION
This PR is for the record, because it brings the repository in agreement to what is actually online. The patch instructions should have been updated with 2025.1, but they were not (last update was in 2024). I copied the files from the flight channel.

This is relevant now because patches need to be updated for the gfortran update to ska3-core in 2025.5.