### PR TITLE
2026.9

### DIFF
--- a/pkg_defs/ska3-core/meta.yaml
+++ b/pkg_defs/ska3-core/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-core
-  version: 2026.7
+  version: 2026.9
 
 requirements:
   run:
@@ -26,7 +26,7 @@ requirements:
     - astropy ==7.2.0
     - astropy-base ==7.2.0
     - astropy-healpix ==1.1.2
-    - astropy-iers-data ==0.2026.1.5.0.43.43
+    - astropy-iers-data ==0.2026.6.22.1.23.34
     - astropy-sphinx-theme ==2.0
     - astroquery ==0.4.11
     - asttokens ==3.0.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-flight
-  version: 2026.6
+  version: 2026.9
 
 build:
   noarch: generic
@@ -20,18 +20,18 @@ requirements:
     - chandra_time ==4.3.1
     - cheta ==4.68.0
     - cxotime ==3.11.1
-    - fot-matlab ==2.5.2
+    - fot-matlab ==2.5.3
     - hopper ==4.6.0
-    - kadi ==7.21.0
+    - kadi ==7.22.0
     - maude ==3.15.1
     - mica ==4.40.0
     - parse_cm ==3.19.0
     - proseco ==5.19.0
     - pyyaks ==4.5.1
-    - quaternion ==4.3.1
+    - quaternion ==4.3.2
     - razl ==0.1.0
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2026.6
+    - ska3-core ==2026.7
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
@@ -45,7 +45,7 @@ requirements:
     - ska_quatutil ==4.0.0
     - ska_shell ==4.1.1
     - ska_sun ==3.15.0
-    - ska_sync ==4.13.0
+    - ska_sync ==4.14.0
     - ska_tdb ==4.1.0
     - sparkles ==4.31.3
     - starcheck ==14.16.0

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0
-    - ska_dbi ==5.2.0
+    - ska_dbi ==5.3.0
     - ska_file ==4.0.0
     - ska_ftp ==4.0.1
     - ska_helpers ==0.20.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -8,23 +8,23 @@ build:
 
 requirements:
   run:
-    - aca_view ==0.18.0
+    - aca_view ==0.19.0
     - acis_taco ==4.2.3
     - acis_thermal_check ==5.3.3
     - acispy ==2.8.0
-    - agasc ==4.23.3
+    - agasc ==4.24.0
     - backstop_history ==3.2.1
     - chandra_aca ==4.55.0
     - chandra_limits ==0.11.2
     - chandra_maneuver ==4.4.1
     - chandra_time ==4.3.1
-    - cheta ==4.68.0
+    - cheta ==4.69.0
     - cxotime ==3.11.1
     - fot-matlab ==2.5.3
     - hopper ==4.6.0
     - kadi ==7.22.0
     - maude ==3.15.1
-    - mica ==4.40.0
+    - mica ==4.41.0
     - parse_cm ==3.19.0
     - proseco ==5.19.0
     - pyyaks ==4.5.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - acispy ==2.8.0
     - agasc ==4.24.0
     - backstop_history ==3.2.1
-    - chandra_aca ==4.55.0
+    - chandra_aca ==4.56.0
     - chandra_limits ==0.11.2
     - chandra_maneuver ==4.4.1
     - chandra_time ==4.3.1

--- a/pkg_defs/ska3-flight/meta.yaml
+++ b/pkg_defs/ska3-flight/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - quaternion ==4.3.2
     - razl ==0.1.0
     - ska-sphinx-theme ==1.3.0
-    - ska3-core ==2026.7
+    - ska3-core ==2026.9
     - ska3-template ==2022.06.02
     - ska_arc5gl ==4.0.1
     - ska_astro ==4.0.0

--- a/pkg_defs/ska3-perl/meta.yaml
+++ b/pkg_defs/ska3-perl/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - perl-astro-fits-cfitsio-simple ==0.20  # [linux]
     - perl-chandra-time ==0.9.2  # [linux]
     - perl-core-deps ==0.5.0
-    - perl-cxc-sysarch ==1.00  # [linux]
+    - perl-cxc-sysarch ==1.1  # [linux]
     - perl-dbd-sybase ==1.24  # [linux]
     - perl-extended-deps ==0.5.0  # [linux]
     - perl-io-tty ==1.20

--- a/pkg_defs/ska3-template/bin/flt_envs
+++ b/pkg_defs/ska3-template/bin/flt_envs
@@ -41,9 +41,9 @@ envs = dict(('SKA_' + suffix.upper(), os.path.join(ska, suffix))
         for suffix in ('arch', 'data', 'lib', 'share', 'bin', 'idl'))
 envs['SKA'] = ska
 envs['SKA_ARCH_OS'] = ska
-envs['SYBASE_OCS'] = 'OCS-16_0'
+envs['SYBASE_OCS'] = 'OCS-16_1'
 envs['PGPLOT_DIR'] = os.path.join(ska, 'pgplot')
-envs['SYBASE'] = '/soft/SYBASE16.0'
+envs['SYBASE'] = '/soft/SYBASE16.1'
 envs['APP_ENV_ASCDS_STR'] ='/home/ascds/DS.release/config/system/.ascrc'
 envs['CFITSIO'] = ska
 


### PR DESCRIPTION
# ska3-flight 2026.9

This PR includes mostly changes useful for aspect. The more important ones are:
- cheta: Support ingesting ACA L0 image telemetry into cheta archive
- mica: Support decom of the 32-bit HDR3 quadrant offsets

## Interface Impacts:

This release requires the cheta ACA image telemetry data from sot/cheta/pull/291. This was copied into `$SKA/data/eng_archive` **in the test environment** and will need to be promoted to the flight environment. This is accounted for in the ska3-flight issue (#1708)

## Testing:

- [HEAD](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.9rc3-HEAD/).
- [GRETA](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.9rc3-GRETA/) (on chimchim).
- [OSX](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.9rc3-OSX/).

Additional tests were run on Rocky Linux 10. ACIS thermal check amd mica tests failed in this run. We believe this is caused by tests taking too long. Mica tests were repeated on their own and passed.
- [Rocky Linux 10](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.9rc3-RL10/).
- [Rocky Linux 10 mica](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.9rc3-RL10-mica/).

skare3 dashboard and test result password at https://icxc.cfa.harvard.edu/aspect/skare3_dash_cred.txt

The latest release candidates will be installed in `/proj/sot/ska3/test` on HEAD, and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-flight-2026.9rc3 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2026.9rc3
```

If this release includes an update to ska3-perl, the install process for Aspect will include that. Note: ska3-perl is generally not needed for non-Aspect users.

```
conda create -n ska3-flight-2026.9rc3 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-flight==2026.9rc3 ska3-perl
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-flight 2026.9 will be promoted to flight conda channel and installed on HEAD and GRETA Linux upon approval of FSDS Jira ticket.

# Code changes

## ska3-core changes (2026.7 -> 2026.9rc3)

### Updated Packages

- **astropy-iers-data:** 0.2026.1.5.0.43.43 -> 0.2026.6.22.1.23.34

## ska3-flight changes (2026.6 -> 2026.9rc3)

### Updated Packages

- **aca_view:** 0.18.0 -> 0.19.0 (0.18.0 -> 0.19.0)
  - [PR 217](https://github.com/sot/aca_view/pull/217) (Javier Gonzalez): When fetching data from mica l0 files, set AABGDTYP from the files
- **agasc:** 4.23.3 -> 4.24.0 (4.23.3 -> 4.24.0)
  - [PR 208](https://github.com/sot/agasc/pull/208) (Javier Gonzalez): Refactor observation statistics processing and discard recent observations without telemetry
  - [PR 210](https://github.com/sot/agasc/pull/210) (Javier Gonzalez): Always use call_args.yml to store arguments in supplement report
  - [PR 205](https://github.com/sot/agasc/pull/205) (Javier Gonzalez): Disposition docs
- **chandra_aca:** 4.55.0 -> 4.56.0 (4.55.0 -> 4.56.0)
  - [PR 207](https://github.com/sot/chandra_aca/pull/207) (Javier Gonzalez): make chandra_aca.drift.get_fid_offset faster
  - [PR 210](https://github.com/sot/chandra_aca/pull/210) (Jean Connelly): Fix bug clipping/flooring the background subtracted images at zero
  - [PR 209](https://github.com/sot/chandra_aca/pull/209) (Tom Aldcroft): Support cheta as a source for get_aca_images
  - [PR 205](https://github.com/sot/chandra_aca/pull/205) (Tom Aldcroft): Add function to compute earth and moon limb angles
  - [PR 206](https://github.com/sot/chandra_aca/pull/206) (Tom Aldcroft): Add function to get CCD quadrant from row, col
- **cheta:** 4.68.0 -> 4.69.0 (4.68.0 -> 4.69.0)
  - [PR 291](https://github.com/sot/cheta/pull/291) (Tom Aldcroft): Support ingesting ACA L0 image telemetry into cheta archive
- **fot-matlab:** 2.5.2 -> 2.5.3 (2.5.2 -> 2.5.3)
  - [PR 35](https://github.com/sot/fot-matlab/pull/35) (James Jay): Add gen_fp_limit module and corresponding test
- **kadi:** 7.21.0 -> 7.22.0 (7.21.0 -> 7.22.0)
  - [PR 387](https://github.com/sot/kadi/pull/387) (Tom Aldcroft): Further improvements to kadi observations
  - [PR 386](https://github.com/sot/kadi/pull/386) (Jean Connelly): Add notes for repairing recently-archived cmds
- **mica:** 4.40.0 -> 4.41.0 (4.40.0 -> 4.41.0)
  - [PR 327](https://github.com/sot/mica/pull/327) (Tom Aldcroft): Support decom of the 32-bit HDR3 quadrant offsets
- **quaternion:** 4.3.1 -> 4.3.2 (4.3.1 -> 4.3.2)
  - [PR 53](https://github.com/sot/Quaternion/pull/53) (Jean Connelly): Remove download_url from setup.py
- **ska3-core:** 2026.6 -> 2026.9rc3
- **ska_dbi:** 5.2.0 -> 5.3.0 (5.2.0 -> 5.3.0)
  - [PR 29](https://github.com/sot/ska_dbi/pull/29) (Jean Connelly): Update sqsh/SYBASE libraries to 16.1
- **ska_sync:** 4.13.0 -> 4.14.0 (4.13.0 -> 4.14.0)
  - [PR 35](https://github.com/sot/ska_sync/pull/35) (Jean Connelly): Add cmds3 to config


# Related Issues

Fixes #1703
Fixes #1708
Fixes #1709
Fixes #1710
Fixes #1711
Fixes #1712
Fixes #1713
Fixes #1714
