### PR TITLE
2026.7

### DIFF
--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -9,7 +9,6 @@ requirements:
    - astropy-sphinx-theme
    - astropy-healpix
    - astroquery
-   - attrs
    - backports
    - backports.zoneinfo
    - beautifulsoup4
@@ -17,6 +16,7 @@ requirements:
    - black
    - cloudpickle # [win]
    - conda
+   - conda-build  # [linux or osx]
    - configobj
    - coverage
    - cython
@@ -50,7 +50,6 @@ requirements:
    - numpy
    - numpydoc
    - pandas
-   - psutil
    - pytables
    - autopep8
    - openpyxl
@@ -78,7 +77,6 @@ requirements:
    - setuptools
    - setuptools_scm
    - sherpa # [not win]
-   - soupsieve
    - sphinx-argparse
    - sphinx-autoapi
    - sphinx-copybutton

--- a/pkg_defs/ska3-core-latest/meta.yaml
+++ b/pkg_defs/ska3-core-latest/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: ska3-core-latest
-  version: 2026.1
+  version: 2026.7
 
 requirements:
   run:
@@ -9,6 +9,7 @@ requirements:
    - astropy-sphinx-theme
    - astropy-healpix
    - astroquery
+   - attrs
    - backports
    - backports.zoneinfo
    - beautifulsoup4
@@ -16,7 +17,6 @@ requirements:
    - black
    - cloudpickle # [win]
    - conda
-   - conda-build
    - configobj
    - coverage
    - cython
@@ -50,6 +50,7 @@ requirements:
    - numpy
    - numpydoc
    - pandas
+   - psutil
    - pytables
    - autopep8
    - openpyxl
@@ -77,6 +78,7 @@ requirements:
    - setuptools
    - setuptools_scm
    - sherpa # [not win]
+   - soupsieve
    - sphinx-argparse
    - sphinx-autoapi
    - sphinx-copybutton

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2026.6
+  version: 2026.7
 
 requirements:
   run:
@@ -109,7 +109,6 @@ requirements:
     - comm ==0.2.3
     - commonmark ==0.9.1
     - conda ==25.11.1
-    - conda-build ==25.11.1
     - conda-index ==0.7.0
     - conda-libmamba-solver ==25.11.0
     - conda-package-handling ==2.4.0
@@ -209,9 +208,6 @@ requirements:
     - json5 ==0.13.0
     - jsonpatch ==1.33
     - jsonpointer ==3.0.0
-    - jsonschema ==4.25.1
-    - jsonschema-specifications ==2025.9.1
-    - jsonschema-with-format-nongpl ==4.25.1
     - jupyter ==1.1.1
     - jupyter-lsp ==2.3.0
     - jupyter_client ==8.7.0
@@ -362,9 +358,6 @@ requirements:
     - lxml ==6.0.2
     - lz4-c ==1.10.0
     - lzo ==2.10
-    - m2-conda-epoch ==20250515  # [win]
-    - m2-msys2-runtime ==3.6.1.4  # [win]
-    - m2-patch ==2.7.6.3  # [win]
     - mamba ==2.3.2  # [linux]
     - mamba ==2.4.0  # [osx or win]
     - markupsafe ==3.0.3
@@ -502,7 +495,6 @@ requirements:
     - qtpy ==2.4.3
     - re2 ==2025.11.05
     - readline ==8.3  # [linux or osx]
-    - referencing ==0.37.0
     - regions ==0.11
     - reproc ==14.2.5.post0
     - reproc-cpp ==14.2.5.post0
@@ -515,7 +507,6 @@ requirements:
     - ripgrep ==15.1.0
     - roman-numerals ==4.1.0
     - rope ==1.14.0
-    - rpds-py ==0.30.0
     - ruamel.yaml ==0.18.17
     - ruamel.yaml.clib ==0.2.15
     - s2n ==1.5.26  # [linux]

--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -109,6 +109,7 @@ requirements:
     - comm ==0.2.3
     - commonmark ==0.9.1
     - conda ==25.11.1
+    - conda-build ==25.11.1  # [linux or osx]
     - conda-index ==0.7.0
     - conda-libmamba-solver ==25.11.0
     - conda-package-handling ==2.4.0
@@ -208,6 +209,9 @@ requirements:
     - json5 ==0.13.0
     - jsonpatch ==1.33
     - jsonpointer ==3.0.0
+    - jsonschema ==4.25.1  # [linux or osx]
+    - jsonschema-specifications ==2025.9.1  # [linux or osx]
+    - jsonschema-with-format-nongpl ==4.25.1  # [linux or osx]
     - jupyter ==1.1.1
     - jupyter-lsp ==2.3.0
     - jupyter_client ==8.7.0
@@ -495,6 +499,7 @@ requirements:
     - qtpy ==2.4.3
     - re2 ==2025.11.05
     - readline ==8.3  # [linux or osx]
+    - referencing ==0.37.0  # [linux or osx]
     - regions ==0.11
     - reproc ==14.2.5.post0
     - reproc-cpp ==14.2.5.post0
@@ -507,6 +512,7 @@ requirements:
     - ripgrep ==15.1.0
     - roman-numerals ==4.1.0
     - rope ==1.14.0
+    - rpds-py ==0.30.0  # [linux or osx]
     - ruamel.yaml ==0.18.17
     - ruamel.yaml.clib ==0.2.15
     - s2n ==1.5.26  # [linux]


### PR DESCRIPTION
# ska3-core 2026.7

remove conda-build from ska3-core[-latest] on windows, add some of its dependencies to ska3-core-latest, and remove the rest of its dependencies from ska3-core

## Interface Impacts:

The `skare3-promote` script in skare3_tools will not work unless conda-build is installed but is not used on windows.

## Testing:

Testing was done on a ska3-masters environment, which includes ska3-perl and find_attitude. ACIS tests were not run on HEAD because they take too long and I wanted to have this.

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.7rc1-HEAD/).
- [Windows](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.7rc1-Windows/).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.7rc1-OSX/).

## Review

## Deployment

This will not be deployed on its own. **The intention is to release 2026.7 so it can already be used in ska3-matlab 2026.8 and others.** Strictly speaking, we don't have to release it. We would then have to release the same thing as part of the ska3-matlab, ska3-flight and ska3-aca releases.

# Code changes

# Related Issues
