### PR TITLE
2025.8

### DIFF
--- a/pkg_defs/ska3-aca/meta.yaml
+++ b/pkg_defs/ska3-aca/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - proseco ==5.16.2
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
+    - razl ==0.1.0
     - ska-sphinx-theme ==1.3.0
     - ska3-core ==2025.5
     - ska3-template ==2022.06.02

--- a/pkg_defs/ska3-aca/meta.yaml
+++ b/pkg_defs/ska3-aca/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-aca
-  version: 2025.5
+  version: 2025.8
 
 build:
   noarch: generic
@@ -13,21 +13,21 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.3.1
     - acispy ==2.8.0
-    - agasc ==4.23.0
+    - agasc ==4.23.1
     - backstop_history ==3.2.1
-    - chandra_aca ==4.51.0
+    - chandra_aca ==4.51.1
     - chandra_limits ==0.10.1
-    - chandra_maneuver ==4.3.1
+    - chandra_maneuver ==4.4.0
     - chandra_time ==4.2.0
     - cheta ==4.63.2
-    - cxotime ==3.10.1
-    - fot-matlab ==2.4.1
+    - cxotime ==3.10.2
+    - fot-matlab ==2.5.0
     - hopper ==4.6.0
-    - kadi ==7.17.1
-    - maude ==3.13.0
+    - kadi ==7.17.3
+    - maude ==3.14.0
     - mica ==4.39.0
     - parse_cm ==3.17.0
-    - proseco ==5.16.1
+    - proseco ==5.16.2
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -48,7 +48,7 @@ requirements:
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - sparkles ==4.29.0
+    - sparkles ==4.30.0
     - starcheck ==14.14.0
     - testr ==4.13.0
     - xija ==4.33.2

--- a/pkg_defs/ska3-aca/meta.yaml
+++ b/pkg_defs/ska3-aca/meta.yaml
@@ -9,7 +9,7 @@ build:
 requirements:
   run:
     # The following packages are common to ska3-<flight|matlab|aca>
-    - aca_view ==0.16.0
+    - aca_view ==0.17.0
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.3.1
     - acispy ==2.8.0
@@ -19,7 +19,7 @@ requirements:
     - chandra_limits ==0.10.1
     - chandra_maneuver ==4.4.0
     - chandra_time ==4.2.0
-    - cheta ==4.63.2
+    - cheta ==4.64.0
     - cxotime ==3.10.2
     - fot-matlab ==2.5.0
     - hopper ==4.6.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2025.6
+  version: 2025.8
 
 build:
   noarch: generic
@@ -12,21 +12,21 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.3.1
     - acispy ==2.8.0
-    - agasc ==4.23.0
+    - agasc ==4.23.1
     - backstop_history ==3.2.1
-    - chandra_aca ==4.51.0
+    - chandra_aca ==4.51.1
     - chandra_limits ==0.10.1
-    - chandra_maneuver ==4.3.1
+    - chandra_maneuver ==4.4.0
     - chandra_time ==4.2.0
     - cheta ==4.63.2
-    - cxotime ==3.10.1
-    - fot-matlab ==2.4.1
+    - cxotime ==3.10.2
+    - fot-matlab ==2.5.0
     - hopper ==4.6.0
-    - kadi ==7.17.1
-    - maude ==3.13.0
+    - kadi ==7.17.3
+    - maude ==3.14.0
     - mica ==4.39.0
     - parse_cm ==3.17.0
-    - proseco ==5.16.1
+    - proseco ==5.16.2
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -47,7 +47,7 @@ requirements:
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - sparkles ==4.29.0
+    - sparkles ==4.30.0
     - starcheck ==14.14.0
     - testr ==4.13.0
     - xija ==4.33.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2025.8
+  version: 2025.6
 
 build:
   noarch: generic
@@ -12,21 +12,21 @@ requirements:
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.3.1
     - acispy ==2.8.0
-    - agasc ==4.23.1
+    - agasc ==4.23.0
     - backstop_history ==3.2.1
-    - chandra_aca ==4.51.1
+    - chandra_aca ==4.51.0
     - chandra_limits ==0.10.1
-    - chandra_maneuver ==4.4.0
+    - chandra_maneuver ==4.3.1
     - chandra_time ==4.2.0
-    - cheta ==4.64.0
-    - cxotime ==3.10.2
-    - fot-matlab ==2.5.0
+    - cheta ==4.63.2
+    - cxotime ==3.10.1
+    - fot-matlab ==2.4.1
     - hopper ==4.6.0
-    - kadi ==7.17.3
-    - maude ==3.14.0
+    - kadi ==7.17.1
+    - maude ==3.13.0
     - mica ==4.39.0
     - parse_cm ==3.17.0
-    - proseco ==5.16.2
+    - proseco ==5.16.1
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
     - ska-sphinx-theme ==1.3.0
@@ -47,7 +47,7 @@ requirements:
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - sparkles ==4.30.0
+    - sparkles ==4.29.0
     - starcheck ==14.14.0
     - testr ==4.13.0
     - xija ==4.33.2

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - chandra_limits ==0.10.1
     - chandra_maneuver ==4.4.0
     - chandra_time ==4.2.0
-    - cheta ==4.63.2
+    - cheta ==4.64.0
     - cxotime ==3.10.2
     - fot-matlab ==2.5.0
     - hopper ==4.6.0


### PR DESCRIPTION
# ska3-aca 2025.8

This PR includes:
- sparkles: as the definition of "creep-away" has been updated to be a maneuver angle within 3 degrees, the code has been updated to use that as well (was previously within 5 degrees).  This was discussed at SS&AWG on 07/30/2025.

## Interface Impacts:

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.8-HEAD).

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2025.8rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2025.8rc#
```

If this release includes an update to ska3-perl, the install process for Aspect will include that. Note: ska3-perl is generally not needed for non-Aspect users.

```
conda create -n ska3-flight-2025.8rc# --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2025.8rc# ska3-perl==2025.8rc#
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2025.8 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-flight changes (2025.6 -> 2025.8rc1)

### Updated Packages

- **agasc:** 4.23.0 -> 4.23.1 (4.23.0 -> 4.23.1)
  - [PR 202](https://github.com/sot/agasc/pull/202) (Javier Gonzalez): Zero size error
  - [PR 200](https://github.com/sot/agasc/pull/200) (Javier Gonzalez): ruff
- **chandra_aca:** 4.51.0 -> 4.51.1 (4.51.0 -> 4.51.1)
  - [PR 195](https://github.com/sot/chandra_aca/pull/195) (Jean Connelly): Add IMGSIZE to maude aca images
- **chandra_maneuver:** 4.3.1 -> 4.4.0 (4.3.1 -> 4.4.0)
  - [PR 33](https://github.com/sot/chandra_maneuver/pull/33) (Tom Aldcroft): Add function to return maneuver profile and update docstrings to numpydoc
  - [PR 32](https://github.com/sot/chandra_maneuver/pull/32) (Jean Connelly): Install the new test data in the namespace version
  - [PR 31](https://github.com/sot/chandra_maneuver/pull/31) (Jean Connelly): Add a method to calculate the maneuver error due to stellar aberration
- **cheta:** 4.63.2 -> 4.64.0 (4.63.2 -> 4.64.0)
  - [PR 278](https://github.com/sot/cheta/pull/278) (Jean Connelly): Update MSID dtype property to handle objects
  - [PR 276](https://github.com/sot/cheta/pull/276) (Tom Aldcroft): Exactly one data source
- **cxotime:** 3.10.1 -> 3.10.2 (3.10.1 -> 3.10.2)
  - [PR 53](https://github.com/sot/cxotime/pull/53) (Jean Connelly): Fix docs typo 'muade'
- **fot-matlab:** 2.4.1 -> 2.5.0 (2.4.1 -> 2.5.0)
  - [PR 30](https://github.com/sot/fot-matlab/pull/30) (James Kristoff): Ruff take 2
  - [PR 29](https://github.com/sot/fot-matlab/pull/29) (James Jay): Creating a Suite of fot-matlab Utilities
  - [PR 1](https://github.com/sot/fot-matlab/pull/1) (Unknown): updates to PR for generality and performance
- **kadi:** 7.17.1 -> 7.17.3 (7.17.1 -> 7.17.2 -> 7.17.3)
  - [PR 361](https://github.com/sot/kadi/pull/361) (Jean Connelly): Use shorter file names in the regression test data
  - [PR 362](https://github.com/sot/kadi/pull/362) (Jean Connelly): Update to conditionally skip some tests that fail without internet
- **maude:** 3.13.0 -> 3.14.0 (3.13.0 -> 3.14.0)
  - [PR 49](https://github.com/sot/maude/pull/49) (Jean Connelly): Add functionality to get MAUDE recorded data endtime 
- **proseco:** 5.16.1 -> 5.16.2 (5.16.1 -> 5.16.2)
  - [PR 406](https://github.com/sot/proseco/pull/406) (Tom Aldcroft): Extrapolate mag for mag err and ruff-driven changes
- **sparkles:** 4.29.0 -> 4.30.0 (4.29.0 -> 4.30.0)
  - [PR 222](https://github.com/sot/sparkles/pull/222) (Jean Connelly): Reduce creep-away threshold to 3.0


## ska3-aca changes (2025.5 -> 2025.8rc1)

### Updated Packages

- **agasc:** 4.23.0 -> 4.23.1 (4.23.0 -> 4.23.1)
  - [PR 202](https://github.com/sot/agasc/pull/202) (Javier Gonzalez): Zero size error
  - [PR 200](https://github.com/sot/agasc/pull/200) (Javier Gonzalez): ruff
- **chandra_aca:** 4.51.0 -> 4.51.1 (4.51.0 -> 4.51.1)
  - [PR 195](https://github.com/sot/chandra_aca/pull/195) (Jean Connelly): Add IMGSIZE to maude aca images
- **chandra_maneuver:** 4.3.1 -> 4.4.0 (4.3.1 -> 4.4.0)
  - [PR 33](https://github.com/sot/chandra_maneuver/pull/33) (Tom Aldcroft): Add function to return maneuver profile and update docstrings to numpydoc
  - [PR 32](https://github.com/sot/chandra_maneuver/pull/32) (Jean Connelly): Install the new test data in the namespace version
  - [PR 31](https://github.com/sot/chandra_maneuver/pull/31) (Jean Connelly): Add a method to calculate the maneuver error due to stellar aberration
- **cxotime:** 3.10.1 -> 3.10.2 (3.10.1 -> 3.10.2)
  - [PR 53](https://github.com/sot/cxotime/pull/53) (Jean Connelly): Fix docs typo 'muade'
- **fot-matlab:** 2.4.1 -> 2.5.0 (2.4.1 -> 2.5.0)
  - [PR 30](https://github.com/sot/fot-matlab/pull/30) (James Kristoff): Ruff take 2
  - [PR 29](https://github.com/sot/fot-matlab/pull/29) (James Jay): Creating a Suite of fot-matlab Utilities
  - [PR 1](https://github.com/sot/fot-matlab/pull/1) (Unknown): updates to PR for generality and performance
- **kadi:** 7.17.1 -> 7.17.3 (7.17.1 -> 7.17.2 -> 7.17.3)
  - [PR 361](https://github.com/sot/kadi/pull/361) (Jean Connelly): Use shorter file names in the regression test data
  - [PR 362](https://github.com/sot/kadi/pull/362) (Jean Connelly): Update to conditionally skip some tests that fail without internet
- **maude:** 3.13.0 -> 3.14.0 (3.13.0 -> 3.14.0)
  - [PR 49](https://github.com/sot/maude/pull/49) (Jean Connelly): Add functionality to get MAUDE recorded data endtime 
- **proseco:** 5.16.1 -> 5.16.2 (5.16.1 -> 5.16.2)
  - [PR 406](https://github.com/sot/proseco/pull/406) (Tom Aldcroft): Extrapolate mag for mag err and ruff-driven changes
- **sparkles:** 4.29.0 -> 4.30.0 (4.29.0 -> 4.30.0)
  - [PR 222](https://github.com/sot/sparkles/pull/222) (Jean Connelly): Reduce creep-away threshold to 3.0

# Related Issues

Fixes #1560
Fixes #1561
Fixes #1562
Fixes #1563
Fixes #1564
Fixes #1565
Fixes #1568
Fixes #1572
Fixes #1573

