### PR TITLE
2026.10

### DIFF
--- a/pkg_defs/ska3-matlab/meta.yaml
+++ b/pkg_defs/ska3-matlab/meta.yaml
@@ -1,7 +1,7 @@
 ---
 package:
   name: ska3-matlab
-  version: 2026.8
+  version: "2026.10"
 
 build:
   noarch: generic
@@ -20,7 +20,7 @@ requirements:
     - chandra_time ==4.3.1
     - cheta ==4.68.0
     - cxotime ==3.11.1
-    - fot-matlab ==2.5.2
+    - fot-matlab ==2.5.3
     - hopper ==4.6.0
     - kadi ==7.22.0
     - maude ==3.15.1


### PR DESCRIPTION
# ska3-matlab 2026.10

This PR includes:
- fot-matlab: Add gen_fp_limit module

## Interface Impacts:

## Testing:

- [Automated tests](https://icxc.cfa.harvard.edu/aspect/skare3/testr/releases/2026.10/).

The latest release candidates will be installed in `/proj/sot/ska3/matlab/test` on GRETA,
and all release candidates will be available for testing from the usual channels:
```
conda create -n ska3-matlab-2026.10rc1 --override-channels \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/flight \
  -c https://icxc.cfa.harvard.edu/aspect/ska3-conda/test \
  ska3-matlab==2026.10rc1
```

## Review

All operations critical or impacting PR's are independently and carefully reviewed. For other PR's the level of detail for review is calibrated to operations criticality. Some PR's that are confined to aspect-team-specific processing may have little to no independent review.

## Deployment

ska3-matlab 2026.10 will be promoted to flight conda channel and installed on GRETA Linux after approval from FOT team.

# Code changes

## ska3-matlab changes (2026.8 -> 2026.10rc1)

### Updated Packages

- **fot-matlab:** 2.5.2 -> 2.5.3 (2.5.2 -> 2.5.3)
  - [PR 35](https://github.com/sot/fot-matlab/pull/35) (James Jay): Add gen_fp_limit module and corresponding test


# Related Issues

Fixes #1705 
Fixes #1704 