### PR TITLE
2025.14

### DIFF
--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - ska_dbi ==5.2.0
     - ska_file ==4.0.0
     - ska_ftp ==4.0.1
-    - ska_helpers ==0.20.0
+    - ska_helpers ==0.20.1
     - ska_matplotlib ==4.0.1
     - ska_numpy ==4.0.1
     - ska_parsecm ==4.0.1


### PR DESCRIPTION
# ska3-flight 2025.14

This PR includes:
- chandra_time and cxotime: Changes to allow for quantity-string time delta as CxoTime initializer. 
- chandra_limits: Fix incorrect handling of SPECTRA_MAX_COUNT limit value
- kadi: changes to ensure that the scheduled stop time for loads reflects interrupts by clipping the stop time to the RLTT of the interrupt load.
- xija: various enhancements to guifit
- updates to aspect processing packages

NOTE: an issue was found in RC2, so RC3 fixed it. The only difference between RC2 and RC3 is
- **ska_helpers:** 0.19.0 -> 0.20.0 (0.19.0 -> 0.20.0)
  - [PR 65](https://github.com/sot/ska_helpers/pull/65) (Tom Aldcroft): Hide retry func kwarg values in logging
  
## Interface Impacts:

- sot/kadi/pull/364 Changes the timing of the LOAD_EVENT SCHEDULED_STOP_TIME command for an interrupted load.
- sot/cxotime/pull/54 adds a way to initialize CxoTime
- sot/chandra_time/pull/60 adds a way to initialize DateTime

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.14rc3-HEAD).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.14rc3-GRETA).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2025.14rc3-OSX).

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2025.14rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2025.14rc1
```

If this release includes an update to ska3-perl, the install process for Aspect will include that. Note: ska3-perl is generally not needed for non-Aspect users.

```
conda create -n ska3-flight-2025.14rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2025.14rc1 ska3-perl==2025.14rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2025.14 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-flight changes (2025.10 -> 2025.14rc3)

### Updated Packages

- **aca_view:** 0.17.0 -> 0.18.0 (0.17.0 -> 0.18.0)
  - [PR 197](https://github.com/sot/aca_view/pull/197) (Javier Gonzalez): add aperoll
  - [PR 210](https://github.com/sot/aca_view/pull/210) (Jean Connelly): Fix start stop for delta time
- **acis_thermal_check:** 5.3.1 -> 5.3.2 (5.3.1 -> 5.3.2)
  - [PR 78](https://github.com/acisops/acis_thermal_check/pull/78) (John ZuHone): Fix ACIS FP limit in test answers following chandra_limits PR 23 fix, use ruff for all linting
- **agasc:** 4.23.1 -> 4.23.2 (4.23.1 -> 4.23.2)
  - [PR 203](https://github.com/sot/agasc/pull/203) (Javier Gonzalez): Make it so "No telemetry data" is not considered a failure
  - [PR 190](https://github.com/sot/agasc/pull/190) (Javier Gonzalez): Get last_updated supplement table without error
- **chandra_aca:** 4.51.1 -> 4.52.0 (4.51.1 -> 4.52.0)
  - [PR 196](https://github.com/sot/chandra_aca/pull/196) (Jean Connelly): Add STK ephem source option to get_planet_chandra
- **chandra_limits:** 0.11.0 -> 0.11.1 (0.11.0 -> 0.11.1)
  - [PR 23](https://github.com/sot/chandra_limits/pull/23) (John ZuHone): [bugfix] Fix incorrect handling of SPECTRA_MAX_COUNT limit value
- **chandra_time:** 4.2.0 -> 4.3.0 (4.2.0 -> 4.3.0)
  - [PR 60](https://github.com/sot/chandra_time/pull/60) (Tom Aldcroft): Allow for quantity-string time delta as CxoTime initializer
- **cheta:** 4.65.0 -> 4.66.0 (4.65.0 -> 4.66.0)
  - [PR 283](https://github.com/sot/cheta/pull/283) (Tom Aldcroft): Update ephem_stk code and testing for kadi.occweb built-in retry
- **cxotime:** 3.10.2 -> 3.11.0 (3.10.2 -> 3.11.0)
  - [PR 54](https://github.com/sot/cxotime/pull/54) (Tom Aldcroft): Allow for quantity-string time delta as CxoTime initializer
- **fot-matlab:** 2.5.0 -> 2.5.1 (2.5.0 -> 2.5.1)
  - [PR 34](https://github.com/sot/fot-matlab/pull/34) (James Jay): More Ruff Updates
  - [PR 33](https://github.com/sot/fot-matlab/pull/33) (James Jay): Updated code to fix existing ruff issues
  - [PR 32](https://github.com/sot/fot-matlab/pull/32) (James Jay): Update kadi.py configuration options
- **kadi:** 7.17.3 -> 7.17.5 (7.17.3 -> 7.17.4 -> 7.17.5)
  - [PR 364](https://github.com/sot/kadi/pull/364) (Tom Aldcroft): Clip scheduled_stop_time to RLTT
  - [PR 366](https://github.com/sot/kadi/pull/366) (Tom Aldcroft): Improve robustness of OCCweb utilities and kadi commands
- **maude:** 3.14.0 -> 3.15.0 (3.14.0 -> 3.15.0)
  - [PR 53](https://github.com/sot/maude/pull/53) (Jean Connelly): Add default maude query retry and conf to control it
- **ska_helpers:** 0.19.0 -> 0.20.0 (0.19.0 -> 0.20.1)
  - [PR 64](https://github.com/sot/ska_helpers/pull/64) (Tom Aldcroft): Improve retry functionality in a few ways
  - [PR 65](https://github.com/sot/ska_helpers/pull/65) (Tom Aldcroft): Hide retry func kwarg values in logging
- **xija:** 4.33.2 -> 4.35.0 (4.33.2 -> 4.34.0 -> 4.35.0)
  - [PR 146](https://github.com/sot/xija/pull/146) (John ZuHone): xija_gui_fit enhancements
  - [PR 148](https://github.com/sot/xija/pull/148) (John ZuHone): Add eclipse support to the SimZDepSolarHeat class and fix crashes in xija_gui_fit
  
# Related Issues

Fixes #1603
Fixes #1605
Fixes #1606
Fixes #1607
Fixes #1608
Fixes #1609
Fixes #1610
Fixes #1611

