### PR TITLE
Add a recipe to build replan central

### DIFF
--- a/pkg_defs/arc/meta.yaml
+++ b/pkg_defs/arc/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: replan_central
+  name: arc
   version:  {{ SKA_PKG_VERSION }}
 
 build:
@@ -19,7 +19,7 @@ build:
     - replan-central-plot-hrc=replan_central.plot_hrc:main
 
 source:
-  path: {{ SKA_TOP_SRC_DIR }}/xija
+  path: {{ SKA_TOP_SRC_DIR }}/arc
 
 
 # the build and runtime requirements. Dependencies of these requirements


### PR DESCRIPTION
Add a recipe to build replan central.

This works with the build in the "package" branch in https://github.com/sot/arc/pull/96 .

Tested against ac4c84b using ska_builder.py on Linux only.