### PR TITLE
Update ruff-base.toml to ignore PLW1641

### DIFF
--- a/templates/ruff-base.toml
+++ b/templates/ruff-base.toml
@@ -42,6 +42,7 @@ lint.ignore = [
   "PLR0913", # Too many arguments to function call
   "PLR1730", # Checks for if statements that can be replaced with min() or max() calls
   "PLC0415", # `import` should be at the top-level of a file
+  "PLW1641", # Class implements `__hash__` if `__eq__` is implemented
 ]
 
 extend-exclude = [


### PR DESCRIPTION
Rule PLW1641 requires that any class that implements `__eq__` also implements `__hash__`. 

This is misguided since in practice it is common for classes to define a "liberal" view of equality where objects that compare equal do not have the same hash. As a simple example, `np.dtype("float64") == "float64"` is `True`, while the `hash()` values are not equal.

In our code base it is fine for a class object to not be hashable by default, which is what can happen by ignoring PLW1641.