### PR TITLE
2026.4

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2026.2
+  version: 2026.4
 
 build:
   noarch: generic
@@ -14,7 +14,7 @@ requirements:
     - acispy ==2.8.0
     - agasc ==4.23.3
     - backstop_history ==3.2.1
-    - chandra_aca ==4.53.0
+    - chandra_aca ==4.54.0
     - chandra_limits ==0.11.2
     - chandra_maneuver ==4.4.1
     - chandra_time ==4.3.1
@@ -22,16 +22,16 @@ requirements:
     - cxotime ==3.11.1
     - fot-matlab ==2.5.2
     - hopper ==4.6.0
-    - kadi ==7.18.1
+    - kadi ==7.19.0
     - maude ==3.15.1
-    - mica ==4.39.2
+    - mica ==4.40.0
     - parse_cm ==3.18.1
     - proseco ==5.18.0
     - pyyaks ==4.5.1
     - quaternion ==4.3.1
     - razl ==0.1.0
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2026.2
+    - ska3-core ==2026.3
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cxotime ==3.11.1
     - fot-matlab ==2.5.2
     - hopper ==4.6.0
-    - kadi ==7.19.0
+    - kadi ==7.19.1
     - maude ==3.15.1
     - mica ==4.40.0
     - parse_cm ==3.18.1


### PR DESCRIPTION
# ska3-matlab 2026.4

This PR includes:
- kadi:
  - Add scheduled obsid to commands, states, observations (https://github.com/sot/kadi/pull/368)
  - change date filtering in `get_observations` so an observation goes from manvr_start to obs_stop
  -  `kadi.commands` will now require scenario="flight" if there is no internet connection (https://github.com/sot/kadi/pull/375)
  - Support HRC 15V On from SCS-85 activation (https://github.com/sot/kadi/pull/384)

## Interface Impacts:

Interface impacts from kadi:
- Kadi will now require scenario="flight" if there is no internet connection. This can be set globally via the environment variable `KADI_SCENARIO="flight"`
- Date-based queries that start or end within a maneuver may return additional observations relative to the previous version.
- Adds new archive files `$SKA/data/kadi/cmds3.{h5,pkl}` that need to be synced.
- Adds new `type=LOAD_EVENT tlmsid=OBSID` commands.
- Adds a new column `obsid_sched` to the output of `get_observations()`.
- Adds a new state key `obsid_sched` to query the scheduled ObsID.
- Adds a new `conf.matching_block_size` configuration variable for testing.
- Adds a new environment variable `KADI_CMDS_VERSION` to explicitly specify the cmds archive version.
- In the function `get_load_cmds_from_occweb_or_local`, the `archive` kwarg is renamed to `in_work` for clarity. This function is private in practice.

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.4rc2-HEAD/).
- [Windows](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.4rc2-Windows/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.4rc2-GRETA/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2026.4rc2 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2026.4rc2
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2026.4 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2026.4rc1 -> 2026.4rc2)

https://github.com/sot/skare3/compare/2026.4rc1...2026.4rc2

- **kadi:** 7.19.0 -> 7.19.1
  - [PR](https://github.com/sot/kadi/pull/384) (Tom Aldcroft): https://github.com/sot/kadi/pull/384

## ska3-matlab changes (2026.2 -> 2026.4rc1)

### Updated Packages

- **chandra_aca:** 4.53.0 -> 4.54.0 (4.53.0 -> 4.54.0)
  - [PR 200](https://github.com/sot/chandra_aca/pull/200) (Tom Aldcroft): DOC: Fix tiny documentation typo
  - [PR 199](https://github.com/sot/chandra_aca/pull/199) (Tom Aldcroft): Add support for new quadrant zero offsets and constraint handling
- **kadi:** 7.18.1 -> 7.19.1 (7.18.1 -> 7.19.1)
  - [PR 381](https://github.com/sot/kadi/pull/381) (Tom Aldcroft): Make date filtering for get_observations more inclusive
  - [PR 352](https://github.com/sot/kadi/pull/352) (Tom Aldcroft): Set star IDs per star and fix get_starcats bug
  - [PR 379](https://github.com/sot/kadi/pull/379) (Tom Aldcroft): Fix the absolute path handling to work on Windows
  - [PR 368](https://github.com/sot/kadi/pull/368) (Tom Aldcroft): Add scheduled obsid to commands, states, observations
  - [PR 375](https://github.com/sot/kadi/pull/375) (Tom Aldcroft): Require scenario="flight" if no internet
  - [PR 378](https://github.com/sot/kadi/pull/378) (Tom Aldcroft): Fix mistake in docs for filtering events
- **mica:** 4.39.2 -> 4.40.0 (4.39.2 -> 4.40.0)
  - [PR 325](https://github.com/sot/mica/pull/325) (Tom Aldcroft): Improve ACA header 3 decom support
- **ska3-core:** 2026.2 -> 2026.3

# Related Issues

Fixes #1668