### PR TITLE
Add requests and pyjwt to skare3_tools run requirements

### DIFF
--- a/pkg_defs/skare3_tools/meta.yaml
+++ b/pkg_defs/skare3_tools/meta.yaml
@@ -29,8 +29,10 @@ requirements:
   run:
     - gitpython
     - jinja2
+    - pyjwt
     - python
     - pyyaml
+    - requests
     - setuptools_scm
     - sphinx-argparse
 


### PR DESCRIPTION
As the title says: adding some core requirements that are actually used for the dashboard.