### PR TITLE
2026.8

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - cxotime ==3.11.1
     - fot-matlab ==2.5.2
     - hopper ==4.6.0
-    - kadi ==7.21.0
+    - kadi ==7.22.0
     - maude ==3.15.1
     - mica ==4.40.0
     - parse_cm ==3.19.0
@@ -31,7 +31,7 @@ requirements:
     - quaternion ==4.3.1
     - razl ==0.1.0
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2026.6
+    - ska3-core ==2026.7
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
@@ -43,9 +43,9 @@ requirements:
     - ska_numpy ==4.0.2
     - ska_path ==3.1.2
     - ska_quatutil ==4.0.0
-    - ska_shell ==4.1.1
+    - ska_shell ==4.2.0
     - ska_sun ==3.15.0
-    - ska_sync ==4.13.0
+    - ska_sync ==4.14.0
     - ska_tdb ==4.1.0
     - sparkles ==4.31.3
     - starcheck ==14.16.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - ska_numpy ==4.0.2
     - ska_path ==3.1.2
     - ska_quatutil ==4.0.0
-    - ska_shell ==4.2.0
+    - ska_shell ==4.1.1
     - ska_sun ==3.15.0
     - ska_sync ==4.14.0
     - ska_tdb ==4.1.0

--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2026.4
+  version: 2026.8
 
 build:
   noarch: generic
@@ -14,24 +14,24 @@ requirements:
     - acispy ==2.8.0
     - agasc ==4.23.3
     - backstop_history ==3.2.1
-    - chandra_aca ==4.54.0
+    - chandra_aca ==4.55.0
     - chandra_limits ==0.11.2
     - chandra_maneuver ==4.4.1
     - chandra_time ==4.3.1
-    - cheta ==4.67.1
+    - cheta ==4.68.0
     - cxotime ==3.11.1
     - fot-matlab ==2.5.2
     - hopper ==4.6.0
-    - kadi ==7.19.1
+    - kadi ==7.21.0
     - maude ==3.15.1
     - mica ==4.40.0
-    - parse_cm ==3.18.1
-    - proseco ==5.18.0
+    - parse_cm ==3.19.0
+    - proseco ==5.19.0
     - pyyaks ==4.5.1
     - quaternion ==4.3.1
     - razl ==0.1.0
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2026.3
+    - ska3-core ==2026.6
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
@@ -47,7 +47,7 @@ requirements:
     - ska_sun ==3.15.0
     - ska_sync ==4.13.0
     - ska_tdb ==4.1.0
-    - sparkles ==4.31.2
+    - sparkles ==4.31.3
     - starcheck ==14.16.0
     - testr ==4.13.0
-    - xija ==4.36.0
+    - xija ==4.37.0


### PR DESCRIPTION
# ska3-matlab 2026.8

This PR includes:
- kadi
  - fix an issue when getting star IDs from backstop, and in `commands.observations.get_starcats`. 
  - Add function get_observation to get a single observation.
- parse_cm: Add a new convenience function (`paths.load_url_from_load_name`) to get the URL for a load directory on either icxc or OCCweb based on the load name.
- chandra_aca:
  - improve ACA pixel row,col <=> angle yag,zag transformations to properly account for CCD temperature.


## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.8/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2026.8rc2 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2026.8rc2
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2026.8 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-core changes:

The following packages were removed from Windows:
- conda-build ==25.11.1
- m2-conda-epoch ==20250515
- m2-msys2-runtime ==3.6.1.4
- m2-patch ==2.7.6.3


## ska3-matlab changes (2026.4 -> 2026.8rc2)

### Updated Packages

- **chandra_aca:** 4.54.0 -> 4.55.0 (4.54.0 -> 4.55.0)
  - [PR 202](https://github.com/sot/chandra_aca/pull/202) (Tom Aldcroft): Improve aca coord transforms
- **cheta:** 4.67.1 -> 4.68.0 (4.67.1 -> 4.68.0)
  - [PR 289](https://github.com/sot/cheta/pull/289) (Tom Aldcroft): Better missing units handling
- **kadi:** 7.19.1 -> 7.22.0 (7.19.1 -> 7.20.0 -> 7.21.0 -> 7.22.0)
  - [PR 383](https://github.com/sot/kadi/pull/383) (Jean Connelly): Remove defunct unused AGASC_FILE from observations
  - [PR 382](https://github.com/sot/kadi/pull/382) (Tom Aldcroft): Merge each OBS command from an obsid-changing CMD_EVT into the prior …
  - [PR 380](https://github.com/sot/kadi/pull/380) (Tom Aldcroft): Filter observations and starcats by scheduled obsid and other obs params
  - [PR 387](https://github.com/sot/kadi/pull/387) (Tom Aldcroft): Further improvements to kadi observations
  - [PR 386](https://github.com/sot/kadi/pull/386) (Jean Connelly): Add notes for repairing recently-archived cmds
- **parse_cm:** 3.18.1 -> 3.19.0 (3.18.1 -> 3.19.0)
  - [PR 64](https://github.com/sot/parse_cm/pull/64) (Tom Aldcroft): Add load_url_from_load_name function and corresponding tests
- **proseco:** 5.18.0 -> 5.19.0 (5.18.0 -> 5.19.0)
  - [PR 414](https://github.com/sot/proseco/pull/414) (Tom Aldcroft): Use chandra_aca 2020 transforms with T_aca = T_ccd + 41 C
- **ska3-core:** 2026.3 -> 2026.7
- **ska_sync:** 4.13.0 -> 4.14.0 (4.13.0 -> 4.14.0)
  - [PR 35](https://github.com/sot/ska_sync/pull/35) (Jean Connelly): Add cmds3 to config
- **sparkles:** 4.31.2 -> 4.31.3 (4.31.2 -> 4.31.3)
  - [PR 228](https://github.com/sot/sparkles/pull/228) (Jean Connelly): Update test regress vals for chandra_aca coord improvements
- **xija:** 4.36.0 -> 4.37.0 (4.36.0 -> 4.37.0)
  - [PR 153](https://github.com/sot/xija/pull/153) (Tom Aldcroft): DOC: Modernize and fix example script
 
# Related Issues

Fixes #1694
Fixes #1692
Fixes #1691
Fixes #1690
