### PR TITLE
2026.6

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2026.3
+  version: 2026.6
 
 requirements:
   run:
@@ -267,7 +267,7 @@ requirements:
     - libcrc32c ==1.1.2
     - libcups ==2.3.3  # [linux]
     - libcurl ==8.17.0
-    - libcxx ==21.1.8  # [osx]
+    - libcxx ==22.1.2  # [osx]
     - libdeflate ==1.25
     - libdrm ==2.4.125  # [linux]
     - libedit ==3.1.20250104  # [linux or osx]

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2026.1
+  version: 2026.6
 
 build:
   noarch: generic
@@ -14,24 +14,24 @@ requirements:
     - acispy ==2.8.0
     - agasc ==4.23.3
     - backstop_history ==3.2.1
-    - chandra_aca ==4.53.0
+    - chandra_aca ==4.55.0
     - chandra_limits ==0.11.2
     - chandra_maneuver ==4.4.1
     - chandra_time ==4.3.1
-    - cheta ==4.67.1
+    - cheta ==4.68.0
     - cxotime ==3.11.1
-    - fot-matlab ==2.5.1
+    - fot-matlab ==2.5.2
     - hopper ==4.6.0
-    - kadi ==7.18.1
+    - kadi ==7.21.0
     - maude ==3.15.1
-    - mica ==4.39.2
-    - parse_cm ==3.18.1
-    - proseco ==5.18.0
+    - mica ==4.40.0
+    - parse_cm ==3.19.0
+    - proseco ==5.19.0
     - pyyaks ==4.5.1
     - quaternion ==4.3.1
     - razl ==0.1.0
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2026.1
+    - ska3-core ==2026.6
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
@@ -47,7 +47,7 @@ requirements:
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - sparkles ==4.31.2
+    - sparkles ==4.31.3
     - starcheck ==14.16.0
     - testr ==4.13.0
-    - xija ==4.36.0
+    - xija ==4.37.0


### PR DESCRIPTION
# ska3-flight 2026.6

This PR includes:

- kadi
  - change the filtering in `commands.observations.get_observations` to use the observation's `manvr_start`and `obs_stop` (as opposed to `obs_start` and `obs_stop`).
  - fix an issue when getting star IDs from backstop, and in `commands.observations.get_starcats`. 
  - Add scheduled obsid to commands, states, observations.
  - Require scenario="flight" if no internet.
  - Support HRC 15V On from SCS-85 activation.
- parse_cm: Add a new convenience function (`paths.load_url_from_load_name`) to get the URL for a load directory on either icxc or OCCweb based on the load name.
- chandra_aca:
  - improve ACA pixel row,col <=> angle yag,zag transformations to properly account for CCD temperature.
  - in read_manvr_mon_images: add support for new quadrant zero offsets, and for filtering based on planning constraints.

## Interface Impacts:


**Requires `scenario="flight"` if there is no internet**.

This might require changes in downstream code, e.g. `mica.starcheck.get_starcheck_catalog` ends up calling `get_observations`, so now that would fail without internet. Kadi scenario can be set globally via the environment variable `KADI_SCENARIO="flight"` (either programatically or in a shell).

**New data file**
There are new kadi archive files `$SKA/data/kadi/cmds3.{h5,pkl}` **that need to be synced.**

If the files are not present, kadi falls back to use the previous version, which is fine unless one intends to use the scheduled OBSID.

**Other changes in kadi**

- Date-based queries that start or end within a maneuver may return additional observations relative to the previous version.
- Adds new `type=LOAD_EVENT tlmsid=OBSID` commands.
- Adds a new column `obsid_sched` to the output of `get_observations()`.
- Adds a new state key `obsid_sched` to query the scheduled ObsID.
- Adds a new `conf.matching_block_size` configuration variable for testing.
- Adds a new environment variable `KADI_CMDS_VERSION` to explicitly specify the cmds archive version.
- In the function `get_load_cmds_from_occweb_or_local`, the `archive` kwarg is renamed to `in_work` for clarity. This function is private in practice.

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.6rc1-HEAD/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.6rc1-GRETA/).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.6rc3-OSX/).

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2026.6rc3 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2026.6rc3
```

If this release includes an update to ska3-perl, the install process for Aspect will include that. Note: ska3-perl is generally not needed for non-Aspect users.

```
conda create -n ska3-flight-2026.6rc3 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2026.6rc3 ska3-perl
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2026.6 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-flight changes (2026.1 -> 2026.6rc2)

### Updated Packages

- **chandra_aca:** 4.53.0 -> 4.55.0 (4.53.0 -> 4.54.0 -> 4.55.0)
  - [PR 200](https://github.com/sot/chandra_aca/pull/200) (Tom Aldcroft): DOC: Fix tiny documentation typo
  - [PR 199](https://github.com/sot/chandra_aca/pull/199) (Tom Aldcroft): Add support for new quadrant zero offsets and constraint handling
  - [PR 202](https://github.com/sot/chandra_aca/pull/202) (Tom Aldcroft): Improve aca coord transforms
- **cheta:** 4.67.1 -> 4.68.0 (4.67.1 -> 4.68.0)
  - [PR 289](https://github.com/sot/cheta/pull/289) (Tom Aldcroft): Better missing units handling
- **fot-matlab:** 2.5.1 -> 2.5.2 (2.5.1 -> 2.5.2)
- **kadi:** 7.18.1 -> 7.21.0 (7.18.1 -> 7.19.0 -> 7.19.1 -> 7.20.0 -> 7.21.0)
  - [PR 381](https://github.com/sot/kadi/pull/381) (Tom Aldcroft): Make date filtering for get_observations more inclusive
  - [PR 352](https://github.com/sot/kadi/pull/352) (Tom Aldcroft): Set star IDs per star and fix get_starcats bug
  - [PR 379](https://github.com/sot/kadi/pull/379) (Tom Aldcroft): Fix the absolute path handling to work on Windows
  - [PR 368](https://github.com/sot/kadi/pull/368) (Tom Aldcroft): Add scheduled obsid to commands, states, observations
  - [PR 375](https://github.com/sot/kadi/pull/375) (Tom Aldcroft): Require scenario="flight" if no internet
  - [PR 378](https://github.com/sot/kadi/pull/378) (Tom Aldcroft): Fix mistake in docs for filtering events
  - [PR 383](https://github.com/sot/kadi/pull/383) (Jean Connelly): Remove defunct unused AGASC_FILE from observations
  - [PR 382](https://github.com/sot/kadi/pull/382) (Tom Aldcroft): Merge each OBS command from an obsid-changing CMD_EVT into the prior …
  - [PR 380](https://github.com/sot/kadi/pull/380) (Tom Aldcroft): Filter observations and starcats by scheduled obsid and other obs params
  - [PR 384](https://github.com/sot/kadi/pull/384) (Tom Aldcroft): Support HRC 15V On from SCS-85 activation
- **mica:** 4.39.2 -> 4.40.0 (4.39.2 -> 4.40.0)
  - [PR 325](https://github.com/sot/mica/pull/325) (Tom Aldcroft): Improve ACA header 3 decom support
- **parse_cm:** 3.18.1 -> 3.19.0 (3.18.1 -> 3.19.0)
  - [PR 64](https://github.com/sot/parse_cm/pull/64) (Tom Aldcroft): Add load_url_from_load_name function and corresponding tests
- **proseco:** 5.18.0 -> 5.19.0 (5.18.0 -> 5.19.0)
  - [PR 414](https://github.com/sot/proseco/pull/414) (Tom Aldcroft): Use chandra_aca 2020 transforms with T_aca = T_ccd + 41 C
- **ska3-core:** 2026.1 -> 2026.3
- **sparkles:** 4.31.2 -> 4.31.3 (4.31.2 -> 4.31.3)
  - [PR 228](https://github.com/sot/sparkles/pull/228) (Jean Connelly): Update test regress vals for chandra_aca coord improvements
- **xija:** 4.36.0 -> 4.37.0 (4.36.0 -> 4.37.0)
  - [PR 153](https://github.com/sot/xija/pull/153) (Tom Aldcroft): DOC: Modernize and fix example script
 

# Related Issues

Fixes #1681
