### PR TITLE
Add '.eggs' to extend-exclude list in ruff-base.toml

### DIFF
--- a/templates/ruff-base.toml
+++ b/templates/ruff-base.toml
@@ -48,6 +48,7 @@ lint.ignore = [
 extend-exclude = [
   "docs",
   "build",
+  ".eggs",
 ]
 
 [lint.pycodestyle]


### PR DESCRIPTION
Ruff is digging into an `.eggs` directory.