### PR TITLE
Update ruff-base to ignore PLC0415 (imports at top)

### DIFF
--- a/templates/ruff-base.toml
+++ b/templates/ruff-base.toml
@@ -41,6 +41,7 @@ lint.ignore = [
   "B028", # No explicit `stacklevel` keyword argument found
   "PLR0913", # Too many arguments to function call
   "PLR1730", # Checks for if statements that can be replaced with min() or max() calls
+  "PLC0415", # `import` should be at the top-level of a file
 ]
 
 extend-exclude = [


### PR DESCRIPTION
Update ruff-base to ignore PLC0415 (imports at top)