### PR TITLE
Remove PLR1730 from ruff-base.toml as now unknown

### DIFF
--- a/templates/ruff-base.toml
+++ b/templates/ruff-base.toml
@@ -40,7 +40,6 @@ lint.ignore = [
   "PLR2004", # Magic number
   "B028", # No explicit `stacklevel` keyword argument found
   "PLR0913", # Too many arguments to function call
-  "PLR1730", # Checks for if statements that can be replaced with min() or max() calls
   "PLC0415", # `import` should be at the top-level of a file
   "PLW1641", # Class implements `__hash__` if `__eq__` is implemented
 ]


### PR DESCRIPTION
Remove PLR1730 as now unknown

Unknown rule selector: `PLR1730`
