### PR TITLE
2025.10

### DIFF
--- a/pkg_defs/ska3-flight-latest/meta.yaml
+++ b/pkg_defs/ska3-flight-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-flight-latest
-  version: 2025.1
+  version: 2025.10
 
 build:
   noarch: generic
@@ -30,6 +30,7 @@ requirements:
     - proseco
     - pyyaks
     - quaternion
+    - razl
     - ska-sphinx-theme
     - ska_arc5gl
     - ska_astro

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,34 +1,35 @@
 ---
 package:
   name: ska3-flight
-  version: 2025.6
+  version: "2025.10"
 
 build:
   noarch: generic
 
 requirements:
   run:
-    - aca_view ==0.16.0
+    - aca_view ==0.17.0
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.3.1
     - acispy ==2.8.0
-    - agasc ==4.23.0
+    - agasc ==4.23.1
     - backstop_history ==3.2.1
-    - chandra_aca ==4.51.0
-    - chandra_limits ==0.10.1
-    - chandra_maneuver ==4.3.1
+    - chandra_aca ==4.51.1
+    - chandra_limits ==0.11.0
+    - chandra_maneuver ==4.4.0
     - chandra_time ==4.2.0
-    - cheta ==4.63.2
-    - cxotime ==3.10.1
-    - fot-matlab ==2.4.1
+    - cheta ==4.65.0
+    - cxotime ==3.10.2
+    - fot-matlab ==2.5.0
     - hopper ==4.6.0
-    - kadi ==7.17.1
-    - maude ==3.13.0
-    - mica ==4.39.0
-    - parse_cm ==3.17.0
-    - proseco ==5.16.1
+    - kadi ==7.17.3
+    - maude ==3.14.0
+    - mica ==4.39.1
+    - parse_cm ==3.18.0
+    - proseco ==5.17.0
     - pyyaks ==4.5.0
     - quaternion ==4.3.1
+    - razl ==0.1.0
     - ska-sphinx-theme ==1.3.0
     - ska3-core ==2025.5
     - ska3-template ==2022.06.02
@@ -47,7 +48,7 @@ requirements:
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - sparkles ==4.29.0
-    - starcheck ==14.14.0
+    - sparkles ==4.31.0
+    - starcheck ==14.15.0
     - testr ==4.13.0
     - xija ==4.33.2


### PR DESCRIPTION
# ska3-flight 2025.10

This PR includes:
-

## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.10/).

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2025.10rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2025.10rc1
```

If this release includes an update to ska3-perl, the install process for Aspect will include that. Note: ska3-perl is generally not needed for non-Aspect users.

```
conda create -n ska3-flight-2025.10rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2025.10rc1 ska3-perl==2025.10rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2025.10 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

# Related Issues
